### PR TITLE
Fix Python version mismatch in mypy config

### DIFF
--- a/datagen/pyproject.toml
+++ b/datagen/pyproject.toml
@@ -55,7 +55,7 @@ markers = [
 ]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
Align mypy python_version with requires-python (3.11) to ensure type
checking uses the same version as the minimum runtime requirement.

Fixes #21