### PR TITLE
fix: update materialized views script comment from 05 to 04

### DIFF
--- a/fabric/kql_database/04-create-materialized-views.kql
+++ b/fabric/kql_database/04-create-materialized-views.kql
@@ -1,4 +1,4 @@
-// 05 Materialized Views
+// 04 Materialized Views
 // Purpose: Materialized views for hot KPIs (aligned to datagen payloads)
 // Run this entire script at once using .execute database script
 // ============================================================================


### PR DESCRIPTION
Fixes the numbering mismatch in `fabric/kql_database/04-create-materialized-views.kql`

Updated the first line comment from `// 05 Materialized Views` to `// 04 Materialized Views` to match the filename.

Fixes #22

Generated with [Claude Code](https://claude.ai/code)