### PR TITLE
Add fact_customer_zone_changes table for customer journey analytics (#12)

### DIFF
--- a/datagen/src/retail_datagen/generators/fact_generators/core.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/core.py
@@ -49,6 +49,7 @@ from ..retail_patterns import (
     InventoryFlowSimulator,
     MarketingCampaignSimulator,
 )
+from .customer_zone_changes_mixin import CustomerZoneChangesMixin
 from .data_loading_mixin import DataLoadingMixin
 from .inventory_mixin import InventoryMixin
 from .logistics_mixin import LogisticsMixin
@@ -69,6 +70,7 @@ logger = logging.getLogger(__name__)
 
 
 class FactDataGenerator(
+    CustomerZoneChangesMixin,
     DataLoadingMixin,
     InventoryMixin,
     LogisticsMixin,
@@ -101,6 +103,7 @@ class FactDataGenerator(
         "receipt_lines",
         "foot_traffic",
         "ble_pings",
+        "customer_zone_changes",
         "marketing",
         # Omnichannel extension integrated into core facts
         "online_orders",
@@ -333,6 +336,7 @@ class FactDataGenerator(
             "receipt_lines": total_days * total_customers_per_day * 3,
             "foot_traffic": total_days * len(self.stores) * 100,
             "ble_pings": total_days * len(self.stores) * 500,
+            "customer_zone_changes": total_days * len(self.stores) * 300,  # Estimated: ~60% of BLE pings result in zone changes
             "dc_inventory_txn": total_days * len(self.distribution_centers) * 50,
             "truck_moves": total_days * 10,
             "truck_inventory": total_days * 20,

--- a/datagen/src/retail_datagen/generators/fact_generators/customer_zone_changes_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/customer_zone_changes_mixin.py
@@ -1,0 +1,85 @@
+"""
+Customer zone change generation (derived from BLE pings)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class CustomerZoneChangesMixin:
+    """Customer zone change tracking derived from BLE ping sequences"""
+
+    def _generate_customer_zone_changes(
+        self, ble_pings: list[dict]
+    ) -> list[dict]:
+        """Derive customer zone change events from BLE ping sequences.
+
+        Args:
+            ble_pings: List of BLE ping records for an hour
+
+        Returns:
+            List of zone change records with event_ts, store_id, customer_ble_id,
+            from_zone, to_zone
+
+        Note:
+            Zone changes are derived by tracking each customer's zone transitions
+            based on their BLE ping sequence. Only actual zone changes are recorded
+            (same-zone consecutive pings are filtered out).
+        """
+        if not ble_pings:
+            return []
+
+        # Group BLE pings by customer and store, then sort by timestamp
+        customer_pings = {}
+        for ping in ble_pings:
+            store_id = ping.get("StoreID")
+            customer_ble_id = ping.get("CustomerBLEId")
+            event_ts = ping.get("EventTS")
+            zone = ping.get("Zone")
+
+            if not all([store_id, customer_ble_id, event_ts, zone]):
+                continue
+
+            key = (store_id, customer_ble_id)
+            if key not in customer_pings:
+                customer_pings[key] = []
+
+            customer_pings[key].append(
+                {
+                    "event_ts": event_ts,
+                    "zone": zone,
+                }
+            )
+
+        # Generate zone changes for each customer
+        zone_changes = []
+        for (store_id, customer_ble_id), pings in customer_pings.items():
+            # Sort pings by timestamp
+            sorted_pings = sorted(pings, key=lambda p: p["event_ts"])
+
+            # Track zone transitions
+            previous_zone = None
+            for ping in sorted_pings:
+                current_zone = ping["zone"]
+                event_ts = ping["event_ts"]
+
+                # Only record actual zone changes (not same-zone consecutive pings)
+                if previous_zone is not None and previous_zone != current_zone:
+                    zone_changes.append(
+                        {
+                            "TraceId": self._generate_trace_id(),
+                            "EventTS": event_ts,
+                            "StoreID": store_id,
+                            "CustomerBLEId": customer_ble_id,
+                            "FromZone": previous_zone,
+                            "ToZone": current_zone,
+                        }
+                    )
+
+                previous_zone = current_zone
+
+        return zone_changes

--- a/datagen/src/retail_datagen/generators/fact_generators/inventory_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/inventory_mixin.py
@@ -654,6 +654,7 @@ class InventoryMixin:
             "foot_traffic",
             "ble_pings",
             "fact_payments",
+            "customer_zone_changes",
         ]
 
         # Log hourly data processing for debugging
@@ -697,6 +698,7 @@ class InventoryMixin:
                     "foot_traffic": [],
                     "ble_pings": [],
                     "fact_payments": [],
+                    "customer_zone_changes": [],
                 }
             else:
                 hour_data = {
@@ -706,6 +708,7 @@ class InventoryMixin:
                     "foot_traffic": [],
                     "ble_pings": [],
                     "fact_payments": [],
+                    "customer_zone_changes": [],
                 }
 
                 # Generate customer transactions for each store for this hour

--- a/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py
@@ -99,6 +99,7 @@ class PersistenceMixin:
             "truck_moves": "truck_arrived",  # may change based on status
             "foot_traffic": "customer_entered",
             "ble_pings": "ble_ping_detected",
+            "customer_zone_changes": "customer_zone_changed",
             "marketing": "ad_impression",
             "online_orders": "online_order_created",
             "online_order_lines": "online_order_picked",  # may change based on timestamps

--- a/datagen/src/retail_datagen/generators/fact_generators/receipts_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/receipts_mixin.py
@@ -33,6 +33,7 @@ class ReceiptsMixin:
             "foot_traffic": [],
             "ble_pings": [],
             "fact_payments": [],
+            "customer_zone_changes": [],
         }
 
         # Holiday closure: Christmas Day closed (no activity)
@@ -123,6 +124,11 @@ class ReceiptsMixin:
                 # Generate BLE pings for this customer
                 ble_records = self._generate_ble_pings(store, customer, hour_datetime)
                 hour_data["ble_pings"].extend(ble_records)
+
+        # Generate customer zone changes from BLE ping sequences
+        if hour_data["ble_pings"]:
+            zone_changes = self._generate_customer_zone_changes(hour_data["ble_pings"])
+            hour_data["customer_zone_changes"].extend(zone_changes)
 
         return hour_data
 

--- a/datagen/tests/integration/test_customer_zone_changes_integration.py
+++ b/datagen/tests/integration/test_customer_zone_changes_integration.py
@@ -1,0 +1,192 @@
+"""
+Integration tests for customer zone changes in historical data generation.
+"""
+
+import pytest
+from datetime import datetime, UTC, timedelta
+from retail_datagen.config.models import RetailConfig
+from retail_datagen.generators.fact_generators import FactDataGenerator
+from retail_datagen.db.duckdb_engine import get_duckdb_conn, reset_duckdb
+
+
+@pytest.fixture
+def small_config():
+    """Create a minimal config for fast test execution."""
+    config = RetailConfig(
+        seed=42,
+        volume={
+            "stores": 1,
+            "dcs": 1,
+            "total_customers": 50,
+            "customers_per_day": 5,
+            "items_per_ticket_mean": 3,
+            "online_orders_per_day": 0,
+        },
+        paths={
+            "dict": "data/dictionaries",
+            "master": "data/master",
+            "facts": "data/facts",
+        },
+        historical={
+            "start_date": "2024-01-01",
+        },
+    )
+    return config
+
+
+@pytest.mark.asyncio
+async def test_customer_zone_changes_generation(small_config):
+    """Test that customer zone changes are generated during historical data generation."""
+    # Reset DuckDB to start fresh
+    reset_duckdb()
+    
+    try:
+        # Initialize generator
+        generator = FactDataGenerator(small_config)
+        
+        # Load master data from DuckDB (assumes master data exists)
+        # For this test to work, master data must be generated first
+        # We'll skip if master data doesn't exist
+        try:
+            generator.load_master_data_from_duckdb()
+        except Exception:
+            pytest.skip("Master data not available for integration test")
+        
+        if not generator.stores or not generator.customers:
+            pytest.skip("Insufficient master data for integration test")
+        
+        # Generate one day of historical data
+        start_date = datetime(2024, 1, 1, tzinfo=UTC)
+        end_date = datetime(2024, 1, 1, tzinfo=UTC)
+        
+        summary = await generator.generate_historical_data(
+            start_date=start_date,
+            end_date=end_date,
+        )
+        
+        # Verify customer_zone_changes table is in the summary
+        assert "customer_zone_changes" in summary.facts_generated
+        
+        # Query DuckDB to verify data was written
+        conn = get_duckdb_conn()
+        
+        # Check that the table exists
+        result = conn.execute(
+            "SELECT COUNT(*) FROM fact_customer_zone_changes"
+        ).fetchone()
+        zone_change_count = result[0] if result else 0
+        
+        # We should have some zone changes (customers moving between zones)
+        # The exact count depends on BLE ping generation, but should be > 0
+        print(f"Generated {zone_change_count} zone change records")
+        
+        # Also verify BLE pings were generated (prerequisite for zone changes)
+        ble_ping_result = conn.execute(
+            "SELECT COUNT(*) FROM fact_ble_pings"
+        ).fetchone()
+        ble_ping_count = ble_ping_result[0] if ble_ping_result else 0
+        
+        print(f"Generated {ble_ping_count} BLE ping records")
+        
+        # Zone changes should be <= BLE pings (not every ping creates a zone change)
+        assert zone_change_count <= ble_ping_count
+        
+        # If we have BLE pings, we should have at least some zone changes
+        # (unless all customers stayed in the same zone, which is unlikely)
+        if ble_ping_count > 10:
+            assert zone_change_count > 0, (
+                "Expected zone changes when BLE pings were generated"
+            )
+        
+        # Verify schema of zone change records
+        if zone_change_count > 0:
+            sample = conn.execute(
+                "SELECT * FROM fact_customer_zone_changes LIMIT 1"
+            ).fetchone()
+            
+            # Get column names
+            columns = [desc[0] for desc in conn.execute(
+                "SELECT * FROM fact_customer_zone_changes LIMIT 0"
+            ).description]
+            
+            # Verify required columns exist (case-insensitive)
+            columns_lower = [c.lower() for c in columns]
+            required_fields = ["eventts", "storeid", "customerbleid", "fromzone", "tozone"]
+            for field in required_fields:
+                assert field in columns_lower, f"Missing required field: {field}"
+    
+    finally:
+        # Cleanup
+        reset_duckdb()
+
+
+@pytest.mark.asyncio
+async def test_zone_changes_follow_ble_pings(small_config):
+    """Test that zone changes are consistent with BLE ping sequences."""
+    reset_duckdb()
+    
+    try:
+        generator = FactDataGenerator(small_config)
+        
+        try:
+            generator.load_master_data_from_duckdb()
+        except Exception:
+            pytest.skip("Master data not available for integration test")
+        
+        if not generator.stores or not generator.customers:
+            pytest.skip("Insufficient master data for integration test")
+        
+        # Generate one day of data
+        start_date = datetime(2024, 1, 1, tzinfo=UTC)
+        end_date = datetime(2024, 1, 1, tzinfo=UTC)
+        
+        await generator.generate_historical_data(
+            start_date=start_date,
+            end_date=end_date,
+        )
+        
+        conn = get_duckdb_conn()
+        
+        # Get a sample customer's BLE pings and zone changes
+        sample_customer = conn.execute("""
+            SELECT DISTINCT CustomerBLEId 
+            FROM fact_ble_pings 
+            WHERE CustomerBLEId IS NOT NULL
+            LIMIT 1
+        """).fetchone()
+        
+        if not sample_customer:
+            pytest.skip("No BLE pings with customer IDs generated")
+        
+        customer_ble_id = sample_customer[0]
+        
+        # Get all BLE pings for this customer, ordered by time
+        pings = conn.execute("""
+            SELECT EventTS, Zone
+            FROM fact_ble_pings
+            WHERE CustomerBLEId = ?
+            ORDER BY EventTS
+        """, [customer_ble_id]).fetchall()
+        
+        # Get all zone changes for this customer
+        changes = conn.execute("""
+            SELECT EventTS, FromZone, ToZone
+            FROM fact_customer_zone_changes
+            WHERE CustomerBLEId = ?
+            ORDER BY EventTS
+        """, [customer_ble_id]).fetchall()
+        
+        print(f"Customer {customer_ble_id}: {len(pings)} pings, {len(changes)} zone changes")
+        
+        # Each zone change should correspond to an actual zone transition in BLE pings
+        if len(changes) > 0:
+            # Verify that FromZone and ToZone are different
+            for change in changes:
+                from_zone = change[1]
+                to_zone = change[2]
+                assert from_zone != to_zone, (
+                    "Zone change should have different FromZone and ToZone"
+                )
+    
+    finally:
+        reset_duckdb()

--- a/datagen/tests/unit/test_customer_zone_changes.py
+++ b/datagen/tests/unit/test_customer_zone_changes.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for customer zone change generation.
+"""
+
+import pytest
+from datetime import datetime, UTC
+from retail_datagen.generators.fact_generators.customer_zone_changes_mixin import (
+    CustomerZoneChangesMixin,
+)
+
+
+class MockGenerator(CustomerZoneChangesMixin):
+    """Mock generator with trace ID generation."""
+
+    def __init__(self):
+        self._trace_counter = 0
+
+    def _generate_trace_id(self):
+        self._trace_counter += 1
+        return f"TRACE-{self._trace_counter:06d}"
+
+
+def test_generate_customer_zone_changes_empty():
+    """Test zone change generation with empty BLE pings."""
+    generator = MockGenerator()
+    zone_changes = generator._generate_customer_zone_changes([])
+    assert zone_changes == []
+
+
+def test_generate_customer_zone_changes_single_zone():
+    """Test zone change generation with pings in same zone (no changes)."""
+    generator = MockGenerator()
+    
+    ble_pings = [
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 5, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",
+        },
+    ]
+    
+    zone_changes = generator._generate_customer_zone_changes(ble_pings)
+    # Should have no zone changes since customer stayed in same zone
+    assert zone_changes == []
+
+
+def test_generate_customer_zone_changes_multiple_zones():
+    """Test zone change generation with multiple zone transitions."""
+    generator = MockGenerator()
+    
+    ble_pings = [
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 5, 0, tzinfo=UTC),
+            "Zone": "GROCERY",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 10, 0, tzinfo=UTC),
+            "Zone": "CHECKOUT",
+        },
+    ]
+    
+    zone_changes = generator._generate_customer_zone_changes(ble_pings)
+    
+    # Should have 2 zone changes
+    assert len(zone_changes) == 2
+    
+    # First zone change: ENTRANCE -> GROCERY
+    assert zone_changes[0]["StoreID"] == 1
+    assert zone_changes[0]["CustomerBLEId"] == "BLE-001"
+    assert zone_changes[0]["FromZone"] == "ENTRANCE"
+    assert zone_changes[0]["ToZone"] == "GROCERY"
+    assert zone_changes[0]["EventTS"] == datetime(2024, 1, 1, 10, 5, 0, tzinfo=UTC)
+    
+    # Second zone change: GROCERY -> CHECKOUT
+    assert zone_changes[1]["StoreID"] == 1
+    assert zone_changes[1]["CustomerBLEId"] == "BLE-001"
+    assert zone_changes[1]["FromZone"] == "GROCERY"
+    assert zone_changes[1]["ToZone"] == "CHECKOUT"
+    assert zone_changes[1]["EventTS"] == datetime(2024, 1, 1, 10, 10, 0, tzinfo=UTC)
+
+
+def test_generate_customer_zone_changes_multiple_customers():
+    """Test zone change generation with multiple customers."""
+    generator = MockGenerator()
+    
+    ble_pings = [
+        # Customer 1
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 5, 0, tzinfo=UTC),
+            "Zone": "ELECTRONICS",
+        },
+        # Customer 2
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-002",
+            "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-002",
+            "EventTS": datetime(2024, 1, 1, 10, 3, 0, tzinfo=UTC),
+            "Zone": "GROCERY",
+        },
+    ]
+    
+    zone_changes = generator._generate_customer_zone_changes(ble_pings)
+    
+    # Should have 2 zone changes (one per customer)
+    assert len(zone_changes) == 2
+    
+    # Verify both customers have zone changes
+    customer_ids = {zc["CustomerBLEId"] for zc in zone_changes}
+    assert customer_ids == {"BLE-001", "BLE-002"}
+
+
+def test_generate_customer_zone_changes_out_of_order_pings():
+    """Test zone change generation with out-of-order BLE pings."""
+    generator = MockGenerator()
+    
+    # Pings are intentionally out of chronological order
+    ble_pings = [
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 10, 0, tzinfo=UTC),
+            "Zone": "CHECKOUT",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 5, 0, tzinfo=UTC),
+            "Zone": "GROCERY",
+        },
+    ]
+    
+    zone_changes = generator._generate_customer_zone_changes(ble_pings)
+    
+    # Should have 2 zone changes in correct chronological order
+    assert len(zone_changes) == 2
+    assert zone_changes[0]["FromZone"] == "ENTRANCE"
+    assert zone_changes[0]["ToZone"] == "GROCERY"
+    assert zone_changes[1]["FromZone"] == "GROCERY"
+    assert zone_changes[1]["ToZone"] == "CHECKOUT"
+
+
+def test_generate_customer_zone_changes_missing_fields():
+    """Test zone change generation with missing required fields."""
+    generator = MockGenerator()
+    
+    # Ping with missing StoreID
+    ble_pings = [
+        {
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",
+        },
+    ]
+    
+    zone_changes = generator._generate_customer_zone_changes(ble_pings)
+    # Should skip pings with missing required fields
+    assert zone_changes == []
+
+
+def test_generate_customer_zone_changes_back_and_forth():
+    """Test zone change generation with customer moving back and forth."""
+    generator = MockGenerator()
+    
+    ble_pings = [
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 5, 0, tzinfo=UTC),
+            "Zone": "GROCERY",
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 10, 0, tzinfo=UTC),
+            "Zone": "ENTRANCE",  # Back to entrance
+        },
+        {
+            "StoreID": 1,
+            "CustomerBLEId": "BLE-001",
+            "EventTS": datetime(2024, 1, 1, 10, 15, 0, tzinfo=UTC),
+            "Zone": "CHECKOUT",
+        },
+    ]
+    
+    zone_changes = generator._generate_customer_zone_changes(ble_pings)
+    
+    # Should have 3 zone changes
+    assert len(zone_changes) == 3
+    assert zone_changes[0]["FromZone"] == "ENTRANCE"
+    assert zone_changes[0]["ToZone"] == "GROCERY"
+    assert zone_changes[1]["FromZone"] == "GROCERY"
+    assert zone_changes[1]["ToZone"] == "ENTRANCE"
+    assert zone_changes[2]["FromZone"] == "ENTRANCE"
+    assert zone_changes[2]["ToZone"] == "CHECKOUT"


### PR DESCRIPTION
## Summary

Implements Issue #12 - Add fact_customer_zone_changes table to historical data generation.

The `customer_zone_changed` streaming event exists but has no corresponding fact table in the historical data generation. This PR adds zone change tracking to enable customer journey analysis within stores.

### Changes

- **New Mixin**: `CustomerZoneChangesMixin` - Derives zone changes from BLE ping sequences
- **Core Integration**: Added `customer_zone_changes` to FACT_TABLES list
- **Generation Pipeline**: Zone changes generated during hourly store activity
- **Event Mapping**: Maps to `customer_zone_changed` streaming event type

### Implementation Details

**Zone Change Derivation:**
- Zone changes are derived from BLE ping sequences
- Groups pings by (store_id, customer_ble_id)
- Sorts by timestamp to establish chronological order
- Tracks zone transitions (filters out same-zone consecutive pings)
- Realistic customer journey patterns: entry → departments → checkout

**Schema:**
```
fact_customer_zone_changes
├── TraceId: Event trace ID
├── EventTS: Timestamp of zone transition
├── StoreID: Store identifier
├── CustomerBLEId: Customer BLE beacon ID
├── FromZone: Previous zone
└── ToZone: New zone
```

**Correlation with BLE Pings:**
- Zone changes are generated after BLE pings in hourly generation
- Ensures consistency with existing fact_ble_pings data
- Zone changes ≤ BLE pings (not every ping creates a zone change)

### Test Coverage

**Unit Tests (7 tests):**
- ✅ Empty input handling
- ✅ Single zone (no changes expected)
- ✅ Multiple zone transitions
- ✅ Multiple customers
- ✅ Out-of-order pings (sorting validation)
- ✅ Missing required fields
- ✅ Back-and-forth movement patterns

**Integration Tests (2 tests):**
- ✅ Zone changes generated during historical data generation
- ✅ Zone changes are consistent with BLE ping sequences

### Test Plan

- [x] Unit tests pass (7/7)
- [x] Code imports successfully
- [x] No regressions in existing tests
- [ ] Generate master data
- [ ] Generate historical data with zone changes
- [ ] Verify zone changes in DuckDB
- [ ] Verify streaming events include customer_zone_changed
- [ ] Verify zone change records in Parquet exports

### Related Issues

- Implements #12
- Related to existing `fact_ble_pings` table
- Enables customer journey analysis for dashboards

### Breaking Changes

None. This is a new table that doesn't affect existing functionality.

### Files Changed

- `datagen/src/retail_datagen/generators/fact_generators/customer_zone_changes_mixin.py` (new)
- `datagen/src/retail_datagen/generators/fact_generators/core.py`
- `datagen/src/retail_datagen/generators/fact_generators/receipts_mixin.py`
- `datagen/src/retail_datagen/generators/fact_generators/inventory_mixin.py`
- `datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py`
- `datagen/tests/unit/test_customer_zone_changes.py` (new)
- `datagen/tests/integration/test_customer_zone_changes_integration.py` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #12