### PR TITLE
Add fact_stockouts table for supply chain analytics (#8)

### DIFF
--- a/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py
@@ -105,6 +105,7 @@ class PersistenceMixin:
             "online_order_lines": "online_order_picked",  # may change based on timestamps
             "fact_payments": "payment_processed",
             "store_ops": "store_opened",  # may change based on operation_type
+            "stockouts": "stockout_detected",
         }
 
         default_type = base_type_map.get(table_name, "receipt_created")

--- a/datagen/src/retail_datagen/generators/fact_generators/stockouts_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/stockouts_mixin.py
@@ -1,0 +1,162 @@
+"""
+Stockout detection and tracking for supply chain analytics.
+
+This mixin tracks stockout events when inventory balances reach zero,
+providing critical data for supply chain optimization and demand planning.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class StockoutsMixin:
+    """Stockout detection and tracking mixin for fact data generation."""
+
+    def _detect_and_record_stockout(
+        self,
+        node_type: str,
+        node_id: int,
+        product_id: int,
+        last_known_quantity: int,
+        detection_time: datetime,
+        current_balance: int,
+    ) -> dict | None:
+        """
+        Detect and record a stockout event when inventory reaches zero.
+
+        Args:
+            node_type: "STORE" or "DC"
+            node_id: Store ID or DC ID
+            product_id: Product ID that stocked out
+            last_known_quantity: Last positive quantity before stockout
+            detection_time: Timestamp when stockout was detected
+            current_balance: Current inventory balance (should be 0)
+
+        Returns:
+            Stockout record dict if a new stockout is detected, None otherwise
+        """
+        # Only record stockouts when balance actually reaches zero
+        if current_balance != 0:
+            return None
+
+        # Construct key for tracking duplicate detections
+        key = (node_id, product_id)
+
+        # Check if we already recorded a stockout for this node-product combination
+        # Only record new stockouts if enough time has passed (1 day min)
+        if key in self._last_stockout_detection:
+            last_detection = self._last_stockout_detection[key]
+            hours_since_last = (
+                detection_time - last_detection
+            ).total_seconds() / 3600
+            # Require at least 24 hours between stockout detections for same product
+            # This prevents recording multiple stockouts during the same depletion
+            if hours_since_last < 24:
+                return None
+
+        # Record this stockout detection
+        self._last_stockout_detection[key] = detection_time
+
+        # Build stockout record matching the schema
+        stockout_record = {
+            "TraceId": self._generate_trace_id(),
+            "EventTS": detection_time,
+            "StoreID": node_id if node_type == "STORE" else None,
+            "DCID": node_id if node_type == "DC" else None,
+            "ProductID": product_id,
+            "LastKnownQuantity": max(0, last_known_quantity),
+            "DetectionTime": detection_time,
+        }
+
+        logger.debug(
+            f"Stockout detected: {node_type} {node_id}, Product {product_id} "
+            f"(last qty: {last_known_quantity})"
+        )
+
+        return stockout_record
+
+    def _generate_stockouts_from_inventory_txns(
+        self,
+        store_inventory_txns: list[dict],
+        dc_inventory_txns: list[dict],
+    ) -> list[dict]:
+        """
+        Generate stockout events from inventory transaction records.
+
+        Analyzes inventory transactions to detect when balances hit zero,
+        indicating a stockout condition.
+
+        Args:
+            store_inventory_txns: List of store inventory transaction records
+            dc_inventory_txns: List of DC inventory transaction records
+
+        Returns:
+            List of stockout event records
+        """
+        stockout_records = []
+
+        # Process store inventory transactions
+        for txn in store_inventory_txns:
+            balance = txn.get("Balance", 0)
+            if balance == 0:
+                # Inventory hit zero - potential stockout
+                store_id = txn.get("StoreID")
+                product_id = txn.get("ProductID")
+                event_ts = txn.get("EventTS")
+                qty_delta = txn.get("QtyDelta", 0)
+
+                # Last known quantity is the absolute value of the delta that brought us to zero
+                # (if delta is negative, it represents the sale/usage that depleted inventory)
+                last_known_qty = abs(qty_delta) if qty_delta < 0 else 0
+
+                stockout = self._detect_and_record_stockout(
+                    node_type="STORE",
+                    node_id=store_id,
+                    product_id=product_id,
+                    last_known_quantity=last_known_qty,
+                    detection_time=event_ts,
+                    current_balance=balance,
+                )
+
+                if stockout:
+                    stockout_records.append(stockout)
+
+        # Process DC inventory transactions
+        for txn in dc_inventory_txns:
+            balance = txn.get("Balance", 0)
+            if balance == 0:
+                # DC inventory hit zero - potential stockout
+                dc_id = txn.get("DCID")
+                product_id = txn.get("ProductID")
+                event_ts = txn.get("EventTS")
+                qty_delta = txn.get("QtyDelta", 0)
+
+                # Last known quantity
+                last_known_qty = abs(qty_delta) if qty_delta < 0 else 0
+
+                stockout = self._detect_and_record_stockout(
+                    node_type="DC",
+                    node_id=dc_id,
+                    product_id=product_id,
+                    last_known_quantity=last_known_qty,
+                    detection_time=event_ts,
+                    current_balance=balance,
+                )
+
+                if stockout:
+                    stockout_records.append(stockout)
+
+        if stockout_records:
+            logger.info(
+                f"Generated {len(stockout_records)} stockout events from inventory transactions"
+            )
+
+        return stockout_records

--- a/datagen/tests/unit/test_stockouts.py
+++ b/datagen/tests/unit/test_stockouts.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for stockouts detection and generation.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from retail_datagen.generators.fact_generators.stockouts_mixin import StockoutsMixin
+
+
+class MockStockoutsGenerator(StockoutsMixin):
+    """Mock class to test StockoutsMixin methods."""
+
+    def __init__(self):
+        self._last_stockout_detection = {}
+        self._trace_counter = 0
+
+    def _generate_trace_id(self):
+        """Generate a simple trace ID for testing."""
+        self._trace_counter += 1
+        return f"TRACE-{self._trace_counter}"
+
+
+class TestStockoutsDetection:
+    """Test stockout detection logic."""
+
+    def test_detect_stockout_when_balance_zero(self):
+        """Test that stockout is detected when balance reaches zero."""
+        generator = MockStockoutsGenerator()
+
+        result = generator._detect_and_record_stockout(
+            node_type="STORE",
+            node_id=1,
+            product_id=100,
+            last_known_quantity=5,
+            detection_time=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            current_balance=0,
+        )
+
+        assert result is not None
+        assert result["StoreID"] == 1
+        assert result["DCID"] is None
+        assert result["ProductID"] == 100
+        assert result["LastKnownQuantity"] == 5
+        assert result["TraceId"] == "TRACE-1"
+
+    def test_no_stockout_when_balance_positive(self):
+        """Test that no stockout is detected when balance is still positive."""
+        generator = MockStockoutsGenerator()
+
+        result = generator._detect_and_record_stockout(
+            node_type="STORE",
+            node_id=1,
+            product_id=100,
+            last_known_quantity=5,
+            detection_time=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            current_balance=3,
+        )
+
+        assert result is None
+
+    def test_duplicate_stockout_prevention(self):
+        """Test that duplicate stockouts within 24 hours are prevented."""
+        generator = MockStockoutsGenerator()
+
+        # First stockout
+        result1 = generator._detect_and_record_stockout(
+            node_type="STORE",
+            node_id=1,
+            product_id=100,
+            last_known_quantity=5,
+            detection_time=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            current_balance=0,
+        )
+
+        # Second stockout 12 hours later (should be prevented)
+        result2 = generator._detect_and_record_stockout(
+            node_type="STORE",
+            node_id=1,
+            product_id=100,
+            last_known_quantity=3,
+            detection_time=datetime(2024, 1, 1, 22, 0, 0, tzinfo=timezone.utc),
+            current_balance=0,
+        )
+
+        assert result1 is not None
+        assert result2 is None  # Duplicate prevented
+
+    def test_stockout_after_24_hours_allowed(self):
+        """Test that stockout is allowed after 24 hours have passed."""
+        generator = MockStockoutsGenerator()
+
+        # First stockout
+        result1 = generator._detect_and_record_stockout(
+            node_type="STORE",
+            node_id=1,
+            product_id=100,
+            last_known_quantity=5,
+            detection_time=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            current_balance=0,
+        )
+
+        # Second stockout 25 hours later (should be allowed)
+        result2 = generator._detect_and_record_stockout(
+            node_type="STORE",
+            node_id=1,
+            product_id=100,
+            last_known_quantity=3,
+            detection_time=datetime(2024, 1, 2, 11, 0, 0, tzinfo=timezone.utc),
+            current_balance=0,
+        )
+
+        assert result1 is not None
+        assert result2 is not None
+
+    def test_dc_stockout_detection(self):
+        """Test stockout detection for distribution centers."""
+        generator = MockStockoutsGenerator()
+
+        result = generator._detect_and_record_stockout(
+            node_type="DC",
+            node_id=5,
+            product_id=200,
+            last_known_quantity=10,
+            detection_time=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            current_balance=0,
+        )
+
+        assert result is not None
+        assert result["DCID"] == 5
+        assert result["StoreID"] is None
+        assert result["ProductID"] == 200
+
+    def test_generate_stockouts_from_transactions(self):
+        """Test generating stockouts from inventory transaction records."""
+        generator = MockStockoutsGenerator()
+
+        store_txns = [
+            {
+                "StoreID": 1,
+                "ProductID": 100,
+                "Balance": 0,
+                "QtyDelta": -5,
+                "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            },
+            {
+                "StoreID": 1,
+                "ProductID": 101,
+                "Balance": 10,  # Not a stockout
+                "QtyDelta": -2,
+                "EventTS": datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc),
+            },
+            {
+                "StoreID": 2,
+                "ProductID": 100,
+                "Balance": 0,
+                "QtyDelta": -3,
+                "EventTS": datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            },
+        ]
+
+        dc_txns = [
+            {
+                "DCID": 5,
+                "ProductID": 200,
+                "Balance": 0,
+                "QtyDelta": -8,
+                "EventTS": datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc),
+            }
+        ]
+
+        stockouts = generator._generate_stockouts_from_inventory_txns(
+            store_txns, dc_txns
+        )
+
+        # Should detect 3 stockouts: 2 from stores, 1 from DC
+        assert len(stockouts) == 3
+
+        # Verify store stockouts
+        store_stockouts = [s for s in stockouts if s["StoreID"] is not None]
+        assert len(store_stockouts) == 2
+
+        # Verify DC stockout
+        dc_stockouts = [s for s in stockouts if s["DCID"] is not None]
+        assert len(dc_stockouts) == 1
+        assert dc_stockouts[0]["DCID"] == 5
+
+    def test_negative_last_known_quantity_converted_to_positive(self):
+        """Test that negative quantity deltas are converted to positive last known qty."""
+        generator = MockStockoutsGenerator()
+
+        store_txns = [
+            {
+                "StoreID": 1,
+                "ProductID": 100,
+                "Balance": 0,
+                "QtyDelta": -7,  # Negative delta
+                "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            }
+        ]
+
+        stockouts = generator._generate_stockouts_from_inventory_txns(store_txns, [])
+
+        assert len(stockouts) == 1
+        assert stockouts[0]["LastKnownQuantity"] == 7  # Converted to positive
+
+    def test_zero_delta_yields_zero_last_known_quantity(self):
+        """Test that zero delta results in zero last known quantity."""
+        generator = MockStockoutsGenerator()
+
+        store_txns = [
+            {
+                "StoreID": 1,
+                "ProductID": 100,
+                "Balance": 0,
+                "QtyDelta": 0,  # Zero delta
+                "EventTS": datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            }
+        ]
+
+        stockouts = generator._generate_stockouts_from_inventory_txns(store_txns, [])
+
+        assert len(stockouts) == 1
+        assert stockouts[0]["LastKnownQuantity"] == 0


### PR DESCRIPTION
## Summary

Implements Issue #8 by adding the `fact_stockouts` table to historical data generation. This table tracks stockout events when inventory balances reach zero, providing critical supply chain analytics for demand planning and replenishment optimization.

The implementation follows the existing mixin pattern and integrates seamlessly with the inventory transaction flow. Stockouts are detected automatically when DC or store inventory balances hit zero, with built-in duplicate prevention.

## Changes

### New Files
- `stockouts_mixin.py`: Mixin implementing stockout detection logic
- `test_stockouts.py`: 8 unit tests covering all detection scenarios

### Modified Files
- `core.py`: Added StockoutsMixin to inheritance chain, added "stockouts" to FACT_TABLES
- `inventory_mixin.py`: Integrated stockout generation into daily facts workflow
- `persistence_mixin.py`: Added event mapping for "stockout_detected" streaming events

## Technical Implementation

**Stockout Detection Logic:**
- Analyzes inventory transactions after generation each day
- Detects when `Balance == 0` for store or DC inventory
- Prevents duplicate detections within 24 hours (same product/location)
- Captures last known quantity before stockout

**Data Schema:**
```python
{
    "TraceId": str,
    "EventTS": datetime,
    "StoreID": int | None,  # Store stockout
    "DCID": int | None,     # DC stockout
    "ProductID": int,
    "LastKnownQuantity": int,
    "DetectionTime": datetime
}
```

**Integration Points:**
- Runs after inventory transactions are generated (section 8.5 in daily facts)
- Writes to DuckDB immediately as daily batch
- Updates hourly progress tracker
- Streams to outbox for real-time events

## Test Plan

### Unit Tests (8 tests, all passing)
- ✅ Detects stockout when balance reaches zero
- ✅ No detection when balance is positive
- ✅ Prevents duplicate detections within 24 hours
- ✅ Allows new detection after 24 hours
- ✅ Handles DC stockouts correctly
- ✅ Handles store stockouts correctly
- ✅ Converts negative deltas to positive last quantity
- ✅ Generates from multiple inventory transactions

### Manual Testing
Run historical generation and verify:
```bash
cd datagen
python -m retail_datagen.main
# Generate historical data for 7 days
# Verify fact_stockouts table in DuckDB
# Check stockout counts and distribution
```

### Expected Behavior
- Stockouts correlate with high-velocity products
- More stockouts during peak seasonal periods
- Realistic frequency: ~2 per store per day (estimate)
- Both DC and store stockouts captured

## Dependencies

**Upstream:**
- Requires `fact_store_inventory_txn` and `fact_dc_inventory_txn`
- Streaming schema `StockoutDetectedPayload` already exists

**Downstream:**
- Enables supply chain disruption analysis
- Supports reorder point optimization
- Feeds into Silver/Gold layer aggregations

## Related Issues

- Closes #8
- Related to #9 (fact_reorders - stockouts trigger reorders)
- Complements Issue #7 (fact_payments - completed)

Generated with [Claude Code](https://claude.com/claude-code)

Closes #8