### PR TITLE
Change DuckDB path logging to debug level #119

### DIFF
--- a/datagen/src/retail_datagen/main.py
+++ b/datagen/src/retail_datagen/main.py
@@ -97,7 +97,7 @@ async def lifespan(app: FastAPI):
         conn = get_duckdb_conn()
         conn.execute("SELECT 1")
         logger.info("✅ DuckDB initialized successfully")
-        logger.info(f"  - DuckDB Path: {get_duckdb_path()}")
+        logger.debug(f"  - DuckDB Path: {get_duckdb_path()}")
     except Exception as e:
         logger.error(f"❌ Failed to initialize DuckDB: {e}", exc_info=True)
         logger.warning("Application will continue but database features may not work")


### PR DESCRIPTION
## Summary
Fixes #119 - Changes DuckDB path logging from INFO to DEBUG level to prevent potential information disclosure in production logs.

## Changes
- Changed `logger.info` to `logger.debug` for DuckDB path logging in `datagen/src/retail_datagen/main.py:100`

## Rationale
Logging file paths at INFO level in production can expose system structure and file organization. The DuckDB database path should only be logged at DEBUG level for troubleshooting purposes, not in normal production logs.

## Security Impact
- Reduces potential for information disclosure
- Aligns with security best practices for production logging
- Path information still available when DEBUG logging is enabled for troubleshooting

## Testing
- Ran full test suite: 877 tests passed
- No functionality changes - only log level adjustment
- Verified application startup still works correctly

Generated with [Claude Code](https://claude.com/claude-code)