### PR TITLE
Fix core infrastructure issues #114, #115, #116, #101

### DIFF
--- a/datagen/src/retail_datagen/generators/fact_generators/core.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/core.py
@@ -353,9 +353,10 @@ class FactDataGenerator(
             "receipt_lines": total_days * total_customers_per_day * 3,
             "foot_traffic": total_days * len(self.stores) * 100,
             "ble_pings": total_days * len(self.stores) * 500,
+            # Estimated: ~60% of BLE pings result in zone changes
             "customer_zone_changes": total_days
             * len(self.stores)
-            * 300,  # Estimated: ~60% of BLE pings result in zone changes
+            * int(500 * 0.6),  # 60% of BLE pings (500 per store per day)
             "dc_inventory_txn": total_days * len(self.distribution_centers) * 50,
             "truck_moves": total_days * 10,
             "truck_inventory": total_days * 20,

--- a/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py
@@ -380,6 +380,36 @@ class PersistenceMixin:
                 "DiscountAmount": "discount_amount",
                 "DiscountCents": "discount_cents",
             },
+            "store_ops": {
+                **common_mappings,
+                "StoreID": "store_id",
+                "OperationType": "operation_type",
+            },
+            "customer_zone_changes": {
+                **common_mappings,
+                "StoreID": "store_id",
+                "CustomerBLEId": "customer_ble_id",
+                "FromZone": "from_zone",
+                "ToZone": "to_zone",
+            },
+            "stockouts": {
+                **common_mappings,
+                "StoreID": "store_id",
+                "DCID": "dc_id",
+                "ProductID": "product_id",
+                "LastKnownQuantity": "last_known_quantity",
+                "DetectionTime": "detection_time",
+            },
+            "reorders": {
+                **common_mappings,
+                "StoreID": "store_id",
+                "DCID": "dc_id",
+                "ProductID": "product_id",
+                "CurrentQuantity": "current_quantity",
+                "ReorderQuantity": "reorder_quantity",
+                "ReorderPoint": "reorder_point",
+                "Priority": "priority",
+            },
         }
 
         mapping = table_specific_mappings.get(table_name, common_mappings)
@@ -724,6 +754,10 @@ class PersistenceMixin:
                     "fact_payments": "fact_payments",
                     "promotions": "fact_promotions",
                     "promo_lines": "fact_promo_lines",
+                    "store_ops": "fact_store_ops",
+                    "customer_zone_changes": "fact_customer_zone_changes",
+                    "stockouts": "fact_stockouts",
+                    "reorders": "fact_reorders",
                 }.get(table_name, table_name)
                 from retail_datagen.db.duckdb_engine import (
                     insert_dataframe,
@@ -1031,6 +1065,12 @@ class PersistenceMixin:
             "marketing": "fact_marketing",
             "online_orders": "fact_online_orders",
             "fact_payments": "fact_payments",
+            "promotions": "fact_promotions",
+            "promo_lines": "fact_promo_lines",
+            "store_ops": "fact_store_ops",
+            "customer_zone_changes": "fact_customer_zone_changes",
+            "stockouts": "fact_stockouts",
+            "reorders": "fact_reorders",
         }
 
         for table_name in active_tables:


### PR DESCRIPTION
## Summary

This PR addresses multiple core infrastructure issues related to the new fact tables (store_ops, customer_zone_changes, stockouts, promotions, reorders) that were added but missing required mappings in the persistence layer.

### Changes Made

- **Issue #101 [LOW]**: Replace magic number 300 with derived value
  - Changed hardcoded 300 to `int(500 * 0.6)` with comment explaining it's 60% of BLE pings
  - Location: `core.py:359`

- **Issue #114 [CRITICAL]**: New fact tables in FACT_TABLES list
  - Verified all new tables already present in FACT_TABLES constant
  - No changes needed (already resolved)

- **Issue #115 [HIGH]**: Missing persistence mappings
  - Added field name mappings in `_map_field_names_for_db()` for:
    - `store_ops`: StoreID → store_id, OperationType → operation_type
    - `customer_zone_changes`: StoreID, CustomerBLEId, FromZone, ToZone
    - `stockouts`: StoreID, DCID, ProductID, LastKnownQuantity, DetectionTime
    - `reorders`: StoreID, DCID, ProductID, CurrentQuantity, ReorderQuantity, ReorderPoint, Priority
  - Added DuckDB table mappings in `_insert_hourly_to_db()` for all new tables
  - Added watermark table mappings in `_update_watermarks_after_generation()` for all new tables

- **Issue #116 [HIGH]**: Missing outbox event type mappings
  - Verified all event types already present in `base_type_map`
  - No changes needed (already resolved)

### Test Results

All unit tests passing:
```
884 passed, 3 warnings in 38.51s
```

### Files Changed

- `/Users/amattas/GitHub/retail-demo-core-infra/datagen/src/retail_datagen/generators/fact_generators/core.py`
  - Line 356-359: Replace magic number with derived value

- `/Users/amattas/GitHub/retail-demo-core-infra/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py`
  - Lines 383-412: Add field mappings for new fact tables
  - Lines 757-760: Add DuckDB table mappings
  - Lines 1068-1073: Add watermark table mappings

## Test plan

- [x] All unit tests pass (884 tests)
- [x] Field mappings verified against mixin implementations
- [x] DuckDB table names match database schema
- [x] Event type mappings verified for streaming

Generated with [Claude Code](https://claude.com/claude-code)