### PR TITLE
Fix shared module issues #118, #122

### DIFF
--- a/datagen/src/retail_datagen/shared/validators/synthetic_data.py
+++ b/datagen/src/retail_datagen/shared/validators/synthetic_data.py
@@ -37,14 +37,14 @@ class SyntheticDataValidator:
         """
         Check if a first name is acceptable for synthetic data generation.
 
-        Real names are allowed as per requirements. This method now validates
-        basic format requirements rather than rejecting real names.
+        Validates that the name is not a common real name and meets basic
+        format requirements, as required by AGENTS.md and CLAUDE.md.
 
         Args:
             name: First name to validate
 
         Returns:
-            True if acceptable for use, False if invalid format
+            True if synthetic and acceptable, False if real or invalid format
         """
         name_stripped = name.strip()
 
@@ -57,6 +57,11 @@ class SyntheticDataValidator:
 
         # Allow letters, spaces, hyphens, and apostrophes
         if not re.match(r"^[A-Za-z\s\-']+$", name_stripped):
+            return False
+
+        # Check against real name blocklist
+        name_lower = name_stripped.lower()
+        if name_lower in self.real_first_names:
             return False
 
         return True
@@ -65,14 +70,14 @@ class SyntheticDataValidator:
         """
         Check if a last name is acceptable for synthetic data generation.
 
-        Real names are allowed as per requirements. This method now validates
-        basic format requirements rather than rejecting real names.
+        Validates that the name is not a common real name and meets basic
+        format requirements, as required by AGENTS.md and CLAUDE.md.
 
         Args:
             name: Last name to validate
 
         Returns:
-            True if acceptable for use, False if invalid format
+            True if synthetic and acceptable, False if real or invalid format
         """
         name_stripped = name.strip()
 
@@ -85,6 +90,11 @@ class SyntheticDataValidator:
 
         # Allow letters, spaces, hyphens, and apostrophes
         if not re.match(r"^[A-Za-z\s\-']+$", name_stripped):
+            return False
+
+        # Check against real name blocklist
+        name_lower = name_stripped.lower()
+        if name_lower in self.real_last_names:
             return False
 
         return True


### PR DESCRIPTION
## Summary

- Fix #118: Background task status memory leak
- Fix #122: Synthetic data validator allows real names

## Changes

### Issue #118: Background task status memory leak

The `_background_tasks` and `_task_status` dictionaries in `dependencies.py` were growing indefinitely, causing a memory leak.

**Solution:**
- Added automatic cleanup of old background tasks when threshold (1000 tasks) is exceeded
- Cleanup removes completed/failed tasks older than 24 hours by default
- Configurable via environment variables:
  - `TASK_CLEANUP_MAX_AGE_HOURS` (default: 24)
  - `TASK_CLEANUP_THRESHOLD` (default: 1000)
- Added public `cleanup_old_tasks()` function for manual cleanup from APIs or scheduled jobs
- Added structured logging for cleanup operations

**Files Changed:**
- `datagen/src/retail_datagen/shared/dependencies.py` (+67 lines)

### Issue #122: Synthetic data validator allows real names

The `is_synthetic_first_name()` and `is_synthetic_last_name()` methods had comments stating "Real names are allowed" but CLAUDE.md explicitly requires "Never use real names". The methods were only checking format, not validating against the existing blocklists.

**Solution:**
- Updated `is_synthetic_first_name()` to check against `REAL_FIRST_NAMES` blocklist
- Updated `is_synthetic_last_name()` to check against `REAL_LAST_NAMES` blocklist
- Fixed docstrings to reflect actual behavior (reject real names per CLAUDE.md)
- Now properly validates against common real names (50+ first names, 50+ last names)

**Files Changed:**
- `datagen/src/retail_datagen/shared/validators/synthetic_data.py` (+16 lines)

## Test Results

All unit tests pass:
```
884 passed, 3 warnings in 37.92s
```

## Configuration

The cleanup behavior can be tuned via environment variables:

```bash
# Maximum age for completed/failed tasks (hours)
export TASK_CLEANUP_MAX_AGE_HOURS=48

# Threshold for automatic cleanup trigger
export TASK_CLEANUP_THRESHOLD=500
```

Generated with [Claude Code](https://claude.com/claude-code)