### PR TITLE
Fix core infrastructure issues #114, #115, #116, #101

### DIFF
--- a/datagen/src/retail_datagen/generators/fact_generators/core.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/core.py
@@ -353,9 +353,10 @@ class FactDataGenerator(
             "receipt_lines": total_days * total_customers_per_day * 3,
             "foot_traffic": total_days * len(self.stores) * 100,
             "ble_pings": total_days * len(self.stores) * 500,
+            # Estimated: ~60% of BLE pings result in zone changes
             "customer_zone_changes": total_days
             * len(self.stores)
-            * 300,  # Estimated: ~60% of BLE pings result in zone changes
+            * int(500 * 0.6),  # 60% of BLE pings (500 per store per day)
             "dc_inventory_txn": total_days * len(self.distribution_centers) * 50,
             "truck_moves": total_days * 10,
             "truck_inventory": total_days * 20,

--- a/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py
@@ -380,6 +380,36 @@ class PersistenceMixin:
                 "DiscountAmount": "discount_amount",
                 "DiscountCents": "discount_cents",
             },
+            "store_ops": {
+                **common_mappings,
+                "StoreID": "store_id",
+                "OperationType": "operation_type",
+            },
+            "customer_zone_changes": {
+                **common_mappings,
+                "StoreID": "store_id",
+                "CustomerBLEId": "customer_ble_id",
+                "FromZone": "from_zone",
+                "ToZone": "to_zone",
+            },
+            "stockouts": {
+                **common_mappings,
+                "StoreID": "store_id",
+                "DCID": "dc_id",
+                "ProductID": "product_id",
+                "LastKnownQuantity": "last_known_quantity",
+                "DetectionTime": "detection_time",
+            },
+            "reorders": {
+                **common_mappings,
+                "StoreID": "store_id",
+                "DCID": "dc_id",
+                "ProductID": "product_id",
+                "CurrentQuantity": "current_quantity",
+                "ReorderQuantity": "reorder_quantity",
+                "ReorderPoint": "reorder_point",
+                "Priority": "priority",
+            },
         }
 
         mapping = table_specific_mappings.get(table_name, common_mappings)
@@ -724,6 +754,10 @@ class PersistenceMixin:
                     "fact_payments": "fact_payments",
                     "promotions": "fact_promotions",
                     "promo_lines": "fact_promo_lines",
+                    "store_ops": "fact_store_ops",
+                    "customer_zone_changes": "fact_customer_zone_changes",
+                    "stockouts": "fact_stockouts",
+                    "reorders": "fact_reorders",
                 }.get(table_name, table_name)
                 from retail_datagen.db.duckdb_engine import (
                     insert_dataframe,
@@ -1031,6 +1065,12 @@ class PersistenceMixin:
             "marketing": "fact_marketing",
             "online_orders": "fact_online_orders",
             "fact_payments": "fact_payments",
+            "promotions": "fact_promotions",
+            "promo_lines": "fact_promo_lines",
+            "store_ops": "fact_store_ops",
+            "customer_zone_changes": "fact_customer_zone_changes",
+            "stockouts": "fact_stockouts",
+            "reorders": "fact_reorders",
         }
 
         for table_name in active_tables:


### PR DESCRIPTION
## Summary
Addresses multiple core infrastructure issues related to the new fact tables.

## Changes

### Issue #101 - Replace magic number 300 with derived value
- Changed hardcoded 300 to `int(500 * 0.6)` with comment explaining it's 60% of BLE pings

### Issue #114 - New fact tables in FACT_TABLES list
- Verified all new tables already present (no changes needed)

### Issue #115 - Missing persistence mappings
- Added field name mappings for: store_ops, customer_zone_changes, stockouts, reorders
- Added DuckDB table mappings for all new tables
- Added watermark table mappings for all new tables

### Issue #116 - Missing outbox event type mappings
- Verified all event types already present (no changes needed)

## Testing
- All 884 unit tests pass

## Files Changed
- `datagen/src/retail_datagen/generators/fact_generators/core.py`
- `datagen/src/retail_datagen/generators/fact_generators/persistence_mixin.py`

Closes #101, Closes #114, Closes #115, Closes #116