### PR TITLE
Remove unused receipt_id BIGINT column from fact_receipt_lines schema

### DIFF
--- a/datagen/src/retail_datagen/db/duckdb_engine.py
+++ b/datagen/src/retail_datagen/db/duckdb_engine.py
@@ -498,7 +498,6 @@ def ensure_fact_receipt_lines_table(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS fact_receipt_lines (
-            receipt_id BIGINT,
             receipt_id_ext VARCHAR,
             event_ts TIMESTAMP,
             product_id BIGINT,


### PR DESCRIPTION
## Summary
- Remove the `receipt_id BIGINT` column from the `fact_receipt_lines` table schema
- The data model only uses `receipt_id_ext` (VARCHAR) for linking between `fact_receipts` and `fact_receipt_lines`
- The BIGINT column was never populated, causing all-NULL values

## Background
During data validation after generation, discovered that `fact_receipt_lines.receipt_id` was completely NULL (3.8M rows). The column was added to the explicit schema but the data generator only populates `receipt_id_ext` for cross-table linking.

## Test plan
- [x] Verified all other columns in all tables have data after this change
- [x] Confirmed `receipt_id_ext` is properly populated for FK relationships

🤖 Generated with [Claude Code](https://claude.com/claude-code)