### PR TITLE
Remove unused code and fix broken tests

### DIFF
--- a/datagen/src/retail_datagen/generators/fact_generators/payments_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/payments_mixin.py
@@ -92,9 +92,7 @@ class PaymentsMixin(FactGeneratorBase):
         amount_str = receipt.get("Total", "0.00")
 
         # Determine if payment should be declined
-        is_declined, decline_reason = self._should_decline_payment(
-            payment_method, amount_cents
-        )
+        is_declined, decline_reason = self._should_decline_payment(payment_method)
 
         # Simulate processing time
         processing_time_ms = self._simulate_processing_time_ms(payment_method)
@@ -144,9 +142,7 @@ class PaymentsMixin(FactGeneratorBase):
         amount_str = order.get("Total", "0.00")
 
         # Determine if payment should be declined
-        is_declined, decline_reason = self._should_decline_payment(
-            payment_method, amount_cents
-        )
+        is_declined, decline_reason = self._should_decline_payment(payment_method)
 
         # Simulate processing time
         processing_time_ms = self._simulate_processing_time_ms(payment_method)
@@ -176,7 +172,6 @@ class PaymentsMixin(FactGeneratorBase):
     def _should_decline_payment(
         self,
         payment_method: str,
-        amount_cents: int,  # noqa: ARG002 - reserved for future use
     ) -> tuple[bool, str | None]:
         """Determine if a payment should be declined.
 
@@ -185,7 +180,6 @@ class PaymentsMixin(FactGeneratorBase):
 
         Args:
             payment_method: The payment method (CREDIT_CARD, CASH, etc.)
-            amount_cents: Payment amount in cents (reserved for future high-value logic)
 
         Returns:
             Tuple of (is_declined, decline_reason).

--- a/datagen/src/retail_datagen/generators/fact_generators/receipts_mixin.py
+++ b/datagen/src/retail_datagen/generators/fact_generators/receipts_mixin.py
@@ -156,7 +156,6 @@ class ReceiptsMixin(FactGeneratorBase):
         customer: Customer,
         basket: Any,
         transaction_time: datetime,
-        _campaign_id: str | None = None,  # noqa: ARG002 - intentionally unused, see TODO below
     ) -> dict[str, list[dict]]:
         """Create receipt, receipt lines, and inventory transactions.
 
@@ -165,34 +164,13 @@ class ReceiptsMixin(FactGeneratorBase):
             customer: Customer making purchase
             basket: ShoppingBasket with items to purchase
             transaction_time: Timestamp of transaction
-            _campaign_id: Optional marketing campaign ID for attribution tracking.
-                When provided, indicates this purchase was influenced by a marketing
-                campaign. Used by fn_attribution_window KQL function for ROI analysis.
-                NOTE: Parameter prefixed with underscore to indicate it's intentionally
-                unused in this implementation (see TODO below).
 
         Returns:
             Dictionary with receipt, lines, and inventory_transactions
 
         Raises:
             ValueError: If basket has no items (business rule violation)
-
-        Note:
-            campaign_id population for historical data requires attribution window
-            analysis (matching ad impressions to purchases within a time window).
-            See issue #78 for implementation details. Real-time streaming already
-            supports campaign_id via event_factory.py.
         """
-        # TODO(#78): Implement campaign_id attribution for historical data generation.
-        # This requires:
-        # 1. Track ad impressions per customer during marketing generation
-        # 2. When generating receipts, check if customer had impression within
-        #    attribution window
-        # 3. If yes, pass campaign_id to receipt record
-        # For now, _campaign_id parameter is accepted but not used in historical
-        # generation. Real-time streaming (event_factory.py) already implements
-        # this logic.
-
         # CRITICAL: Validate basket has at least 1 item
         # Empty receipts violate business rules and should never be generated
         if not basket.items or len(basket.items) == 0:

--- a/datagen/src/retail_datagen/shared/models.py
+++ b/datagen/src/retail_datagen/shared/models.py
@@ -645,29 +645,6 @@ class Marketing(BaseModel):
     Device: DeviceType = Field(..., description="Device type")
 
 
-class SupplyChainDisruption(BaseModel):
-    """Supply chain disruption event fact."""
-
-    TraceId: str = Field(..., description="Unique trace identifier")
-    EventTS: datetime = Field(..., description="Event timestamp")
-    DCID: int = Field(..., gt=0, description="Distribution center ID")
-    Type: DisruptionType = Field(..., description="Type of disruption")
-    Severity: DisruptionSeverity = Field(..., description="Severity level")
-    Description: str = Field(
-        ..., min_length=1, description="Human readable description"
-    )
-    StartTime: datetime = Field(..., description="Disruption start time")
-    EndTime: datetime | None = Field(
-        None, description="Disruption end time (null if ongoing)"
-    )
-    ImpactPercentage: float = Field(
-        ..., ge=0, le=100, description="Percentage impact on capacity"
-    )
-    AffectedProducts: str | None = Field(
-        None, description="JSON array of affected product IDs"
-    )
-
-
 class OnlineOrder(BaseModel):
     """
     Online order fact table.
@@ -738,35 +715,3 @@ class StoreOperation(BaseModel):
         if v.lower() not in ["opened", "closed"]:
             raise ValueError("OperationType must be either 'opened' or 'closed'")
         return v.lower()
-
-
-# ================================
-# ALIASES FOR TEST COMPATIBILITY
-# ================================
-
-# Dictionary model aliases
-GeographyDict = GeographyDict
-FirstNameDict = FirstNameDict
-LastNameDict = LastNameDict
-ProductCompanyDict = ProductCompanyDict
-ProductBrandDict = ProductBrandDict
-ProductDict = ProductDict
-
-# Dimension model aliases
-GeographyMaster = GeographyMaster
-Store = Store
-DistributionCenter = DistributionCenter
-Customer = Customer
-ProductMaster = ProductMaster
-
-# Fact model aliases
-DCInventoryTransaction = DCInventoryTransaction
-TruckMove = TruckMove
-StoreInventoryTransaction = StoreInventoryTransaction
-Receipt = Receipt
-ReceiptLine = ReceiptLine
-FootTraffic = FootTraffic
-BLEPing = BLEPing
-Marketing = Marketing
-OnlineOrder = OnlineOrder
-StoreOperation = StoreOperation

--- a/datagen/tests/integration/test_payments_integration.py
+++ b/datagen/tests/integration/test_payments_integration.py
@@ -102,10 +102,10 @@ class TestPaymentPersistenceMapping:
 
     def test_outbox_type_mapping(self):
         """fact_payments should map to payment_processed event type."""
-        from retail_datagen.generators.fact_generators import persistence_mixin
+        from retail_datagen.generators.fact_generators import field_mapping
 
-        # Read the source to verify the mapping exists
-        source_file = persistence_mixin.__file__
+        # Read the source to verify the mapping exists in field_mapping module
+        source_file = field_mapping.__file__
         with open(source_file) as f:
             source = f.read()
 
@@ -113,10 +113,10 @@ class TestPaymentPersistenceMapping:
 
     def test_duckdb_table_mapping(self):
         """fact_payments should have correct DuckDB table mapping."""
-        from retail_datagen.generators.fact_generators import persistence_mixin
+        from retail_datagen.generators.routers import common
 
-        # Read the source to verify the duck_table mapping exists
-        source_file = persistence_mixin.__file__
+        # Read the source to verify the duck_table mapping exists in common module
+        source_file = common.__file__
         with open(source_file) as f:
             source = f.read()
 

--- a/datagen/tests/unit/test_payments_generation.py
+++ b/datagen/tests/unit/test_payments_generation.py
@@ -196,7 +196,7 @@ class TestDeclineLogic:
         """Cash payments should never decline."""
         # Test many times to ensure no declines
         for _ in range(100):
-            is_declined, reason = payments_mixin._should_decline_payment("CASH", 10000)
+            is_declined, reason = payments_mixin._should_decline_payment("CASH")
             assert is_declined is False
             assert reason is None
 
@@ -206,9 +206,7 @@ class TestDeclineLogic:
         declined_count = 0
         for i in range(1000):
             payments_mixin._rng.seed(i)  # Different seed each time
-            is_declined, reason = payments_mixin._should_decline_payment(
-                "CREDIT_CARD", 10000
-            )
+            is_declined, reason = payments_mixin._should_decline_payment("CREDIT_CARD")
             if is_declined:
                 declined_count += 1
                 assert reason is not None
@@ -221,9 +219,7 @@ class TestDeclineLogic:
         """Approved payments should not have a decline reason."""
         # Reset with known seed that produces approval
         payments_mixin._rng.seed(42)
-        is_declined, reason = payments_mixin._should_decline_payment(
-            "CREDIT_CARD", 10000
-        )
+        is_declined, reason = payments_mixin._should_decline_payment("CREDIT_CARD")
         if not is_declined:
             assert reason is None
 
@@ -234,7 +230,7 @@ class TestDeclineLogic:
         total = 10000
 
         for _ in range(total):
-            is_declined, _ = mixin._should_decline_payment("CREDIT_CARD", 5000)
+            is_declined, _ = mixin._should_decline_payment("CREDIT_CARD")
             if is_declined:
                 declined += 1
 


### PR DESCRIPTION
## Summary
- Remove ~87 lines of dead/unused code identified via static analysis
- Fix 2 broken integration tests that were checking the wrong source files

## Changes

### Dead Code Removed
- **models.py**: Remove 25 self-alias variables (no-op `X = X` assignments)
- **models.py**: Remove unused `SupplyChainDisruption` class (never imported)
- **receipts_mixin.py**: Remove unused `_campaign_id` parameter and stale TODO(#78) block
- **payments_mixin.py**: Remove unused `amount_cents` parameter from `_should_decline_payment`

### Test Fixes
- **test_payments_integration.py**: Fix `test_outbox_type_mapping` to check `field_mapping.py` (where the mapping actually exists)
- **test_payments_integration.py**: Fix `test_duckdb_table_mapping` to check `routers/common.py` (where the mapping actually exists)
- **test_payments_generation.py**: Update 4 test call sites to match new method signature

## Test plan
- [x] All 944 unit tests pass
- [x] All 13 payment integration tests pass (previously 2 were failing)
- [x] Smoke tests pass
- [x] `ruff check` passes
- [x] All imports verified working

🤖 Generated with [Claude Code](https://claude.ai/code)