### PR TITLE
claude/rename-powerbi-columns-FXNYH

### DIFF
--- a/fabric/semantic_model/retail_model.SemanticModel/definition/relationships.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/relationships.tmdl
@@ -1,180 +1,180 @@
-relationship 'dim_customers to dim_geographies'
+relationship 'Customers to Geographies'
 	isActive: false
-	fromColumn: dim_customers.GeographyID
-	toColumn: dim_geographies.ID
+	fromColumn: Customers.'Geography ID'
+	toColumn: Geographies.ID
 
-relationship 'dim_stores to dim_geographies'
-	fromColumn: dim_stores.GeographyID
-	toColumn: dim_geographies.ID
+relationship 'Stores to Geographies'
+	fromColumn: Stores.'Geography ID'
+	toColumn: Geographies.ID
 
-relationship 'dim_distribution_centers to dim_geographies'
-	fromColumn: dim_distribution_centers.GeographyID
-	toColumn: dim_geographies.ID
+relationship 'Distribution Centers to Geographies'
+	fromColumn: 'Distribution Centers'.'Geography ID'
+	toColumn: Geographies.ID
 
-relationship 'fact_receipts to dim_customers'
-	fromColumn: fact_receipts.customer_id
-	toColumn: dim_customers.ID
+relationship 'Receipts to Customers'
+	fromColumn: Receipts.'Customer ID'
+	toColumn: Customers.ID
 
-relationship 'fact_receipts to dim_stores'
-	fromColumn: fact_receipts.store_id
-	toColumn: dim_stores.ID
+relationship 'Receipts to Stores'
+	fromColumn: Receipts.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'fact_receipt_lines to fact_receipts'
-	fromColumn: fact_receipt_lines.receipt_id_ext
-	toColumn: fact_receipts.receipt_id_ext
+relationship 'Receipt Lines to Receipts'
+	fromColumn: 'Receipt Lines'.'Receipt ID'
+	toColumn: Receipts.'Receipt ID'
 
-relationship 'fact_receipt_lines to dim_products'
-	fromColumn: fact_receipt_lines.product_id
-	toColumn: dim_products.ID
+relationship 'Receipt Lines to Products'
+	fromColumn: 'Receipt Lines'.'Product ID'
+	toColumn: Products.ID
 
-relationship 'fact_payments to fact_receipts'
-	fromColumn: fact_payments.receipt_id_ext
-	toColumn: fact_receipts.receipt_id_ext
+relationship 'Payments to Receipts'
+	fromColumn: Payments.'Receipt ID'
+	toColumn: Receipts.'Receipt ID'
 
-relationship 'fact_payments to fact_online_order_headers'
+relationship 'Payments to Online Orders'
 	isActive: false
-	fromColumn: fact_payments.order_id_ext
-	toColumn: fact_online_order_headers.order_id_ext
+	fromColumn: Payments.'Order ID'
+	toColumn: 'Online Orders'.'Order ID'
 
-relationship 'fact_payments to dim_stores'
+relationship 'Payments to Stores'
 	isActive: false
-	fromColumn: fact_payments.store_id
-	toColumn: dim_stores.ID
+	fromColumn: Payments.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'fact_payments to dim_customers'
+relationship 'Payments to Customers'
 	isActive: false
-	fromColumn: fact_payments.customer_id
-	toColumn: dim_customers.ID
+	fromColumn: Payments.'Customer ID'
+	toColumn: Customers.ID
 
-relationship 'fact_online_order_headers to dim_customers'
-	fromColumn: fact_online_order_headers.customer_id
-	toColumn: dim_customers.ID
+relationship 'Online Orders to Customers'
+	fromColumn: 'Online Orders'.'Customer ID'
+	toColumn: Customers.ID
 
-relationship 'fact_online_order_lines to fact_online_order_headers'
-	fromColumn: fact_online_order_lines.order_id
-	toColumn: fact_online_order_headers.order_id_ext
+relationship 'Online Order Lines to Online Orders'
+	fromColumn: 'Online Order Lines'.'Order ID'
+	toColumn: 'Online Orders'.'Order ID'
 
-relationship 'fact_online_order_lines to dim_products'
-	fromColumn: fact_online_order_lines.product_id
-	toColumn: dim_products.ID
+relationship 'Online Order Lines to Products'
+	fromColumn: 'Online Order Lines'.'Product ID'
+	toColumn: Products.ID
 
-relationship 'fact_store_inventory_txn to dim_stores'
-	fromColumn: fact_store_inventory_txn.store_id
-	toColumn: dim_stores.ID
+relationship 'Store Inventory Transactions to Stores'
+	fromColumn: 'Store Inventory Transactions'.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'fact_store_inventory_txn to dim_products'
-	fromColumn: fact_store_inventory_txn.product_id
-	toColumn: dim_products.ID
+relationship 'Store Inventory Transactions to Products'
+	fromColumn: 'Store Inventory Transactions'.'Product ID'
+	toColumn: Products.ID
 
-relationship 'inventory_position_current to dim_stores'
-	fromColumn: inventory_position_current.store_id
-	toColumn: dim_stores.ID
+relationship 'Store Inventory Position to Stores'
+	fromColumn: 'Store Inventory Position'.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'inventory_position_current to dim_products'
-	fromColumn: inventory_position_current.product_id
-	toColumn: dim_products.ID
+relationship 'Store Inventory Position to Products'
+	fromColumn: 'Store Inventory Position'.'Product ID'
+	toColumn: Products.ID
 
-relationship 'dc_inventory_position_current to dim_distribution_centers'
-	fromColumn: dc_inventory_position_current.dc_id
-	toColumn: dim_distribution_centers.ID
+relationship 'DC Inventory Position to Distribution Centers'
+	fromColumn: 'DC Inventory Position'.'DC ID'
+	toColumn: 'Distribution Centers'.ID
 
-relationship 'dc_inventory_position_current to dim_products'
-	fromColumn: dc_inventory_position_current.product_id
-	toColumn: dim_products.ID
+relationship 'DC Inventory Position to Products'
+	fromColumn: 'DC Inventory Position'.'Product ID'
+	toColumn: Products.ID
 
-relationship 'fact_dc_inventory_txn to dim_distribution_centers'
-	fromColumn: fact_dc_inventory_txn.dc_id
-	toColumn: dim_distribution_centers.ID
+relationship 'DC Inventory Transactions to Distribution Centers'
+	fromColumn: 'DC Inventory Transactions'.'DC ID'
+	toColumn: 'Distribution Centers'.ID
 
-relationship 'fact_dc_inventory_txn to dim_products'
-	fromColumn: fact_dc_inventory_txn.product_id
-	toColumn: dim_products.ID
+relationship 'DC Inventory Transactions to Products'
+	fromColumn: 'DC Inventory Transactions'.'Product ID'
+	toColumn: Products.ID
 
-relationship 'fact_truck_moves to dim_trucks'
-	fromColumn: fact_truck_moves.truck_id
-	toColumn: dim_trucks.ID
+relationship 'Truck Moves to Trucks'
+	fromColumn: 'Truck Moves'.'Truck ID'
+	toColumn: Trucks.ID
 
-relationship 'fact_truck_moves to dim_stores'
+relationship 'Truck Moves to Stores'
 	isActive: false
-	fromColumn: fact_truck_moves.store_id
-	toColumn: dim_stores.ID
+	fromColumn: 'Truck Moves'.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'fact_truck_moves to dim_distribution_centers'
-	fromColumn: fact_truck_moves.dc_id
-	toColumn: dim_distribution_centers.ID
+relationship 'Truck Moves to Distribution Centers'
+	fromColumn: 'Truck Moves'.'DC ID'
+	toColumn: 'Distribution Centers'.ID
 
-relationship 'fact_truck_inventory to dim_trucks'
-	fromColumn: fact_truck_inventory.truck_id
-	toColumn: dim_trucks.ID
+relationship 'Truck Inventory to Trucks'
+	fromColumn: 'Truck Inventory'.'Truck ID'
+	toColumn: Trucks.ID
 
-relationship 'fact_truck_inventory to dim_products'
-	fromColumn: fact_truck_inventory.product_id
-	toColumn: dim_products.ID
+relationship 'Truck Inventory to Products'
+	fromColumn: 'Truck Inventory'.'Product ID'
+	toColumn: Products.ID
 
-relationship 'fact_foot_traffic to dim_stores'
-	fromColumn: fact_foot_traffic.store_id
-	toColumn: dim_stores.ID
+relationship 'Foot Traffic to Stores'
+	fromColumn: 'Foot Traffic'.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'fact_stockouts to dim_products'
-	fromColumn: fact_stockouts.ProductID
-	toColumn: dim_products.ID
+relationship 'Stockouts to Products'
+	fromColumn: Stockouts.'Product ID'
+	toColumn: Products.ID
 
-relationship 'fact_reorders to dim_stores'
-	fromColumn: fact_reorders.store_id
-	toColumn: dim_stores.ID
+relationship 'Reorders to Stores'
+	fromColumn: Reorders.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'fact_reorders to dim_products'
-	fromColumn: fact_reorders.product_id
-	toColumn: dim_products.ID
+relationship 'Reorders to Products'
+	fromColumn: Reorders.'Product ID'
+	toColumn: Products.ID
 
-relationship 'fact_reorders to dim_distribution_centers'
+relationship 'Reorders to Distribution Centers'
 	isActive: false
-	fromColumn: fact_reorders.dc_id
-	toColumn: dim_distribution_centers.ID
+	fromColumn: Reorders.'DC ID'
+	toColumn: 'Distribution Centers'.ID
 
-relationship 'fact_store_ops to dim_stores'
-	fromColumn: fact_store_ops.store_id
-	toColumn: dim_stores.ID
+relationship 'Store Operations to Stores'
+	fromColumn: 'Store Operations'.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'fact_promotions to dim_stores'
+relationship 'Promotions to Stores'
 	isActive: false
-	fromColumn: fact_promotions.StoreID
-	toColumn: dim_stores.ID
+	fromColumn: Promotions.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'fact_promotions to dim_customers'
+relationship 'Promotions to Customers'
 	isActive: false
-	fromColumn: fact_promotions.CustomerID
-	toColumn: dim_customers.ID
+	fromColumn: Promotions.'Customer ID'
+	toColumn: Customers.ID
 
-relationship 'fact_promotions to fact_receipts'
-	fromColumn: fact_promotions.ReceiptId
-	toColumn: fact_receipts.receipt_id_ext
+relationship 'Promotions to Receipts'
+	fromColumn: Promotions.'Receipt ID'
+	toColumn: Receipts.'Receipt ID'
 
-relationship 'sales_minute_store to dim_stores'
-	fromColumn: sales_minute_store.store_id
-	toColumn: dim_stores.ID
+relationship 'Store Sales by Minute to Stores'
+	fromColumn: 'Store Sales by Minute'.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'top_products_15m to dim_products'
-	fromColumn: top_products_15m.product_id
-	toColumn: dim_products.ID
+relationship 'Top Products 15 Min to Products'
+	fromColumn: 'Top Products 15 Min'.'Product ID'
+	toColumn: Products.ID
 
-relationship 'zone_dwell_minute to dim_stores'
-	fromColumn: zone_dwell_minute.store_id
-	toColumn: dim_stores.ID
+relationship 'Zone Dwell by Minute to Stores'
+	fromColumn: 'Zone Dwell by Minute'.'Store ID'
+	toColumn: Stores.ID
 
-relationship 'online_sales_daily to dim_date'
-	fromColumn: online_sales_daily.day
-	toColumn: dim_date.date
+relationship 'Online Sales Daily to Date'
+	fromColumn: 'Online Sales Daily'.Day
+	toColumn: Date.Date
 
-relationship 'tender_mix_daily to dim_date'
-	fromColumn: tender_mix_daily.day
-	toColumn: dim_date.date
+relationship 'Tender Mix Daily to Date'
+	fromColumn: 'Tender Mix Daily'.Day
+	toColumn: Date.Date
 
-relationship 'marketing_cost_daily to dim_date'
-	fromColumn: marketing_cost_daily.day
-	toColumn: dim_date.date
+relationship 'Marketing Cost Daily to Date'
+	fromColumn: 'Marketing Cost Daily'.Day
+	toColumn: Date.Date
 
-relationship 'truck_dwell_daily to dim_date'
-	fromColumn: truck_dwell_daily.day
-	toColumn: dim_date.date
+relationship 'Truck Dwell Daily to Date'
+	fromColumn: 'Truck Dwell Daily'.Day
+	toColumn: Date.Date
 

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/_watermarks.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/_watermarks.tmdl
@@ -1,17 +1,19 @@
-table _watermarks
+table Watermarks
 	lineageTag: 0a6eb3a9-dfc1-4cb2-814c-3b67f979d2ae
 	sourceLineageTag: [ag].[_watermarks]
 
-	column source_table
+	column 'Source Table'
 		dataType: string
 		lineageTag: 1763d036-3789-473a-a984-1b81b3ab5a75
 		sourceLineageTag: source_table
 		summarizeBy: none
 		sourceColumn: source_table
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column last_processed_ts
+	column 'Last Processed Timestamp'
 		dataType: dateTime
 		formatString: General Date
 		lineageTag: 1a34ee4b-d4af-46d6-81af-41e493cb7bf8
@@ -19,9 +21,11 @@ table _watermarks
 		summarizeBy: none
 		sourceColumn: last_processed_ts
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column updated_at
+	column 'Updated At'
 		dataType: dateTime
 		formatString: General Date
 		lineageTag: 6776ab1d-f90b-4891-9af5-462126fd000c
@@ -29,9 +33,11 @@ table _watermarks
 		summarizeBy: none
 		sourceColumn: updated_at
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition _watermarks = entity
+	partition Watermarks = entity
 		mode: directLake
 		source
 			entityName: _watermarks

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dc_inventory_position_current.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dc_inventory_position_current.tmdl
@@ -1,8 +1,8 @@
-table dc_inventory_position_current
+table 'DC Inventory Position'
 	lineageTag: 6e01fb51-1261-4586-97ec-01c0f7b73a13
 	sourceLineageTag: [au].[dc_inventory_position_current]
 
-	column dc_id
+	column 'DC ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 847804d1-5b60-4232-a3c8-4daa440a4ceb
@@ -10,9 +10,11 @@ table dc_inventory_position_current
 		summarizeBy: sum
 		sourceColumn: dc_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column product_id
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 637a2bb9-88bd-4b52-a68d-f453131dd46e
@@ -20,9 +22,11 @@ table dc_inventory_position_current
 		summarizeBy: sum
 		sourceColumn: product_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column on_hand
+	column 'On Hand'
 		dataType: int64
 		formatString: 0
 		lineageTag: 59670602-e36f-4c3f-ac16-f953603778a2
@@ -30,9 +34,11 @@ table dc_inventory_position_current
 		summarizeBy: sum
 		sourceColumn: on_hand
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition dc_inventory_position_current = entity
+	partition 'DC Inventory Position' = entity
 		mode: directLake
 		source
 			entityName: dc_inventory_position_current

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_customers.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_customers.tmdl
@@ -1,8 +1,8 @@
-table dim_customers
+table Customers
 	lineageTag: 5531b22c-bc78-4ae9-8d9f-64dcee879bad
 	sourceLineageTag: [ag].[dim_customers]
 
-	measure '# of Customers' = COUNTROWS(dim_customers)
+	measure '# of Customers' = COUNTROWS(Customers)
 		formatString: #,0
 		lineageTag: 01a1a1b3-0001-0001-0001-000000000001
 
@@ -16,21 +16,23 @@ table dim_customers
 
 		annotation SummarizationSetBy = Automatic
 
-	column FirstName
+	column 'First Name'
 		dataType: string
 		lineageTag: 29fdf2eb-f734-4dca-a4d5-57494eb37a71
 		sourceLineageTag: FirstName
 		summarizeBy: none
 		sourceColumn: FirstName
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column LastName
+	column 'Last Name'
 		dataType: string
 		lineageTag: 485d56e0-0b8f-41da-bbcd-cb500561440c
 		sourceLineageTag: LastName
 		summarizeBy: none
 		sourceColumn: LastName
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -43,22 +45,24 @@ table dim_customers
 
 		annotation SummarizationSetBy = Automatic
 
-	column GeographyID
+	column 'Geography ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 1b0afb62-5a20-472d-9486-5f52b3dc74f6
 		sourceLineageTag: GeographyID
 		summarizeBy: count
 		sourceColumn: GeographyID
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column LoyaltyCard
+	column 'Loyalty Card'
 		dataType: string
 		lineageTag: a9c05456-300a-4430-a34b-184f017b66ae
 		sourceLineageTag: LoyaltyCard
 		summarizeBy: none
 		sourceColumn: LoyaltyCard
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -71,25 +75,27 @@ table dim_customers
 
 		annotation SummarizationSetBy = Automatic
 
-	column BLEId
+	column 'BLE ID'
 		dataType: string
 		lineageTag: be6bd21e-b728-46c6-b62b-5550e2abedba
 		sourceLineageTag: BLEId
 		summarizeBy: none
 		sourceColumn: BLEId
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column AdId
+	column 'Ad ID'
 		dataType: string
 		lineageTag: 0d74302f-4f4b-472c-9b9b-48b57d298e6b
 		sourceLineageTag: AdId
 		summarizeBy: none
 		sourceColumn: AdId
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	partition dim_customers = entity
+	partition Customers = entity
 		mode: directLake
 		source
 			entityName: dim_customers

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_date.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_date.tmdl
@@ -1,8 +1,8 @@
-table dim_date
+table Date
 	lineageTag: 8a9c5f7e-7d3b-4f0a-9b6d-2e4f8c9a1b3d
 	sourceLineageTag: [ag].[dim_date]
 
-	column date_key
+	column 'Date Key'
 		dataType: int64
 		isKey
 		formatString: 0
@@ -10,132 +10,146 @@ table dim_date
 		sourceLineageTag: date_key
 		summarizeBy: none
 		sourceColumn: date_key
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column date
+	column Date
 		dataType: dateTime
 		formatString: Short Date
 		lineageTag: 663140d5-bad2-44f0-85c4-d838593e15ec
 		sourceLineageTag: date
 		summarizeBy: none
 		sourceColumn: date
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
 		annotation UnderlyingDateTimeDataType = Date
 
-	column year
+	column Year
 		dataType: int64
 		formatString: 0
 		lineageTag: 3cbeb486-9983-4ef0-b633-89271227d3a9
 		sourceLineageTag: year
 		summarizeBy: none
 		sourceColumn: year
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column quarter
+	column Quarter
 		dataType: int64
 		formatString: 0
 		lineageTag: 94b46b9b-340d-4be7-b75c-41cbd74c17e0
 		sourceLineageTag: quarter
 		summarizeBy: none
 		sourceColumn: quarter
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column month
+	column Month
 		dataType: int64
 		formatString: 0
 		lineageTag: fc5a6c34-f14e-4004-b991-36ebf22d1cfe
 		sourceLineageTag: month
 		summarizeBy: none
 		sourceColumn: month
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column month_name
+	column 'Month Name'
 		dataType: string
 		lineageTag: aa93e8de-fad2-4609-9ca1-cc51410c4d95
 		sourceLineageTag: month_name
 		summarizeBy: none
 		sourceColumn: month_name
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column day
+	column Day
 		dataType: int64
 		formatString: 0
 		lineageTag: 7320cbff-3fdf-49f3-9676-ace53d312dde
 		sourceLineageTag: day
 		summarizeBy: none
 		sourceColumn: day
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column day_of_week
+	column 'Day of Week'
 		dataType: int64
 		formatString: 0
 		lineageTag: 936c71b6-5eed-4352-ab5c-581cba9a4237
 		sourceLineageTag: day_of_week
 		summarizeBy: none
 		sourceColumn: day_of_week
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column day_name
+	column 'Day Name'
 		dataType: string
 		lineageTag: 868f4eb8-8b2e-4e62-97d3-6f59f18a09dd
 		sourceLineageTag: day_name
 		summarizeBy: none
 		sourceColumn: day_name
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column week_of_year
+	column 'Week of Year'
 		dataType: int64
 		formatString: 0
 		lineageTag: f8a2a5e8-d83e-4e4c-a301-fb6fe12b6f75
 		sourceLineageTag: week_of_year
 		summarizeBy: none
 		sourceColumn: week_of_year
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column is_weekend
+	column 'Is Weekend'
 		dataType: int64
 		formatString: 0
 		lineageTag: a16bc468-9f30-4bc3-8fe7-01dc817b9d01
 		sourceLineageTag: is_weekend
 		summarizeBy: none
 		sourceColumn: is_weekend
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column fiscal_year
+	column 'Fiscal Year'
 		dataType: int64
 		formatString: 0
 		lineageTag: 5f84809b-99e1-4134-a29d-8418f7e2e3f3
 		sourceLineageTag: fiscal_year
 		summarizeBy: none
 		sourceColumn: fiscal_year
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column fiscal_quarter
+	column 'Fiscal Quarter'
 		dataType: int64
 		formatString: 0
 		lineageTag: 0e0b8933-f9c2-4d2c-95d0-e5f8207a6537
 		sourceLineageTag: fiscal_quarter
 		summarizeBy: none
 		sourceColumn: fiscal_quarter
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	partition dim_date = entity
+	partition Date = entity
 		mode: directLake
 		source
 			entityName: dim_date
 			schemaName: ag
 			expressionSource: 'DirectLake - retail_lakehouse'
+

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_distribution_centers.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_distribution_centers.tmdl
@@ -1,8 +1,8 @@
-table dim_distribution_centers
+table 'Distribution Centers'
 	lineageTag: ae706b9b-d53f-48e5-8f09-4c969f0d6b4a
 	sourceLineageTag: [ag].[dim_distribution_centers]
 
-	measure '# of Distribution Centers' = COUNTROWS(dim_distribution_centers)
+	measure '# of Distribution Centers' = COUNTROWS('Distribution Centers')
 		formatString: #,0
 		lineageTag: 01a1a1b4-0001-0001-0001-000000000001
 
@@ -16,12 +16,13 @@ table dim_distribution_centers
 
 		annotation SummarizationSetBy = Automatic
 
-	column DCNumber
+	column 'DC Number'
 		dataType: string
 		lineageTag: 44b8d211-1e3a-4e3e-bd7b-db2bc8964e77
 		sourceLineageTag: DCNumber
 		summarizeBy: none
 		sourceColumn: DCNumber
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -34,17 +35,18 @@ table dim_distribution_centers
 
 		annotation SummarizationSetBy = Automatic
 
-	column GeographyID
+	column 'Geography ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 4881f71c-36d7-4f39-968c-453678861c69
 		sourceLineageTag: GeographyID
 		summarizeBy: count
 		sourceColumn: GeographyID
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	partition dim_distribution_centers = entity
+	partition 'Distribution Centers' = entity
 		mode: directLake
 		source
 			entityName: dim_distribution_centers

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_geographies.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_geographies.tmdl
@@ -1,8 +1,8 @@
-table dim_geographies
+table Geographies
 	lineageTag: 0182aad6-4ad2-40ca-ad96-bccd64f82380
 	sourceLineageTag: [ag].[dim_geographies]
 
-	measure '# of Locations' = COUNTROWS(dim_geographies)
+	measure '# of Locations' = COUNTROWS(Geographies)
 		formatString: #,0
 		lineageTag: 01a1a1b6-0001-0001-0001-000000000001
 
@@ -34,12 +34,13 @@ table dim_geographies
 
 		annotation SummarizationSetBy = Automatic
 
-	column ZipCode
+	column 'Zip Code'
 		dataType: string
 		lineageTag: 00fa76f8-35be-45d4-85ab-485a221637c1
 		sourceLineageTag: ZipCode
 		summarizeBy: none
 		sourceColumn: ZipCode
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -61,7 +62,7 @@ table dim_geographies
 
 		annotation SummarizationSetBy = Automatic
 
-	partition dim_geographies = entity
+	partition Geographies = entity
 		mode: directLake
 		source
 			entityName: dim_geographies

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_products.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_products.tmdl
@@ -1,16 +1,16 @@
-table dim_products
+table Products
 	lineageTag: 7a341aa1-e4de-4e62-8737-d78ecfeea40b
 	sourceLineageTag: [ag].[dim_products]
 
-	measure '# of Products' = COUNTROWS(dim_products)
+	measure '# of Products' = COUNTROWS(Products)
 		formatString: #,0
 		lineageTag: 01a1a1b1-0001-0001-0001-000000000001
 
-	measure 'Average Product Cost' = AVERAGE(dim_products[Cost])
+	measure 'Average Product Cost' = AVERAGE(Products[Cost])
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1b1-0001-0001-0001-000000000002
 
-	measure 'Average Product Price' = AVERAGE(dim_products[SalePrice])
+	measure 'Average Product Price' = AVERAGE(Products[Sale Price])
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1b1-0001-0001-0001-000000000003
 
@@ -24,12 +24,13 @@ table dim_products
 
 		annotation SummarizationSetBy = Automatic
 
-	column ProductName
+	column 'Product Name'
 		dataType: string
 		lineageTag: cb4130e7-5394-4782-acf3-ab5644c978e8
 		sourceLineageTag: ProductName
 		summarizeBy: none
 		sourceColumn: ProductName
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -100,33 +101,36 @@ table dim_products
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column SalePrice
+	column 'Sale Price'
 		dataType: double
 		lineageTag: c24767c6-4fea-47f9-9065-cfb0bff80eae
 		sourceLineageTag: SalePrice
 		summarizeBy: sum
 		sourceColumn: SalePrice
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column RequiresRefrigeration
+	column 'Requires Refrigeration'
 		dataType: boolean
 		formatString: """TRUE"";""TRUE"";""FALSE"""
 		lineageTag: dd0cf621-be7f-44c8-b63e-462cfadd4b68
 		sourceLineageTag: RequiresRefrigeration
 		summarizeBy: none
 		sourceColumn: RequiresRefrigeration
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column taxability
+	column Taxability
 		dataType: string
 		lineageTag: 4496d2dc-3d8f-4844-9e61-57c6fd4c4bd5
 		sourceLineageTag: taxability
 		summarizeBy: none
 		sourceColumn: taxability
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -139,7 +143,7 @@ table dim_products
 
 		annotation SummarizationSetBy = Automatic
 
-	partition dim_products = entity
+	partition Products = entity
 		mode: directLake
 		source
 			entityName: dim_products

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_stores.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_stores.tmdl
@@ -1,8 +1,8 @@
-table dim_stores
+table Stores
 	lineageTag: 7a2501f0-2aab-403a-82e0-5f791cd939ef
 	sourceLineageTag: [ag].[dim_stores]
 
-	measure '# of Stores' = COUNTROWS(dim_stores)
+	measure '# of Stores' = COUNTROWS(Stores)
 		formatString: #,0
 		lineageTag: 01a1a1b2-0001-0001-0001-000000000001
 
@@ -16,12 +16,13 @@ table dim_stores
 
 		annotation SummarizationSetBy = Automatic
 
-	column StoreNumber
+	column 'Store Number'
 		dataType: string
 		lineageTag: 26e6a058-d596-4bfe-8e69-52e779a7adfa
 		sourceLineageTag: StoreNumber
 		summarizeBy: none
 		sourceColumn: StoreNumber
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -34,66 +35,72 @@ table dim_stores
 
 		annotation SummarizationSetBy = Automatic
 
-	column GeographyID
+	column 'Geography ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 34b29980-f042-438f-bedc-96916d57be64
 		sourceLineageTag: GeographyID
 		summarizeBy: none
 		sourceColumn: GeographyID
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column tax_rate
+	column 'Tax Rate'
 		dataType: double
 		lineageTag: 5d48e6a7-58d4-4ae4-a1fb-af34db5aa099
 		sourceLineageTag: tax_rate
 		summarizeBy: none
 		sourceColumn: tax_rate
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column volume_class
+	column 'Volume Class'
 		dataType: string
 		lineageTag: 0295d16e-cf12-4f89-a22b-e19fa4c8e6ca
 		sourceLineageTag: volume_class
 		summarizeBy: none
 		sourceColumn: volume_class
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column store_format
+	column 'Store Format'
 		dataType: string
 		lineageTag: 847e0428-24d0-4c22-adef-1d346945593c
 		sourceLineageTag: store_format
 		summarizeBy: none
 		sourceColumn: store_format
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column operating_hours
+	column 'Operating Hours'
 		dataType: string
 		lineageTag: 57c66eb7-47bd-47d8-a38e-14e7c857926b
 		sourceLineageTag: operating_hours
 		summarizeBy: none
 		sourceColumn: operating_hours
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
-	column daily_traffic_multiplier
+	column 'Daily Traffic Multiplier'
 		dataType: double
 		lineageTag: 718f6419-bcf5-4a30-9ff5-3719ccd5ec78
 		sourceLineageTag: daily_traffic_multiplier
 		summarizeBy: none
 		sourceColumn: daily_traffic_multiplier
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	partition dim_stores = entity
+	partition Stores = entity
 		mode: directLake
 		source
 			entityName: dim_stores

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_trucks.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/dim_trucks.tmdl
@@ -1,8 +1,8 @@
-table dim_trucks
+table Trucks
 	lineageTag: 7eb610bd-c508-404e-b04a-5cb53d07d17a
 	sourceLineageTag: [ag].[dim_trucks]
 
-	measure '# of Trucks' = COUNTROWS(dim_trucks)
+	measure '# of Trucks' = COUNTROWS(Trucks)
 		formatString: #,0
 		lineageTag: 01a1a1b5-0001-0001-0001-000000000001
 
@@ -16,12 +16,13 @@ table dim_trucks
 
 		annotation SummarizationSetBy = Automatic
 
-	column LicensePlate
+	column 'License Plate'
 		dataType: string
 		lineageTag: fbf89ae1-c807-41f3-9079-a59a825406c2
 		sourceLineageTag: LicensePlate
 		summarizeBy: none
 		sourceColumn: LicensePlate
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -35,18 +36,19 @@ table dim_trucks
 
 		annotation SummarizationSetBy = Automatic
 
-	column DCID
+	column 'DC ID'
 		dataType: double
 		lineageTag: 52e87361-f6d2-4cde-944c-1164180439b0
 		sourceLineageTag: DCID
 		summarizeBy: count
 		sourceColumn: DCID
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	partition dim_trucks = entity
+	partition Trucks = entity
 		mode: directLake
 		source
 			entityName: dim_trucks

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_ble_pings.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_ble_pings.tmdl
@@ -1,28 +1,34 @@
-table fact_ble_pings
+table 'BLE Pings'
 	lineageTag: 73ae8b40-2387-4123-859d-f4e85a159c5b
 	sourceLineageTag: [ag].[fact_ble_pings]
 
-	column CustomerId
+	changedProperty = Name
+
+	column 'Customer ID'
 		dataType: double
 		lineageTag: 17cdf61c-5cf1-4033-980c-c519f645366f
 		sourceLineageTag: CustomerId
 		summarizeBy: count
 		sourceColumn: CustomerId
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column beacon_id
+	column 'Beacon ID'
 		dataType: string
 		lineageTag: f363e067-f6a2-4489-8fb9-0a2125b808f9
 		sourceLineageTag: beacon_id
 		summarizeBy: none
 		sourceColumn: beacon_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column rssi
+	column RSSI
 		dataType: int64
 		formatString: 0
 		lineageTag: 8bf658c2-1719-47f2-9f60-b42529ad1ed9
@@ -30,27 +36,33 @@ table fact_ble_pings
 		summarizeBy: sum
 		sourceColumn: rssi
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column customer_ble_id
+	column 'Customer BLE ID'
 		dataType: string
 		lineageTag: 73ee9633-eaef-41f5-b882-d083ac81b298
 		sourceLineageTag: customer_ble_id
 		summarizeBy: none
 		sourceColumn: customer_ble_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column zone
+	column Zone
 		dataType: string
 		lineageTag: cce44947-09a5-4de8-ae38-4c39a9a32350
 		sourceLineageTag: zone
 		summarizeBy: none
 		sourceColumn: zone
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: b00319bf-5301-4ba3-951d-d5092ca7d125
@@ -58,9 +70,11 @@ table fact_ble_pings
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_ble_pings = entity
+	partition 'BLE Pings' = entity
 		mode: directLake
 		source
 			entityName: fact_ble_pings

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_customer_zone_changes.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_customer_zone_changes.tmdl
@@ -1,8 +1,10 @@
-table fact_customer_zone_changes
+table 'Customer Zone Changes'
 	lineageTag: edc61f90-5ee8-4618-9d9d-e496d674f557
 	sourceLineageTag: [ag].[fact_customer_zone_changes]
 
-	column StoreID
+	changedProperty = Name
+
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: ca15bf52-0050-41fa-aa78-434135694b5d
@@ -10,36 +12,44 @@ table fact_customer_zone_changes
 		summarizeBy: count
 		sourceColumn: StoreID
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column CustomerBLEId
+	column 'Customer BLE ID'
 		dataType: string
 		lineageTag: caa3482c-b4fa-4faa-bf95-459fdac0bbfa
 		sourceLineageTag: CustomerBLEId
 		summarizeBy: none
 		sourceColumn: CustomerBLEId
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column FromZone
+	column 'From Zone'
 		dataType: string
 		lineageTag: bda49b7c-f843-4f29-be11-46ede9eac12d
 		sourceLineageTag: FromZone
 		summarizeBy: none
 		sourceColumn: FromZone
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column ToZone
+	column 'To Zone'
 		dataType: string
 		lineageTag: 73a8db4f-652e-4273-afc2-a6e50a2e1408
 		sourceLineageTag: ToZone
 		summarizeBy: none
 		sourceColumn: ToZone
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_customer_zone_changes = entity
+	partition 'Customer Zone Changes' = entity
 		mode: directLake
 		source
 			entityName: fact_customer_zone_changes

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_dc_inventory_txn.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_dc_inventory_txn.tmdl
@@ -1,17 +1,19 @@
-table fact_dc_inventory_txn
+table 'DC Inventory Transactions'
 	lineageTag: 1f83be55-41e6-4951-8d58-fc6f4a5cfa45
 	sourceLineageTag: [ag].[fact_dc_inventory_txn]
 
-	column txn_type
+	column 'Transaction Type'
 		dataType: string
 		lineageTag: b8c7794a-d23b-4894-b0d0-274ab2539d08
 		sourceLineageTag: txn_type
 		summarizeBy: none
 		sourceColumn: txn_type
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column quantity
+	column Quantity
 		dataType: int64
 		formatString: 0
 		lineageTag: 8e8ce055-d5fe-4dda-9de3-85efc19e5767
@@ -19,9 +21,11 @@ table fact_dc_inventory_txn
 		summarizeBy: sum
 		sourceColumn: quantity
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column dc_id
+	column 'DC ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 7dde12d4-b2ad-4285-8593-6084695d1c99
@@ -29,9 +33,11 @@ table fact_dc_inventory_txn
 		summarizeBy: sum
 		sourceColumn: dc_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column balance
+	column Balance
 		dataType: int64
 		formatString: 0
 		lineageTag: 69936964-1b5e-4f95-aa6c-5327f4e8443e
@@ -39,15 +45,19 @@ table fact_dc_inventory_txn
 		summarizeBy: sum
 		sourceColumn: balance
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column product_id
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: a7168582-c6e8-4b62-89e2-de93b91dc4c9
 		sourceLineageTag: product_id
 		summarizeBy: sum
 		sourceColumn: product_id
+
+		changedProperty = Name
 
 		annotation SummarizationSetBy = Automatic
 
@@ -60,7 +70,7 @@ table fact_dc_inventory_txn
 
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_dc_inventory_txn = entity
+	partition 'DC Inventory Transactions' = entity
 		mode: directLake
 		source
 			entityName: fact_dc_inventory_txn

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_foot_traffic.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_foot_traffic.tmdl
@@ -1,8 +1,10 @@
-table fact_foot_traffic
+table 'Foot Traffic'
 	lineageTag: c999b61a-43db-4db3-9783-626a4618f864
 	sourceLineageTag: [ag].[fact_foot_traffic]
 
-	column count
+	changedProperty = Name
+
+	column Count
 		dataType: int64
 		formatString: 0
 		lineageTag: 13698da9-5865-4083-92e8-31aa304ddb63
@@ -10,18 +12,22 @@ table fact_foot_traffic
 		summarizeBy: sum
 		sourceColumn: count
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column zone
+	column Zone
 		dataType: string
 		lineageTag: 557ac75c-0e4d-4954-981c-67823bfdd6e0
 		sourceLineageTag: zone
 		summarizeBy: none
 		sourceColumn: zone
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column dwell_seconds
+	column 'Dwell Seconds'
 		dataType: int64
 		formatString: 0
 		lineageTag: f6e707b1-08c4-41fa-ab1a-233ec061d176
@@ -29,9 +35,11 @@ table fact_foot_traffic
 		summarizeBy: sum
 		sourceColumn: dwell_seconds
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 569af1b5-d33d-496c-b590-76158423c9ce
@@ -39,18 +47,22 @@ table fact_foot_traffic
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column sensor_id
+	column 'Sensor ID'
 		dataType: string
 		lineageTag: 347e7b41-cd79-4e79-8f79-45413192743c
 		sourceLineageTag: sensor_id
 		summarizeBy: none
 		sourceColumn: sensor_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_foot_traffic = entity
+	partition 'Foot Traffic' = entity
 		mode: directLake
 		source
 			entityName: fact_foot_traffic

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_marketing.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_marketing.tmdl
@@ -1,19 +1,23 @@
-table fact_marketing
+table Marketing
 	lineageTag: 0de63cc1-c6da-4354-8a04-602a3c737aa8
 	sourceLineageTag: [ag].[fact_marketing]
 
-	column CustomerId
+	changedProperty = Name
+
+	column 'Customer ID'
 		dataType: double
 		lineageTag: af26fadf-1aa7-4813-b8f2-4b18a7d05aa7
 		sourceLineageTag: CustomerId
 		summarizeBy: count
 		sourceColumn: CustomerId
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column CostCents
+	column 'Cost Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: e29f4b2f-b696-4df5-be7d-227c34ea126b
@@ -21,72 +25,88 @@ table fact_marketing
 		summarizeBy: sum
 		sourceColumn: CostCents
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column device
+	column Device
 		dataType: string
 		lineageTag: b261ffc1-b0e5-4a33-ac71-797d936d6047
 		sourceLineageTag: device
 		summarizeBy: none
 		sourceColumn: device
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column cost
+	column Cost
 		dataType: string
 		lineageTag: 23c50c8e-33b2-47bd-aff8-9a84cad24506
 		sourceLineageTag: cost
 		summarizeBy: none
 		sourceColumn: cost
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column customer_ad_id
+	column 'Customer Ad ID'
 		dataType: string
 		lineageTag: a75aaf0c-3276-4cb6-b82b-5dd328e875de
 		sourceLineageTag: customer_ad_id
 		summarizeBy: none
 		sourceColumn: customer_ad_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column impression_id_ext
+	column 'Impression ID'
 		dataType: string
 		lineageTag: 89d38797-4885-4065-9195-4b0a2120f58e
 		sourceLineageTag: impression_id_ext
 		summarizeBy: none
 		sourceColumn: impression_id_ext
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column campaign_id
+	column 'Campaign ID'
 		dataType: string
 		lineageTag: aeee4a8b-9e31-4c4a-9a0f-e6d15a3d2459
 		sourceLineageTag: campaign_id
 		summarizeBy: none
 		sourceColumn: campaign_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column creative_id
+	column 'Creative ID'
 		dataType: string
 		lineageTag: b60cdc7a-5bde-4e67-a5be-f537896f9931
 		sourceLineageTag: creative_id
 		summarizeBy: none
 		sourceColumn: creative_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column channel
+	column Channel
 		dataType: string
 		lineageTag: 8778e66d-7a6f-4276-bd3b-7abbc83893da
 		sourceLineageTag: channel
 		summarizeBy: none
 		sourceColumn: channel
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_marketing = entity
+	partition Marketing = entity
 		mode: directLake
 		source
 			entityName: fact_marketing

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_online_order_headers.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_online_order_headers.tmdl
@@ -1,20 +1,20 @@
-table fact_online_order_headers
+table 'Online Orders'
 	lineageTag: 930ea7c8-e0a4-4f4a-a7df-1cf98fbeeefd
 	sourceLineageTag: [ag].[fact_online_order_headers]
 
-	measure 'Total Online Sales' = SUM(fact_online_order_headers[total_cents]) / 100
+	measure 'Total Online Sales' = SUM('Online Orders'[Total Cents]) / 100
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a3-0001-0001-0001-000000000001
 
-	measure 'Total Online Tax' = SUM(fact_online_order_headers[tax_cents]) / 100
+	measure 'Total Online Tax' = SUM('Online Orders'[Tax Cents]) / 100
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a3-0001-0001-0001-000000000002
 
-	measure 'Total Online Subtotal' = SUM(fact_online_order_headers[subtotal_cents]) / 100
+	measure 'Total Online Subtotal' = SUM('Online Orders'[Subtotal Cents]) / 100
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a3-0001-0001-0001-000000000003
 
-	measure 'Online Order Count' = COUNTROWS(fact_online_order_headers)
+	measure 'Online Order Count' = COUNTROWS('Online Orders')
 		formatString: #,0
 		lineageTag: 01a1a1a3-0001-0001-0001-000000000004
 
@@ -22,7 +22,7 @@ table fact_online_order_headers
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a3-0001-0001-0001-000000000005
 
-	column customer_id
+	column 'Customer ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: c6cd591e-21eb-4a48-82fe-be8ca75c1e34
@@ -32,7 +32,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	column subtotal_cents
+		changedProperty = Name
+
+	column 'Subtotal Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: 7c45861b-0559-41b0-8f45-d366dc2fc071
@@ -42,7 +44,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	column order_id_ext
+		changedProperty = Name
+
+	column 'Order ID'
 		dataType: string
 		lineageTag: 549cb01f-8401-439b-94a1-03ce546d388c
 		sourceLineageTag: order_id_ext
@@ -51,7 +55,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	column payment_method
+		changedProperty = Name
+
+	column 'Payment Method'
 		dataType: string
 		lineageTag: 2c6791b3-9bd0-4cb7-8e8d-172fdbb2bde6
 		sourceLineageTag: payment_method
@@ -60,7 +66,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	column total_amount
+		changedProperty = Name
+
+	column 'Total Amount'
 		dataType: string
 		lineageTag: 41239a23-abc8-447a-ace2-d14d407e989c
 		sourceLineageTag: total_amount
@@ -69,7 +77,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	column total_cents
+		changedProperty = Name
+
+	column 'Total Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: 2123d982-0ece-4589-a4cb-d2154af602cd
@@ -79,7 +89,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	column tax_amount
+		changedProperty = Name
+
+	column 'Tax Amount'
 		dataType: string
 		lineageTag: 3d73f23c-7703-4673-a845-52220518b0e5
 		sourceLineageTag: tax_amount
@@ -88,7 +100,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	column subtotal_amount
+		changedProperty = Name
+
+	column 'Subtotal Amount'
 		dataType: string
 		lineageTag: 18653173-4d8b-4cf3-b061-7399ace2daa0
 		sourceLineageTag: subtotal_amount
@@ -97,7 +111,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	column tax_cents
+		changedProperty = Name
+
+	column 'Tax Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: d5a18cad-980f-4839-8303-5bfde6a48bc8
@@ -107,7 +123,9 @@ table fact_online_order_headers
 
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_online_order_headers = entity
+		changedProperty = Name
+
+	partition 'Online Orders' = entity
 		mode: directLake
 		source
 			entityName: fact_online_order_headers

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_online_order_lines.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_online_order_lines.tmdl
@@ -1,12 +1,12 @@
-table fact_online_order_lines
+table 'Online Order Lines'
 	lineageTag: ead55580-9419-45ac-91ff-f5ac29096866
 	sourceLineageTag: [ag].[fact_online_order_lines]
 
-	measure 'Total Online Units' = SUM(fact_online_order_lines[quantity])
+	measure 'Total Online Units' = SUM('Online Order Lines'[Quantity])
 		formatString: #,0
 		lineageTag: 01a1a1a4-0001-0001-0001-000000000001
 
-	measure 'Online Line Revenue' = SUM(fact_online_order_lines[ext_cents]) / 100
+	measure 'Online Line Revenue' = SUM('Online Order Lines'[Extended Cents]) / 100
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a4-0001-0001-0001-000000000002
 
@@ -14,7 +14,7 @@ table fact_online_order_lines
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a4-0001-0001-0001-000000000003
 
-	column order_id
+	column 'Order ID'
 		dataType: string
 		lineageTag: 8ed9dac6-9c06-4081-9067-1862bb870d3c
 		sourceLineageTag: order_id
@@ -23,7 +23,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column unit_cents
+		changedProperty = Name
+
+	column 'Unit Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: b71747a4-7708-49b7-ac7a-e81e89e23573
@@ -33,7 +35,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column fulfillment_mode
+		changedProperty = Name
+
+	column 'Fulfillment Mode'
 		dataType: string
 		lineageTag: bf44a73e-258e-48d2-92a9-9df7f0037725
 		sourceLineageTag: fulfillment_mode
@@ -42,7 +46,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column promo_code
+		changedProperty = Name
+
+	column 'Promo Code'
 		dataType: string
 		lineageTag: 0710082e-09b1-4ed6-9298-a29be7298c5d
 		sourceLineageTag: promo_code
@@ -51,7 +57,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column node_type
+		changedProperty = Name
+
+	column 'Node Type'
 		dataType: string
 		lineageTag: d0806b14-a539-49aa-ad23-8ae789dd08b6
 		sourceLineageTag: node_type
@@ -60,7 +68,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column product_id
+		changedProperty = Name
+
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 7a040420-92ea-4167-a7e8-35029e01d4dd
@@ -70,7 +80,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column ext_price
+		changedProperty = Name
+
+	column 'Extended Price'
 		dataType: string
 		lineageTag: 2083d296-c3fa-4e6c-bcb1-a974818b7265
 		sourceLineageTag: ext_price
@@ -79,7 +91,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column ext_cents
+		changedProperty = Name
+
+	column 'Extended Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: 5004ecb4-e6e2-4ec7-b12a-30cb9cc7a7a3
@@ -89,7 +103,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column line_num
+		changedProperty = Name
+
+	column 'Line Number'
 		dataType: int64
 		formatString: 0
 		lineageTag: 6d4df010-8f4e-4a12-aae4-d74075cb4dd8
@@ -99,7 +115,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column fulfillment_status
+		changedProperty = Name
+
+	column 'Fulfillment Status'
 		dataType: string
 		lineageTag: 520daddd-488d-4ea5-b0f3-0bf808a6d8b7
 		sourceLineageTag: fulfillment_status
@@ -108,7 +126,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column unit_price
+		changedProperty = Name
+
+	column 'Unit Price'
 		dataType: string
 		lineageTag: ba2c5305-e11e-45b5-bc3e-4bdaf6e4b350
 		sourceLineageTag: unit_price
@@ -117,7 +137,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column quantity
+		changedProperty = Name
+
+	column Quantity
 		dataType: int64
 		formatString: 0
 		lineageTag: 61bc9749-947f-4815-bc67-3f0a61c0b032
@@ -127,7 +149,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column node_id
+		changedProperty = Name
+
+	column 'Node ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 46f9dba7-f1fe-421f-b5d6-5753941c2834
@@ -137,7 +161,9 @@ table fact_online_order_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_online_order_lines = entity
+		changedProperty = Name
+
+	partition 'Online Order Lines' = entity
 		mode: directLake
 		source
 			entityName: fact_online_order_lines

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_payments.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_payments.tmdl
@@ -1,14 +1,14 @@
-table fact_payments
+table Payments
 	lineageTag: a9ee5779-cb04-439d-8691-5ae9eb849b4e
 	sourceLineageTag: [ag].[fact_payments]
 
-	measure 'Total Amounts' = SUM([amount])
+	measure 'Total Amounts' = SUM(Payments[Amount])
 		formatString: 0
 		lineageTag: 79b75b7a-6c45-4df5-a579-ead43dd9e267
 
 		changedProperty = Name
 
-	column receipt_id_ext
+	column 'Receipt ID'
 		dataType: string
 		lineageTag: efbefad1-5a1b-4c7b-925f-848b4de594d5
 		sourceLineageTag: receipt_id_ext
@@ -17,7 +17,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column order_id_ext
+		changedProperty = Name
+
+	column 'Order ID'
 		dataType: string
 		lineageTag: 52dc2ac3-3b91-401d-acea-49838020c2fe
 		sourceLineageTag: order_id_ext
@@ -26,7 +28,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column payment_method
+		changedProperty = Name
+
+	column 'Payment Method'
 		dataType: string
 		lineageTag: 325aa4a0-21a6-4c72-918d-7d9872000f8c
 		sourceLineageTag: payment_method
@@ -35,7 +39,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column amount_cents
+		changedProperty = Name
+
+	column 'Amount Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: 72a5cd30-df81-4cea-8a0c-857458089bba
@@ -45,7 +51,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column amount
+		changedProperty = Name
+
+	column Amount
 		dataType: string
 		lineageTag: f0c241fa-f5f0-4ab3-b743-15761fcd487b
 		sourceLineageTag: amount
@@ -54,7 +62,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column transaction_id
+		changedProperty = Name
+
+	column 'Transaction ID'
 		dataType: string
 		lineageTag: 59a3a364-edd0-4bed-870d-3dafc0dfdd1a
 		sourceLineageTag: transaction_id
@@ -63,7 +73,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column processing_time_ms
+		changedProperty = Name
+
+	column 'Processing Time MS'
 		dataType: int64
 		formatString: 0
 		lineageTag: 1e22bae8-128a-41d4-bca5-d5f14abcdc70
@@ -73,7 +85,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column status
+		changedProperty = Name
+
+	column Status
 		dataType: string
 		lineageTag: 3544e80a-5367-46e2-a81d-55965f62ec8b
 		sourceLineageTag: status
@@ -82,7 +96,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column decline_reason
+		changedProperty = Name
+
+	column 'Decline Reason'
 		dataType: string
 		lineageTag: 52669962-9147-40a0-a3e5-1a1df7faac53
 		sourceLineageTag: decline_reason
@@ -91,7 +107,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column store_id
+		changedProperty = Name
+
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: d21b659a-0979-44b0-ad34-53109ed5050d
@@ -101,7 +119,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	column customer_id
+		changedProperty = Name
+
+	column 'Customer ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: ae5fe31f-a97a-4799-93fb-98b992cf414d
@@ -111,7 +131,9 @@ table fact_payments
 
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_payments = entity
+		changedProperty = Name
+
+	partition Payments = entity
 		mode: directLake
 		source
 			entityName: fact_payments

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_promo_lines.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_promo_lines.tmdl
@@ -1,26 +1,32 @@
-table fact_promo_lines
+table 'Promotion Lines'
 	lineageTag: 6f0a86e5-8a4e-44c1-a568-13af0862f5ef
 	sourceLineageTag: [ag].[fact_promo_lines]
 
-	column ReceiptId
+	changedProperty = Name
+
+	column 'Receipt ID'
 		dataType: string
 		lineageTag: c6de1bfc-e7ba-4aef-834f-01871476eeb4
 		sourceLineageTag: ReceiptId
 		summarizeBy: none
 		sourceColumn: ReceiptId
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column PromoCode
+	column 'Promo Code'
 		dataType: string
 		lineageTag: f9fe94ee-173b-47de-bf0c-a4c66636e228
 		sourceLineageTag: PromoCode
 		summarizeBy: none
 		sourceColumn: PromoCode
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column LineNumber
+	column 'Line Number'
 		dataType: int64
 		formatString: 0
 		lineageTag: b5260d33-03fb-4167-ab57-3ad94caf561b
@@ -28,9 +34,11 @@ table fact_promo_lines
 		summarizeBy: sum
 		sourceColumn: LineNumber
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column ProductID
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 191a3e31-47de-41fa-8c7e-cdfbf9505ccf
@@ -38,9 +46,11 @@ table fact_promo_lines
 		summarizeBy: count
 		sourceColumn: ProductID
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column Qty
+	column Quantity
 		dataType: int64
 		formatString: 0
 		lineageTag: 281f75bf-5ba8-46a7-a33e-0cfa5adf8fbc
@@ -48,18 +58,22 @@ table fact_promo_lines
 		summarizeBy: sum
 		sourceColumn: Qty
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column DiscountAmount
+	column 'Discount Amount'
 		dataType: string
 		lineageTag: e2dd10cf-48f9-4972-bb14-dfa8cbdf89ac
 		sourceLineageTag: DiscountAmount
 		summarizeBy: none
 		sourceColumn: DiscountAmount
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column DiscountCents
+	column 'Discount Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: f3d66be0-70a2-4008-b5bb-7a5151b15e50
@@ -67,9 +81,11 @@ table fact_promo_lines
 		summarizeBy: sum
 		sourceColumn: DiscountCents
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_promo_lines = entity
+	partition 'Promotion Lines' = entity
 		mode: directLake
 		source
 			entityName: fact_promo_lines

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_promotions.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_promotions.tmdl
@@ -1,35 +1,43 @@
-table fact_promotions
+table Promotions
 	lineageTag: 09104865-1d77-427a-bc33-b0148839d9a5
 	sourceLineageTag: [ag].[fact_promotions]
 
-	column ReceiptId
+	changedProperty = Name
+
+	column 'Receipt ID'
 		dataType: string
 		lineageTag: 699c67ab-2aec-4718-9aa8-7205385c40ab
 		sourceLineageTag: ReceiptId
 		summarizeBy: none
 		sourceColumn: ReceiptId
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column PromoCode
+	column 'Promo Code'
 		dataType: string
 		lineageTag: b0238d92-2da9-40e5-8013-e322014a887a
 		sourceLineageTag: PromoCode
 		summarizeBy: none
 		sourceColumn: PromoCode
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column DiscountAmount
+	column 'Discount Amount'
 		dataType: string
 		lineageTag: 19c7f4b0-852c-471c-95af-c20eaa73d0c5
 		sourceLineageTag: DiscountAmount
 		summarizeBy: none
 		sourceColumn: DiscountAmount
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column DiscountCents
+	column 'Discount Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: 296dc317-642c-4a09-ba33-56b9c99d8c6d
@@ -37,18 +45,22 @@ table fact_promotions
 		summarizeBy: sum
 		sourceColumn: DiscountCents
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column DiscountType
+	column 'Discount Type'
 		dataType: string
 		lineageTag: 65790e25-52e4-4ea4-b186-e91c8b20359d
 		sourceLineageTag: DiscountType
 		summarizeBy: none
 		sourceColumn: DiscountType
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column ProductCount
+	column 'Product Count'
 		dataType: int64
 		formatString: 0
 		lineageTag: d9770793-f93b-410e-92bb-dbf5e4bd7b5f
@@ -56,18 +68,22 @@ table fact_promotions
 		summarizeBy: sum
 		sourceColumn: ProductCount
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column ProductIds
+	column 'Product IDs'
 		dataType: string
 		lineageTag: 76d783a3-362d-4a96-b40f-22ef3efec531
 		sourceLineageTag: ProductIds
 		summarizeBy: none
 		sourceColumn: ProductIds
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column StoreID
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 10e6f985-8df5-44d2-bfbf-95407d67e963
@@ -75,9 +91,11 @@ table fact_promotions
 		summarizeBy: count
 		sourceColumn: StoreID
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column CustomerID
+	column 'Customer ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 2fc2d368-9347-4b26-83b0-f9542c60d2df
@@ -85,9 +103,11 @@ table fact_promotions
 		summarizeBy: count
 		sourceColumn: CustomerID
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_promotions = entity
+	partition Promotions = entity
 		mode: directLake
 		source
 			entityName: fact_promotions

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_receipt_lines.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_receipt_lines.tmdl
@@ -1,12 +1,12 @@
-table fact_receipt_lines
+table 'Receipt Lines'
 	lineageTag: aab05dc7-35b4-4318-affd-bc107c21f8f7
 	sourceLineageTag: [ag].[fact_receipt_lines]
 
-	measure 'Total Units Sold' = SUM(fact_receipt_lines[quantity])
+	measure 'Total Units Sold' = SUM('Receipt Lines'[Quantity])
 		formatString: #,0
 		lineageTag: 01a1a1a2-0001-0001-0001-000000000001
 
-	measure 'Line Revenue' = SUM(fact_receipt_lines[ext_cents]) / 100
+	measure 'Line Revenue' = SUM('Receipt Lines'[Extended Cents]) / 100
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a2-0001-0001-0001-000000000002
 
@@ -14,11 +14,11 @@ table fact_receipt_lines
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a2-0001-0001-0001-000000000003
 
-	measure 'Total Lines' = COUNTROWS(fact_receipt_lines)
+	measure 'Total Lines' = COUNTROWS('Receipt Lines')
 		formatString: #,0
 		lineageTag: 01a1a1a2-0001-0001-0001-000000000004
 
-	column receipt_id_ext
+	column 'Receipt ID'
 		dataType: string
 		lineageTag: 9a782ca7-2110-4e68-994a-5c56e36c0200
 		sourceLineageTag: receipt_id_ext
@@ -27,7 +27,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column product_id
+		changedProperty = Name
+
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 160f5195-0ef4-431a-9e58-e0dda60336f2
@@ -37,7 +39,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column line_num
+		changedProperty = Name
+
+	column 'Line Number'
 		dataType: int64
 		formatString: 0
 		lineageTag: bd65b0d0-4508-4f61-8a08-7bc9e337892e
@@ -47,7 +51,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column quantity
+		changedProperty = Name
+
+	column Quantity
 		dataType: int64
 		formatString: 0
 		lineageTag: de505fd4-366c-410b-9a65-544528a62890
@@ -57,7 +63,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column unit_price
+		changedProperty = Name
+
+	column 'Unit Price'
 		dataType: string
 		lineageTag: 9de741c8-fe8c-43bb-b1d1-3547e0e467e4
 		sourceLineageTag: unit_price
@@ -66,7 +74,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column ext_price
+		changedProperty = Name
+
+	column 'Extended Price'
 		dataType: string
 		lineageTag: a743303d-5bbe-46f7-844b-72b2a53cbd8f
 		sourceLineageTag: ext_price
@@ -75,7 +85,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column unit_cents
+		changedProperty = Name
+
+	column 'Unit Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: 5af8a932-d0bb-4d47-9699-705ddf5bbde0
@@ -85,7 +97,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column ext_cents
+		changedProperty = Name
+
+	column 'Extended Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: 669ff8f4-2ed2-4299-9cf5-9730c3bb22e1
@@ -95,7 +109,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	column promo_code
+		changedProperty = Name
+
+	column 'Promo Code'
 		dataType: string
 		lineageTag: 5848e85f-4f07-40c5-9166-5364b4b7c822
 		sourceLineageTag: promo_code
@@ -104,7 +120,9 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_receipt_lines = entity
+		changedProperty = Name
+
+	partition 'Receipt Lines' = entity
 		mode: directLake
 		source
 			entityName: fact_receipt_lines

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_receipts.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_receipts.tmdl
@@ -1,20 +1,20 @@
-table fact_receipts
+table Receipts
 	lineageTag: dbb3a597-d860-42d1-9585-a7da0fc2a2a4
 	sourceLineageTag: [ag].[fact_receipts]
 
-	measure 'Total Sales' = SUM(fact_receipts[total_cents]) / 100
+	measure 'Total Sales' = SUM(Receipts[Total Cents]) / 100
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a1-0001-0001-0001-000000000001
 
-	measure 'Total Tax' = SUM(fact_receipts[tax_cents]) / 100
+	measure 'Total Tax' = SUM(Receipts[Tax Cents]) / 100
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a1-0001-0001-0001-000000000002
 
-	measure 'Total Subtotal' = SUM(fact_receipts[subtotal_cents]) / 100
+	measure 'Total Subtotal' = SUM(Receipts[Subtotal Cents]) / 100
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a1-0001-0001-0001-000000000003
 
-	measure 'Receipt Count' = COUNTROWS(fact_receipts)
+	measure 'Receipt Count' = COUNTROWS(Receipts)
 		formatString: #,0
 		lineageTag: 01a1a1a1-0001-0001-0001-000000000004
 
@@ -22,7 +22,7 @@ table fact_receipts
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a1-0001-0001-0001-000000000005
 
-	measure 'Total Returns' = CALCULATE([Total Sales], fact_receipts[receipt_type] = "RETURN")
+	measure 'Total Returns' = CALCULATE([Total Sales], Receipts[Receipt Type] = "RETURN")
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a1-0001-0001-0001-000000000006
 
@@ -30,7 +30,7 @@ table fact_receipts
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a1-0001-0001-0001-000000000007
 
-	column customer_id
+	column 'Customer ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 3c038d61-f1c4-4c76-b595-e823714c2eb0
@@ -40,7 +40,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column discount_amount
+		changedProperty = Name
+
+	column 'Discount Amount'
 		dataType: string
 		lineageTag: d8fdc9a6-23b4-4899-adb4-bfe4d04448eb
 		sourceLineageTag: discount_amount
@@ -49,7 +51,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column subtotal_cents
+		changedProperty = Name
+
+	column 'Subtotal Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: d10cc217-8d54-4f48-9786-c2788f401552
@@ -59,7 +63,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column receipt_type
+		changedProperty = Name
+
+	column 'Receipt Type'
 		dataType: string
 		lineageTag: f8a25262-9dde-476e-b2f1-94341f833092
 		sourceLineageTag: receipt_type
@@ -68,7 +74,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column payment_method
+		changedProperty = Name
+
+	column 'Payment Method'
 		dataType: string
 		lineageTag: feff8b81-9380-4f52-8965-e1c810debcc0
 		sourceLineageTag: payment_method
@@ -77,7 +85,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column receipt_id_ext
+		changedProperty = Name
+
+	column 'Receipt ID'
 		dataType: string
 		lineageTag: 63ca03aa-3389-4a3c-a601-c8fbf8359291
 		sourceLineageTag: receipt_id_ext
@@ -86,7 +96,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column total_amount
+		changedProperty = Name
+
+	column 'Total Amount'
 		dataType: string
 		lineageTag: 74c4603e-8ab4-487a-8d69-19de12151b9a
 		sourceLineageTag: total_amount
@@ -95,7 +107,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column total_cents
+		changedProperty = Name
+
+	column 'Total Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: 648ce335-e019-4757-b4bc-e88c0e005ef7
@@ -105,7 +119,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column tax_amount
+		changedProperty = Name
+
+	column 'Tax Amount'
 		dataType: string
 		lineageTag: c4521791-db0f-4658-bb3f-9ca3197a12b7
 		sourceLineageTag: tax_amount
@@ -114,7 +130,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column store_id
+		changedProperty = Name
+
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: aa658e70-f275-4c6d-91c8-63d908c09403
@@ -123,6 +141,8 @@ table fact_receipts
 		sourceColumn: store_id
 
 		annotation SummarizationSetBy = Automatic
+
+		changedProperty = Name
 
 	column Subtotal
 		dataType: string
@@ -133,7 +153,7 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column tax_cents
+	column 'Tax Cents'
 		dataType: int64
 		formatString: 0
 		lineageTag: c4715f0e-a9e5-4470-ac33-ec16b9f046c2
@@ -143,7 +163,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	column return_for_receipt_id_ext
+		changedProperty = Name
+
+	column 'Return For Receipt ID'
 		dataType: string
 		lineageTag: 5d3868eb-9b06-4ce0-801e-7476ff6bba04
 		sourceLineageTag: return_for_receipt_id_ext
@@ -152,7 +174,9 @@ table fact_receipts
 
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_receipts = entity
+		changedProperty = Name
+
+	partition Receipts = entity
 		mode: directLake
 		source
 			entityName: fact_receipts

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_reorders.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_reorders.tmdl
@@ -1,8 +1,8 @@
-table fact_reorders
+table Reorders
 	lineageTag: 5d56e188-c68e-4de1-a166-dba2aab94430
 	sourceLineageTag: [ag].[fact_reorders]
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 9ba003b4-5818-4fdf-a7cb-e746a618a80f
@@ -10,9 +10,11 @@ table fact_reorders
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column dc_id
+	column 'DC ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: e8cc3010-af1a-40d5-b05e-2ae21f44ae39
@@ -20,9 +22,11 @@ table fact_reorders
 		summarizeBy: sum
 		sourceColumn: dc_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column product_id
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: b38c131f-e4a2-4baa-b46c-144a36a860fa
@@ -30,9 +34,11 @@ table fact_reorders
 		summarizeBy: sum
 		sourceColumn: product_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column current_quantity
+	column 'Current Quantity'
 		dataType: int64
 		formatString: 0
 		lineageTag: 58404047-477c-40a4-bbc3-092f7accd81f
@@ -40,9 +46,11 @@ table fact_reorders
 		summarizeBy: sum
 		sourceColumn: current_quantity
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column reorder_quantity
+	column 'Reorder Quantity'
 		dataType: int64
 		formatString: 0
 		lineageTag: 439f2374-5ee5-4420-af92-32a2f9b26007
@@ -50,9 +58,11 @@ table fact_reorders
 		summarizeBy: sum
 		sourceColumn: reorder_quantity
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column reorder_point
+	column 'Reorder Point'
 		dataType: int64
 		formatString: 0
 		lineageTag: 61113c82-1df7-4479-a735-2380f417e406
@@ -60,18 +70,22 @@ table fact_reorders
 		summarizeBy: sum
 		sourceColumn: reorder_point
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column priority
+	column Priority
 		dataType: string
 		lineageTag: dfd389e7-46b4-4e7a-907f-1bfa0fb71f79
 		sourceLineageTag: priority
 		summarizeBy: none
 		sourceColumn: priority
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_reorders = entity
+	partition Reorders = entity
 		mode: directLake
 		source
 			entityName: fact_reorders

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_stockouts.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_stockouts.tmdl
@@ -1,30 +1,34 @@
-table fact_stockouts
+table Stockouts
 	lineageTag: 620b34c9-377c-44fe-bad4-8159499fc668
 	sourceLineageTag: [ag].[fact_stockouts]
 
-	column StoreID
+	column 'Store ID'
 		dataType: double
 		lineageTag: 60d4df49-5a17-4dd0-ba43-6c2c0cec2b4f
 		sourceLineageTag: StoreID
 		summarizeBy: count
 		sourceColumn: StoreID
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column DCID
+	column 'DC ID'
 		dataType: double
 		lineageTag: 1eaacd0f-91e7-4ac9-8c55-b080a302b99e
 		sourceLineageTag: DCID
 		summarizeBy: count
 		sourceColumn: DCID
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column ProductID
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 248dacbe-d44f-4a93-beca-0443b0245698
@@ -32,9 +36,11 @@ table fact_stockouts
 		summarizeBy: count
 		sourceColumn: ProductID
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column LastKnownQuantity
+	column 'Last Known Quantity'
 		dataType: int64
 		formatString: 0
 		lineageTag: 6ae92787-58f4-4902-b05f-83d24d6194b8
@@ -42,9 +48,11 @@ table fact_stockouts
 		summarizeBy: sum
 		sourceColumn: LastKnownQuantity
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_stockouts = entity
+	partition Stockouts = entity
 		mode: directLake
 		source
 			entityName: fact_stockouts

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_store_inventory_txn.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_store_inventory_txn.tmdl
@@ -1,25 +1,27 @@
-table fact_store_inventory_txn
+table 'Store Inventory Transactions'
 	lineageTag: 069e006d-82a8-46ab-abf7-39d781c37887
 	sourceLineageTag: [ag].[fact_store_inventory_txn]
 
-	measure 'Total Inventory Transactions' = COUNTROWS(fact_store_inventory_txn)
+	measure 'Total Inventory Transactions' = COUNTROWS('Store Inventory Transactions')
 		formatString: #,0
 		lineageTag: 01a1a1a6-0001-0001-0001-000000000001
 
-	measure 'Total Quantity Delta' = SUM(fact_store_inventory_txn[quantity])
+	measure 'Total Quantity Delta' = SUM('Store Inventory Transactions'[Quantity])
 		formatString: #,0
 		lineageTag: 01a1a1a6-0001-0001-0001-000000000002
 
-	column txn_type
+	column 'Transaction Type'
 		dataType: string
 		lineageTag: fcdbfd4d-1ec4-422f-b7bd-a6a83e8b03c9
 		sourceLineageTag: txn_type
 		summarizeBy: none
 		sourceColumn: txn_type
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column quantity
+	column Quantity
 		dataType: int64
 		formatString: 0
 		lineageTag: b4460922-757f-4b4e-8fbc-5c30dd6b3740
@@ -27,9 +29,11 @@ table fact_store_inventory_txn
 		summarizeBy: sum
 		sourceColumn: quantity
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column balance
+	column Balance
 		dataType: int64
 		formatString: 0
 		lineageTag: 34eee0a6-d403-445d-83a6-163c9c0da520
@@ -37,9 +41,11 @@ table fact_store_inventory_txn
 		summarizeBy: sum
 		sourceColumn: balance
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column product_id
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 85ecab4a-5ef0-4c6a-bcbd-2db04af2a261
@@ -47,9 +53,11 @@ table fact_store_inventory_txn
 		summarizeBy: sum
 		sourceColumn: product_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: f9411773-fe61-4cc9-bd55-1a200d71cdf8
@@ -57,18 +65,22 @@ table fact_store_inventory_txn
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column source
+	column Source
 		dataType: string
 		lineageTag: 4f1e13af-0613-492f-9b82-4b2c53340348
 		sourceLineageTag: source
 		summarizeBy: none
 		sourceColumn: source
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_store_inventory_txn = entity
+	partition 'Store Inventory Transactions' = entity
 		mode: directLake
 		source
 			entityName: fact_store_inventory_txn

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_store_ops.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_store_ops.tmdl
@@ -1,17 +1,21 @@
-table fact_store_ops
+table 'Store Operations'
 	lineageTag: 30e435c0-c71d-474c-b807-e2f634dbf383
 	sourceLineageTag: [ag].[fact_store_ops]
 
-	column trace_id
+	changedProperty = Name
+
+	column 'Trace ID'
 		dataType: string
 		lineageTag: 7c2cb6d2-a5ec-4d85-9e47-e23513bb14e2
 		sourceLineageTag: trace_id
 		summarizeBy: none
 		sourceColumn: trace_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 7e3719b4-06ee-4594-87db-11bf9f3ce04c
@@ -19,18 +23,22 @@ table fact_store_ops
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column operation_type
+	column 'Operation Type'
 		dataType: string
 		lineageTag: 2e9a1a12-9c75-4a39-b918-4a8048b725ef
 		sourceLineageTag: operation_type
 		summarizeBy: none
 		sourceColumn: operation_type
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_store_ops = entity
+	partition 'Store Operations' = entity
 		mode: directLake
 		source
 			entityName: fact_store_ops

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_truck_inventory.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_truck_inventory.tmdl
@@ -1,8 +1,8 @@
-table fact_truck_inventory
+table 'Truck Inventory'
 	lineageTag: d65dd252-405a-484b-9e2e-efc842442898
 	sourceLineageTag: [ag].[fact_truck_inventory]
 
-	column truck_id
+	column 'Truck ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: abe4d6b6-e6c5-457a-8b6d-7dd3c383dcfb
@@ -10,18 +10,22 @@ table fact_truck_inventory
 		summarizeBy: sum
 		sourceColumn: truck_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column shipment_id
+	column 'Shipment ID'
 		dataType: string
 		lineageTag: b309d174-b1a9-4822-a038-d2c67cc51022
 		sourceLineageTag: shipment_id
 		summarizeBy: none
 		sourceColumn: shipment_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column product_id
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 648fcce8-4a56-44b5-91b4-ffba8a16f659
@@ -29,9 +33,11 @@ table fact_truck_inventory
 		summarizeBy: sum
 		sourceColumn: product_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column quantity
+	column Quantity
 		dataType: int64
 		formatString: 0
 		lineageTag: 83b7b762-6d37-4aa1-ba97-e65cdfa61954
@@ -39,18 +45,22 @@ table fact_truck_inventory
 		summarizeBy: sum
 		sourceColumn: quantity
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column action
+	column Action
 		dataType: string
 		lineageTag: 38bede37-408e-4ef4-866c-68e663962402
 		sourceLineageTag: action
 		summarizeBy: none
 		sourceColumn: action
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column location_id
+	column 'Location ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 360d161e-5905-4982-bef4-21af95d6251f
@@ -58,18 +68,22 @@ table fact_truck_inventory
 		summarizeBy: sum
 		sourceColumn: location_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column location_type
+	column 'Location Type'
 		dataType: string
 		lineageTag: 7d6a6b97-2506-4985-b06d-47e16c6e8d5f
 		sourceLineageTag: location_type
 		summarizeBy: none
 		sourceColumn: location_type
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column __index_level_0__
+	column Index
 		dataType: int64
 		formatString: 0
 		lineageTag: f6d2291c-607f-4414-9647-1d840b908c0e
@@ -77,9 +91,11 @@ table fact_truck_inventory
 		summarizeBy: sum
 		sourceColumn: __index_level_0__
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_truck_inventory = entity
+	partition 'Truck Inventory' = entity
 		mode: directLake
 		source
 			entityName: fact_truck_inventory

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_truck_moves.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/fact_truck_moves.tmdl
@@ -1,26 +1,32 @@
-table fact_truck_moves
+table 'Truck Moves'
 	lineageTag: 486b3beb-5e42-4766-b0d7-1147520e5a37
 	sourceLineageTag: [ag].[fact_truck_moves]
 
-	column status
+	changedProperty = Name
+
+	column Status
 		dataType: string
 		lineageTag: 05d465cc-c274-4016-80ec-bd258e36f80c
 		sourceLineageTag: status
 		summarizeBy: none
 		sourceColumn: status
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column shipment_id
+	column 'Shipment ID'
 		dataType: string
 		lineageTag: 18d1a5ed-9272-4f3e-a6fb-3a01cbd4a295
 		sourceLineageTag: shipment_id
 		summarizeBy: none
 		sourceColumn: shipment_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column dc_id
+	column 'DC ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 8cc6a6be-bcbb-4e57-a42e-383babd8c30c
@@ -28,9 +34,11 @@ table fact_truck_moves
 		summarizeBy: sum
 		sourceColumn: dc_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column truck_id
+	column 'Truck ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: f91cf596-0f96-4834-b402-c55cbabbad71
@@ -38,9 +46,11 @@ table fact_truck_moves
 		summarizeBy: sum
 		sourceColumn: truck_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 54d28e85-f677-4d6c-a288-e1e48f68932e
@@ -48,9 +58,11 @@ table fact_truck_moves
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition fact_truck_moves = entity
+	partition 'Truck Moves' = entity
 		mode: directLake
 		source
 			entityName: fact_truck_moves

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/inventory_position_current.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/inventory_position_current.tmdl
@@ -1,20 +1,20 @@
-table inventory_position_current
+table 'Store Inventory Position'
 	lineageTag: 80253872-c9ec-4d0d-b638-c3c5163306c3
 	sourceLineageTag: [au].[inventory_position_current]
 
-	measure 'Total Units on Hand' = SUM(inventory_position_current[on_hand])
+	measure 'Total Units on Hand' = SUM('Store Inventory Position'[On Hand])
 		formatString: #,0
 		lineageTag: 01a1a1a5-0001-0001-0001-000000000001
 
-	measure 'Total Inventory Value' = SUMX(inventory_position_current, inventory_position_current[on_hand] * RELATED(dim_products[Cost]))
+	measure 'Total Inventory Value' = SUMX('Store Inventory Position', 'Store Inventory Position'[On Hand] * RELATED(Products[Cost]))
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a5-0001-0001-0001-000000000002
 
-	measure 'Total Inventory Retail Value' = SUMX(inventory_position_current, inventory_position_current[on_hand] * RELATED(dim_products[SalePrice]))
+	measure 'Total Inventory Retail Value' = SUMX('Store Inventory Position', 'Store Inventory Position'[On Hand] * RELATED(Products[Sale Price]))
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1a5-0001-0001-0001-000000000003
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 657f2501-30bd-49f7-b3b0-979a5491791c
@@ -22,9 +22,11 @@ table inventory_position_current
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column product_id
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: cbc2790a-4977-4e9b-af30-d485dcdee191
@@ -32,9 +34,11 @@ table inventory_position_current
 		summarizeBy: sum
 		sourceColumn: product_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column on_hand
+	column 'On Hand'
 		dataType: int64
 		formatString: 0
 		lineageTag: 4ac72f8c-f640-45cd-9cac-8d4f713b4b58
@@ -42,9 +46,11 @@ table inventory_position_current
 		summarizeBy: sum
 		sourceColumn: on_hand
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition inventory_position_current = entity
+	partition 'Store Inventory Position' = entity
 		mode: directLake
 		source
 			entityName: inventory_position_current

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/marketing_cost_daily.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/marketing_cost_daily.tmdl
@@ -1,17 +1,19 @@
-table marketing_cost_daily
+table 'Marketing Cost Daily'
 	lineageTag: 4bb353d5-fa0d-4c32-911a-584a960f5482
 	sourceLineageTag: [au].[marketing_cost_daily]
 
-	column campaign_id
+	column 'Campaign ID'
 		dataType: string
 		lineageTag: b157fd89-f13a-41ea-91db-9be92915c7db
 		sourceLineageTag: campaign_id
 		summarizeBy: none
 		sourceColumn: campaign_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column day
+	column Day
 		dataType: dateTime
 		formatString: General Date
 		lineageTag: 601e19ab-304b-46d4-a357-76f8461372b8
@@ -19,9 +21,11 @@ table marketing_cost_daily
 		summarizeBy: none
 		sourceColumn: day
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column impressions
+	column Impressions
 		dataType: int64
 		formatString: 0
 		lineageTag: f567b3cc-29dc-4181-a70e-8d1bd45e464a
@@ -29,20 +33,24 @@ table marketing_cost_daily
 		summarizeBy: sum
 		sourceColumn: impressions
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column cost
+	column Cost
 		dataType: double
 		lineageTag: 69e20067-0b0a-4503-b10c-80e75ca38f85
 		sourceLineageTag: cost
 		summarizeBy: sum
 		sourceColumn: cost
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	partition marketing_cost_daily = entity
+	partition 'Marketing Cost Daily' = entity
 		mode: directLake
 		source
 			entityName: marketing_cost_daily

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/online_sales_daily.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/online_sales_daily.tmdl
@@ -1,8 +1,8 @@
-table online_sales_daily
+table 'Online Sales Daily'
 	lineageTag: a2c1b744-09a3-4341-9934-282e0cd86ef7
 	sourceLineageTag: [au].[online_sales_daily]
 
-	column day
+	column Day
 		dataType: dateTime
 		formatString: General Date
 		lineageTag: cee9ed17-cbb5-4d0c-adcc-3409673e03cf
@@ -10,9 +10,11 @@ table online_sales_daily
 		summarizeBy: none
 		sourceColumn: day
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column orders
+	column Orders
 		dataType: int64
 		formatString: 0
 		lineageTag: f4bcbe79-377f-4716-b883-62aa5f638594
@@ -20,53 +22,63 @@ table online_sales_daily
 		summarizeBy: sum
 		sourceColumn: orders
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column subtotal
+	column Subtotal
 		dataType: double
 		lineageTag: daa6013d-b5a8-43f0-be98-281031ed3583
 		sourceLineageTag: subtotal
 		summarizeBy: sum
 		sourceColumn: subtotal
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column tax
+	column Tax
 		dataType: double
 		lineageTag: 9b698455-789b-499d-bbd1-62106620fb61
 		sourceLineageTag: tax
 		summarizeBy: sum
 		sourceColumn: tax
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column total
+	column Total
 		dataType: double
 		lineageTag: 3a046b1a-adfc-42b8-8da4-631614088a5f
 		sourceLineageTag: total
 		summarizeBy: sum
 		sourceColumn: total
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column avg_order_value
+	column 'Average Order Value'
 		dataType: double
 		lineageTag: 793db82f-f43e-4840-88d5-e9395c64a96a
 		sourceLineageTag: avg_order_value
 		summarizeBy: sum
 		sourceColumn: avg_order_value
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	partition online_sales_daily = entity
+	partition 'Online Sales Daily' = entity
 		mode: directLake
 		source
 			entityName: online_sales_daily

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/sales_minute_store.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/sales_minute_store.tmdl
@@ -1,8 +1,8 @@
-table sales_minute_store
+table 'Store Sales by Minute'
 	lineageTag: a8fa2a6d-f69b-426f-a314-e3a5843c3295
 	sourceLineageTag: [au].[sales_minute_store]
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 4523c24b-1eb5-4e76-a360-a309c8aa50aa
@@ -10,9 +10,11 @@ table sales_minute_store
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column ts
+	column Timestamp
 		dataType: dateTime
 		formatString: General Date
 		lineageTag: 83ce5f6d-852a-4ad3-83f4-b6f08f2c433b
@@ -20,20 +22,24 @@ table sales_minute_store
 		summarizeBy: none
 		sourceColumn: ts
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column total_sales
+	column 'Total Sales'
 		dataType: double
 		lineageTag: 5fec6969-b148-481e-8c84-71314f701c96
 		sourceLineageTag: total_sales
 		summarizeBy: sum
 		sourceColumn: total_sales
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column receipts
+	column Receipts
 		dataType: int64
 		formatString: 0
 		lineageTag: caf48a4f-d47e-41eb-ae5e-bf4d6bbd9376
@@ -41,20 +47,24 @@ table sales_minute_store
 		summarizeBy: sum
 		sourceColumn: receipts
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column avg_basket
+	column 'Average Basket'
 		dataType: double
 		lineageTag: c508e7f5-582e-463b-980f-2f0f662cc9b0
 		sourceLineageTag: avg_basket
 		summarizeBy: sum
 		sourceColumn: avg_basket
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	partition sales_minute_store = entity
+	partition 'Store Sales by Minute' = entity
 		mode: directLake
 		source
 			entityName: sales_minute_store

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/tender_mix_daily.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/tender_mix_daily.tmdl
@@ -1,8 +1,8 @@
-table tender_mix_daily
+table 'Tender Mix Daily'
 	lineageTag: 52b36092-c97d-40fd-82fa-5031db035dc5
 	sourceLineageTag: [au].[tender_mix_daily]
 
-	column day
+	column Day
 		dataType: dateTime
 		formatString: General Date
 		lineageTag: 4387d025-d6ea-4ec9-a05d-b596eee6282c
@@ -10,18 +10,22 @@ table tender_mix_daily
 		summarizeBy: none
 		sourceColumn: day
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column payment_method
+	column 'Payment Method'
 		dataType: string
 		lineageTag: 2043d77e-da13-4502-ab9c-d80e17bffaa4
 		sourceLineageTag: payment_method
 		summarizeBy: none
 		sourceColumn: payment_method
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column transactions
+	column Transactions
 		dataType: int64
 		formatString: 0
 		lineageTag: d271d3a5-e547-4ce2-85fc-570fd5b748e6
@@ -29,20 +33,24 @@ table tender_mix_daily
 		summarizeBy: sum
 		sourceColumn: transactions
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column total_amount
+	column 'Total Amount'
 		dataType: double
 		lineageTag: 6facbff4-fe61-4f8a-a4be-3dcdfb1d3e5e
 		sourceLineageTag: total_amount
 		summarizeBy: sum
 		sourceColumn: total_amount
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	partition tender_mix_daily = entity
+	partition 'Tender Mix Daily' = entity
 		mode: directLake
 		source
 			entityName: tender_mix_daily

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/top_products_15m.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/top_products_15m.tmdl
@@ -1,8 +1,8 @@
-table top_products_15m
+table 'Top Products 15 Min'
 	lineageTag: eda9ac0d-bc37-4363-96b4-298c279801bc
 	sourceLineageTag: [au].[top_products_15m]
 
-	column product_id
+	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: f71dd371-de91-495f-ad76-db7f3c6fde8b
@@ -10,20 +10,24 @@ table top_products_15m
 		summarizeBy: sum
 		sourceColumn: product_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column revenue
+	column Revenue
 		dataType: double
 		lineageTag: 95625462-5b71-47fe-8186-915a9a4f1d6a
 		sourceLineageTag: revenue
 		summarizeBy: sum
 		sourceColumn: revenue
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column units
+	column Units
 		dataType: int64
 		formatString: 0
 		lineageTag: 11114f49-2e94-4a9e-9066-1d07443626fc
@@ -31,9 +35,11 @@ table top_products_15m
 		summarizeBy: sum
 		sourceColumn: units
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition top_products_15m = entity
+	partition 'Top Products 15 Min' = entity
 		mode: directLake
 		source
 			entityName: top_products_15m

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/truck_dwell_daily.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/truck_dwell_daily.tmdl
@@ -1,17 +1,19 @@
-table truck_dwell_daily
+table 'Truck Dwell Daily'
 	lineageTag: 27b86d53-bcc1-4b0c-a6b6-bef459bc35ed
 	sourceLineageTag: [au].[truck_dwell_daily]
 
-	column site
+	column Site
 		dataType: string
 		lineageTag: ad2e4e82-92c0-41a1-8e1a-15bbeb1093cb
 		sourceLineageTag: site
 		summarizeBy: none
 		sourceColumn: site
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column day
+	column Day
 		dataType: dateTime
 		formatString: General Date
 		lineageTag: 4bd080fb-437b-41f8-83ce-beb768501d61
@@ -19,20 +21,24 @@ table truck_dwell_daily
 		summarizeBy: none
 		sourceColumn: day
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column avg_dwell_min
+	column 'Average Dwell Minutes'
 		dataType: double
 		lineageTag: d8e13419-3a71-47f4-baea-c166a92a46db
 		sourceLineageTag: avg_dwell_min
 		summarizeBy: sum
 		sourceColumn: avg_dwell_min
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column trucks
+	column Trucks
 		dataType: int64
 		formatString: 0
 		lineageTag: 7908b1e2-0c3c-4dc5-9250-eb7bf836fde4
@@ -40,9 +46,11 @@ table truck_dwell_daily
 		summarizeBy: sum
 		sourceColumn: trucks
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition truck_dwell_daily = entity
+	partition 'Truck Dwell Daily' = entity
 		mode: directLake
 		source
 			entityName: truck_dwell_daily

--- a/fabric/semantic_model/retail_model.SemanticModel/definition/tables/zone_dwell_minute.tmdl
+++ b/fabric/semantic_model/retail_model.SemanticModel/definition/tables/zone_dwell_minute.tmdl
@@ -1,8 +1,8 @@
-table zone_dwell_minute
+table 'Zone Dwell by Minute'
 	lineageTag: 0bf09335-5a4f-471c-9b09-32b6f8261fa6
 	sourceLineageTag: [au].[zone_dwell_minute]
 
-	column store_id
+	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: cbd46151-4680-4fd3-9a7c-0e95183412ff
@@ -10,18 +10,22 @@ table zone_dwell_minute
 		summarizeBy: sum
 		sourceColumn: store_id
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column zone
+	column Zone
 		dataType: string
 		lineageTag: 120f9883-3652-4a83-846c-b4d438b1a3ba
 		sourceLineageTag: zone
 		summarizeBy: none
 		sourceColumn: zone
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column ts
+	column Timestamp
 		dataType: dateTime
 		formatString: General Date
 		lineageTag: c26e9f9a-56af-4116-96f6-089843545694
@@ -29,20 +33,24 @@ table zone_dwell_minute
 		summarizeBy: none
 		sourceColumn: ts
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	column avg_dwell
+	column 'Average Dwell'
 		dataType: double
 		lineageTag: 3e664904-d5dc-47c4-9316-6313e996935b
 		sourceLineageTag: avg_dwell
 		summarizeBy: sum
 		sourceColumn: avg_dwell
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
-	column customers
+	column Customers
 		dataType: int64
 		formatString: 0
 		lineageTag: 88c3825c-bbdd-4e69-8b8e-9c36eca2a746
@@ -50,9 +58,11 @@ table zone_dwell_minute
 		summarizeBy: sum
 		sourceColumn: customers
 
+		changedProperty = Name
+
 		annotation SummarizationSetBy = Automatic
 
-	partition zone_dwell_minute = entity
+	partition 'Zone Dwell by Minute' = entity
 		mode: directLake
 		source
 			entityName: zone_dwell_minute


### PR DESCRIPTION
- Rename dimension tables: dim_stores -> Stores, dim_customers -> Customers, dim_products -> Products, etc.
- Rename fact tables: fact_receipts -> Receipts, fact_receipt_lines ->
  Receipt Lines, etc.
- Rename aggregate tables: inventory_position_current -> Store Inventory Position, sales_minute_store -> Store Sales by Minute, etc.
- Convert snake_case columns to Title Case with spaces (e.g., customer_id -> Customer ID)
- Add sourceColumn property to maintain link to original data source columns
- Add changedProperty = Name to prevent sync from overwriting renames
- Update all DAX measures to reference new table/column names
- Update relationships.tmdl with new table and column references