### PR TITLE
fix(claude): update hooks to new matcher format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,18 +50,22 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": {
-          "tool": "Edit",
-          "file_pattern": "**/*.py"
-        },
-        "command": "ruff check --fix $FILE 2>&1 | grep -v 'All checks passed' | head -10 || true"
+        "matcher": "Edit(**/*.py)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ruff check --fix $FILE 2>&1 | grep -v 'All checks passed' | head -10 || true"
+          }
+        ]
       },
       {
-        "matcher": {
-          "tool": "Write",
-          "file_pattern": "**/*.py"
-        },
-        "command": "ruff check --fix $FILE 2>&1 | grep -v 'All checks passed' | head -10 || true"
+        "matcher": "Write(**/*.py)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ruff check --fix $FILE 2>&1 | grep -v 'All checks passed' | head -10 || true"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Fixed PostToolUse hooks to use the new Claude Code hooks format
- Matcher changed from object `{tool, file_pattern}` to string pattern `"Edit(**/*.py)"`
- Commands now wrapped in `hooks` array with `type` and `command` fields

## Test plan
- [x] Verify settings.json passes Claude Code validation on startup
- [ ] Confirm ruff auto-fix hook triggers on Python file edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)