### PR TITLE
fix(test): use is_string_dtype for pandas string type check

### DIFF
--- a/datagen/tests/unit/test_format_writers.py
+++ b/datagen/tests/unit/test_format_writers.py
@@ -167,7 +167,8 @@ class TestParquetWriterWrite:
         df_read = pd.read_parquet(output_path)
         assert df_read["IntCol"].dtype == "int64"
         assert df_read["FloatCol"].dtype == "float64"
-        assert df_read["StrCol"].dtype == "object"
+        # String columns may be 'object' or pandas StringDtype depending on version/engine
+        assert pd.api.types.is_string_dtype(df_read["StrCol"])
         assert pd.api.types.is_datetime64_any_dtype(df_read["DateCol"])
 
     def test_write_io_error(self, tmp_path):


### PR DESCRIPTION
## Summary
- Fix test that was failing across all PRs due to pandas StringDtype compatibility

## Problem
The `test_write_preserves_dtypes` test was checking for `'object'` dtype but newer pandas versions with pyarrow engine return `StringDtype` instead. This was causing all 20 open PRs to fail the test check.

## Solution
Use the more robust `pd.api.types.is_string_dtype()` check which works with both `object` and `StringDtype`.

## Test plan
- [x] Test passes locally on Python 3.12
- [x] Should fix CI failures across all open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)