### PR TITLE
feat(scripts): add semantic model lakehouse update script

### DIFF
--- a/docs/setup/08-semantic-model-deployment.md
+++ b/docs/setup/08-semantic-model-deployment.md
@@ -22,9 +22,56 @@ With the TMDL-based Power BI Project format (.pbip), deployment is straightforwa
 
 Power BI Desktop will load the semantic model and report together.
 
-### Step 2: Configure Lakehouse Connection (First Time Only)
+### Step 2: Update Lakehouse References (First Time Only)
 
-If this is your first time opening the project, you may need to configure the data source:
+The semantic model contains hardcoded workspace and lakehouse GUIDs that must be updated to match your Fabric environment.
+
+#### Option A: Automated Update (Recommended)
+
+Use the provided Python script to update all references automatically:
+
+```bash
+# Preview changes first with dry run
+python scripts/update_semantic_model.py \
+    --workspace-id "YOUR-WORKSPACE-GUID" \
+    --lakehouse-id "YOUR-LAKEHOUSE-GUID" \
+    --lakehouse-name "retail_lakehouse" \
+    --dry-run
+
+# Apply changes
+python scripts/update_semantic_model.py \
+    --workspace-id "YOUR-WORKSPACE-GUID" \
+    --lakehouse-id "YOUR-LAKEHOUSE-GUID" \
+    --lakehouse-name "retail_lakehouse"
+```
+
+To find your workspace and lakehouse GUIDs:
+1. Navigate to your Fabric workspace in the browser
+2. The workspace GUID is in the URL: `https://app.fabric.microsoft.com/groups/{workspace-guid}/...`
+3. Open your lakehouse and copy the GUID from the URL: `.../lakehouses/{lakehouse-guid}`
+
+The script updates:
+- `fabric/semantic_model/retail_model.SemanticModel/definition/expressions.tmdl` (OneLake URL)
+- All 35 table files in `definition/tables/*.tmdl` (expression source references)
+
+#### Option B: Manual Update
+
+If you prefer to update manually:
+
+1. Open `fabric/semantic_model/retail_model.SemanticModel/definition/expressions.tmdl`
+2. Replace the workspace and lakehouse GUIDs in the OneLake URL:
+   ```tmdl
+   expression 'DirectLake - retail_lakehouse' =
+       let
+           Source = AzureStorage.DataLake("https://onelake.dfs.fabric.microsoft.com/YOUR-WORKSPACE-GUID/YOUR-LAKEHOUSE-GUID", [HierarchicalNavigation=true])
+       in
+           Source
+   ```
+3. Save the file
+
+### Step 3: Configure Lakehouse Connection
+
+After updating the references, configure the data source in Power BI Desktop:
 
 1. Power BI will prompt: "Unable to connect to data source"
 2. Click **Edit** or go to **Transform data** → **Data source settings**
@@ -37,14 +84,14 @@ If this is your first time opening the project, you may need to configure the da
 
 The model uses **DirectLake mode**, which connects directly to your Lakehouse Gold tables without importing data.
 
-### Step 3: Refresh the Data (Optional)
+### Step 4: Refresh the Data (Optional)
 
 To ensure you're seeing the latest data:
 
 1. Click **Refresh** in the Home ribbon
 2. Wait for refresh to complete (typically 10-30 seconds for DirectLake)
 
-### Step 4: Publish to Fabric Workspace
+### Step 5: Publish to Fabric Workspace
 
 1. Click **Publish** in the Home ribbon
 2. Select your target Fabric workspace from the list
@@ -52,7 +99,7 @@ To ensure you're seeing the latest data:
 4. Wait for the upload to complete
 5. When prompted, click **Open in Fabric** to view in the browser
 
-### Step 5: Verify Deployment
+### Step 6: Verify Deployment
 
 After publishing:
 

--- a/scripts/test_update_semantic_model.py
+++ b/scripts/test_update_semantic_model.py
@@ -1,0 +1,243 @@
+"""Tests for update_semantic_model.py script."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from update_semantic_model import (
+    extract_current_config,
+    update_expressions_file,
+    update_table_files,
+    validate_guid,
+)
+
+
+def test_validate_guid_valid():
+    """Test that valid GUIDs pass validation."""
+    valid_guid = "abc12345-1234-5678-90ab-cdef12345678"
+    assert validate_guid(valid_guid, "test") is True
+
+
+def test_validate_guid_invalid():
+    """Test that invalid GUIDs raise ValueError."""
+    invalid_guids = [
+        "not-a-guid",
+        "abc12345-1234-5678-90ab-cdef1234567",  # Too short
+        "abc12345-1234-5678-90ab-cdef12345678x",  # Too long
+        "abc12345_1234_5678_90ab_cdef12345678",  # Wrong separator
+        "ghijklmn-1234-5678-90ab-cdef12345678",  # Invalid hex chars
+    ]
+
+    for invalid_guid in invalid_guids:
+        with pytest.raises(ValueError, match="must be a valid GUID"):
+            validate_guid(invalid_guid, "test")
+
+
+def test_extract_current_config():
+    """Test extracting workspace ID, lakehouse ID, and expression name."""
+    expressions_content = """expression 'DirectLake - retail_lakehouse' =
+\t\tlet
+\t\t    Source = AzureStorage.DataLake("https://onelake.dfs.fabric.microsoft.com/5219ac70-71d4-4dfc-af32-5b8a6c29a471/fc9ed7b6-6723-4116-8bf1-278135865270", [HierarchicalNavigation=true])
+\t\tin
+\t\t    Source
+\tlineageTag: e65b847f-b56a-4c3c-83fa-a7183dd5d7eb
+"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tmdl", delete=False) as f:
+        f.write(expressions_content)
+        temp_path = Path(f.name)
+
+    try:
+        workspace_id, lakehouse_id, expression_name = extract_current_config(temp_path)
+
+        assert workspace_id == "5219ac70-71d4-4dfc-af32-5b8a6c29a471"
+        assert lakehouse_id == "fc9ed7b6-6723-4116-8bf1-278135865270"
+        assert expression_name == "DirectLake - retail_lakehouse"
+    finally:
+        temp_path.unlink()
+
+
+def test_extract_current_config_file_not_found():
+    """Test that missing file raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        extract_current_config(Path("/nonexistent/file.tmdl"))
+
+
+def test_extract_current_config_invalid_format():
+    """Test that invalid file format raises ValueError."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tmdl", delete=False) as f:
+        f.write("invalid content")
+        temp_path = Path(f.name)
+
+    try:
+        with pytest.raises(ValueError, match="Could not find"):
+            extract_current_config(temp_path)
+    finally:
+        temp_path.unlink()
+
+
+def test_update_expressions_file():
+    """Test updating expressions.tmdl with new IDs and name."""
+    original_content = """expression 'DirectLake - retail_lakehouse' =
+\t\tlet
+\t\t    Source = AzureStorage.DataLake("https://onelake.dfs.fabric.microsoft.com/5219ac70-71d4-4dfc-af32-5b8a6c29a471/fc9ed7b6-6723-4116-8bf1-278135865270", [HierarchicalNavigation=true])
+\t\tin
+\t\t    Source
+\tlineageTag: e65b847f-b56a-4c3c-83fa-a7183dd5d7eb
+"""
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".tmdl", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(original_content)
+        temp_path = Path(f.name)
+
+    try:
+        new_workspace_id = "abc12345-1234-5678-90ab-cdef12345678"
+        new_lakehouse_id = "def67890-1234-5678-90ab-cdef67890123"
+        new_lakehouse_name = "my_lakehouse"
+
+        old_name, new_name = update_expressions_file(
+            temp_path,
+            new_workspace_id,
+            new_lakehouse_id,
+            new_lakehouse_name,
+            dry_run=False,
+        )
+
+        assert old_name == "DirectLake - retail_lakehouse"
+        assert new_name == "DirectLake - my_lakehouse"
+
+        # Verify file was updated
+        updated_content = temp_path.read_text(encoding="utf-8")
+        assert f"expression '{new_name}'" in updated_content
+        assert new_workspace_id in updated_content
+        assert new_lakehouse_id in updated_content
+        assert "5219ac70-71d4-4dfc-af32-5b8a6c29a471" not in updated_content
+        assert "fc9ed7b6-6723-4116-8bf1-278135865270" not in updated_content
+    finally:
+        temp_path.unlink()
+
+
+def test_update_expressions_file_dry_run():
+    """Test dry run mode doesn't modify the file."""
+    original_content = """expression 'DirectLake - retail_lakehouse' =
+\t\tlet
+\t\t    Source = AzureStorage.DataLake("https://onelake.dfs.fabric.microsoft.com/5219ac70-71d4-4dfc-af32-5b8a6c29a471/fc9ed7b6-6723-4116-8bf1-278135865270", [HierarchicalNavigation=true])
+\t\tin
+\t\t    Source
+"""
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".tmdl", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(original_content)
+        temp_path = Path(f.name)
+
+    try:
+        new_workspace_id = "abc12345-1234-5678-90ab-cdef12345678"
+        new_lakehouse_id = "def67890-1234-5678-90ab-cdef67890123"
+
+        update_expressions_file(
+            temp_path,
+            new_workspace_id,
+            new_lakehouse_id,
+            "my_lakehouse",
+            dry_run=True,
+        )
+
+        # Verify file was NOT changed
+        content = temp_path.read_text(encoding="utf-8")
+        assert content == original_content
+    finally:
+        temp_path.unlink()
+
+
+def test_update_table_files():
+    """Test updating expression source in table files."""
+    table_content = """table Products
+\tlineageTag: 7a341aa1-e4de-4e62-8737-d78ecfeea40b
+
+\tpartition Products = entity
+\t\tmode: directLake
+\t\tsource
+\t\t\tentityName: dim_products
+\t\t\tschemaName: ag
+\t\t\texpressionSource: 'DirectLake - retail_lakehouse'
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tables_dir = Path(tmpdir)
+
+        # Create multiple table files
+        (tables_dir / "Products.tmdl").write_text(table_content, encoding="utf-8")
+        (tables_dir / "Stores.tmdl").write_text(
+            table_content.replace("Products", "Stores").replace(
+                "dim_products", "dim_stores"
+            ),
+            encoding="utf-8",
+        )
+
+        # Update table files
+        updated_count = update_table_files(
+            tables_dir,
+            "DirectLake - retail_lakehouse",
+            "DirectLake - my_lakehouse",
+            dry_run=False,
+        )
+
+        assert updated_count == 2
+
+        # Verify updates
+        for table_file in tables_dir.glob("*.tmdl"):
+            content = table_file.read_text(encoding="utf-8")
+            assert "expressionSource: 'DirectLake - my_lakehouse'" in content
+            assert "expressionSource: 'DirectLake - retail_lakehouse'" not in content
+
+
+def test_update_table_files_no_change():
+    """Test that no files are updated when expression name is unchanged."""
+    table_content = """table Products
+\tpartition Products = entity
+\t\texpressionSource: 'DirectLake - retail_lakehouse'
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tables_dir = Path(tmpdir)
+        (tables_dir / "Products.tmdl").write_text(table_content, encoding="utf-8")
+
+        # Same old and new name
+        updated_count = update_table_files(
+            tables_dir,
+            "DirectLake - retail_lakehouse",
+            "DirectLake - retail_lakehouse",
+            dry_run=False,
+        )
+
+        assert updated_count == 0
+
+
+def test_update_table_files_dry_run():
+    """Test dry run mode for table files."""
+    table_content = """table Products
+\tpartition Products = entity
+\t\texpressionSource: 'DirectLake - retail_lakehouse'
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tables_dir = Path(tmpdir)
+        table_file = tables_dir / "Products.tmdl"
+        table_file.write_text(table_content, encoding="utf-8")
+
+        updated_count = update_table_files(
+            tables_dir,
+            "DirectLake - retail_lakehouse",
+            "DirectLake - my_lakehouse",
+            dry_run=True,
+        )
+
+        assert updated_count == 1
+
+        # Verify file was NOT changed
+        content = table_file.read_text(encoding="utf-8")
+        assert content == table_content

--- a/scripts/update_semantic_model.py
+++ b/scripts/update_semantic_model.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Update Power BI semantic model lakehouse references.
+
+This script updates the hardcoded lakehouse references in the Power BI semantic model
+TMDL files to match a user's target Fabric workspace and lakehouse.
+
+Usage:
+    python scripts/update_semantic_model.py \\
+        --workspace-id "abc12345-1234-5678-90ab-cdef12345678" \\
+        --lakehouse-id "def67890-1234-5678-90ab-cdef12345678" \\
+        --lakehouse-name "my_retail_lakehouse"
+
+    # Dry run to preview changes:
+    python scripts/update_semantic_model.py \\
+        --workspace-id "abc12345-..." \\
+        --lakehouse-id "def67890-..." \\
+        --dry-run
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def validate_guid(guid: str, field_name: str) -> bool:
+    """Validate that a string is a properly formatted GUID.
+
+    Args:
+        guid: The GUID string to validate
+        field_name: Name of the field for error messages
+
+    Returns:
+        True if valid
+
+    Raises:
+        ValueError: If the GUID format is invalid
+    """
+    guid_pattern = re.compile(
+        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    )
+    if not guid_pattern.match(guid):
+        raise ValueError(
+            f"{field_name} must be a valid GUID format: "
+            f"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        )
+    return True
+
+
+def extract_current_config(expressions_path: Path) -> tuple[str, str, str]:
+    """Extract current workspace ID, lakehouse ID, and expression name.
+
+    Args:
+        expressions_path: Path to the expressions.tmdl file
+
+    Returns:
+        Tuple of (workspace_id, lakehouse_id, expression_name)
+
+    Raises:
+        FileNotFoundError: If expressions.tmdl doesn't exist
+        ValueError: If the file format is unexpected
+    """
+    if not expressions_path.exists():
+        raise FileNotFoundError(f"Expressions file not found: {expressions_path}")
+
+    content = expressions_path.read_text(encoding="utf-8")
+
+    # Extract expression name
+    name_match = re.search(r"^expression '([^']+)'", content, re.MULTILINE)
+    if not name_match:
+        raise ValueError("Could not find expression name in expressions.tmdl")
+    expression_name = name_match.group(1)
+
+    # Extract workspace and lakehouse IDs from OneLake URL
+    url_pattern = (
+        r"https://onelake\.dfs\.fabric\.microsoft\.com/"
+        r"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/"
+        r"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+    )
+    url_match = re.search(url_pattern, content)
+    if not url_match:
+        raise ValueError("Could not find OneLake URL in expressions.tmdl")
+
+    workspace_id = url_match.group(1)
+    lakehouse_id = url_match.group(2)
+
+    return workspace_id, lakehouse_id, expression_name
+
+
+def update_expressions_file(
+    expressions_path: Path,
+    workspace_id: str,
+    lakehouse_id: str,
+    new_lakehouse_name: str,
+    dry_run: bool = False,
+) -> tuple[str, str]:
+    """Update the expressions.tmdl file with new IDs and name.
+
+    Args:
+        expressions_path: Path to the expressions.tmdl file
+        workspace_id: New workspace GUID
+        lakehouse_id: New lakehouse GUID
+        new_lakehouse_name: New lakehouse name for expression
+        dry_run: If True, only preview changes without writing
+
+    Returns:
+        Tuple of (old_expression_name, new_expression_name)
+    """
+    content = expressions_path.read_text(encoding="utf-8")
+
+    # Extract current expression name
+    name_match = re.search(r"^expression '([^']+)'", content, re.MULTILINE)
+    if not name_match:
+        raise ValueError("Could not find expression name in expressions.tmdl")
+    old_expression_name = name_match.group(1)
+
+    # Generate new expression name
+    new_expression_name = f"DirectLake - {new_lakehouse_name}"
+
+    # Update expression name
+    content = re.sub(
+        r"^expression '([^']+)'",
+        f"expression '{new_expression_name}'",
+        content,
+        flags=re.MULTILINE,
+    )
+
+    # Update OneLake URL with new workspace and lakehouse IDs
+    url_pattern = (
+        r"(https://onelake\.dfs\.fabric\.microsoft\.com/)"
+        r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/"
+        r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    )
+    new_url = f"https://onelake.dfs.fabric.microsoft.com/{workspace_id}/{lakehouse_id}"
+    content = re.sub(url_pattern, new_url, content)
+
+    if not dry_run:
+        expressions_path.write_text(content, encoding="utf-8")
+
+    return old_expression_name, new_expression_name
+
+
+def update_table_files(
+    tables_dir: Path,
+    old_expression_name: str,
+    new_expression_name: str,
+    dry_run: bool = False,
+) -> int:
+    """Update all table TMDL files with the new expression name.
+
+    Args:
+        tables_dir: Path to the tables directory
+        old_expression_name: Current expression name to replace
+        new_expression_name: New expression name
+        dry_run: If True, only preview changes without writing
+
+    Returns:
+        Number of files updated
+    """
+    if old_expression_name == new_expression_name:
+        print("Expression name unchanged, skipping table file updates")
+        return 0
+
+    table_files = list(tables_dir.glob("*.tmdl"))
+    if not table_files:
+        raise ValueError(f"No table files found in {tables_dir}")
+
+    updated_count = 0
+    for table_file in table_files:
+        content = table_file.read_text(encoding="utf-8")
+
+        # Check if this table uses the expression source
+        if f"expressionSource: '{old_expression_name}'" not in content:
+            continue
+
+        # Update the expression source reference
+        updated_content = content.replace(
+            f"expressionSource: '{old_expression_name}'",
+            f"expressionSource: '{new_expression_name}'",
+        )
+
+        if not dry_run:
+            table_file.write_text(updated_content, encoding="utf-8")
+
+        updated_count += 1
+
+    return updated_count
+
+
+def main() -> int:
+    """Main entry point for the script.
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    parser = argparse.ArgumentParser(
+        description="Update Power BI semantic model lakehouse references",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Update all references to a new lakehouse
+  python scripts/update_semantic_model.py \\
+      --workspace-id "abc12345-1234-5678-90ab-cdef12345678" \\
+      --lakehouse-id "def67890-1234-5678-90ab-cdef12345678" \\
+      --lakehouse-name "my_retail_lakehouse"
+
+  # Preview changes without modifying files
+  python scripts/update_semantic_model.py \\
+      --workspace-id "abc12345-1234-5678-90ab-cdef12345678" \\
+      --lakehouse-id "def67890-1234-5678-90ab-cdef12345678" \\
+      --dry-run
+        """,
+    )
+
+    parser.add_argument(
+        "--workspace-id",
+        required=True,
+        help="Fabric workspace GUID (e.g., abc12345-1234-5678-90ab-cdef12345678)",
+    )
+    parser.add_argument(
+        "--lakehouse-id",
+        required=True,
+        help="Lakehouse GUID (e.g., def67890-1234-5678-90ab-cdef12345678)",
+    )
+    parser.add_argument(
+        "--lakehouse-name",
+        default="retail_lakehouse",
+        help="Lakehouse display name for expression naming (default: retail_lakehouse)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without modifying files",
+    )
+    parser.add_argument(
+        "--semantic-model-path",
+        type=Path,
+        default=Path("fabric/semantic_model/retail_model.SemanticModel/definition"),
+        help="Path to semantic model definition directory",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        # Validate GUID formats
+        validate_guid(args.workspace_id, "Workspace ID")
+        validate_guid(args.lakehouse_id, "Lakehouse ID")
+
+        # Resolve paths
+        expressions_path = args.semantic_model_path / "expressions.tmdl"
+        tables_dir = args.semantic_model_path / "tables"
+
+        # Extract current configuration
+        print("Current configuration:")
+        old_workspace_id, old_lakehouse_id, old_expression_name = (
+            extract_current_config(expressions_path)
+        )
+        print(f"  Workspace ID: {old_workspace_id}")
+        print(f"  Lakehouse ID: {old_lakehouse_id}")
+        print(f"  Expression name: '{old_expression_name}'")
+        print()
+
+        # Display new configuration
+        new_expression_name = f"DirectLake - {args.lakehouse_name}"
+        print("New configuration:")
+        print(f"  Workspace ID: {args.workspace_id}")
+        print(f"  Lakehouse ID: {args.lakehouse_id}")
+        print(f"  Expression name: '{new_expression_name}'")
+        print()
+
+        if args.dry_run:
+            print("DRY RUN MODE - No files will be modified")
+            print()
+
+        # Update expressions.tmdl
+        print(f"Updating {expressions_path}...")
+        old_name, new_name = update_expressions_file(
+            expressions_path,
+            args.workspace_id,
+            args.lakehouse_id,
+            args.lakehouse_name,
+            dry_run=args.dry_run,
+        )
+
+        if not args.dry_run:
+            print("  Updated OneLake URL")
+            if old_name != new_name:
+                print(f"  Updated expression name: '{old_name}' -> '{new_name}'")
+        else:
+            print("  Would update OneLake URL")
+            if old_name != new_name:
+                print(f"  Would update expression name: '{old_name}' -> '{new_name}'")
+        print()
+
+        # Update table files
+        if old_name != new_name:
+            print(f"Updating table files in {tables_dir}...")
+            updated_count = update_table_files(
+                tables_dir, old_name, new_name, dry_run=args.dry_run
+            )
+            if not args.dry_run:
+                print(f"  Updated {updated_count} table files")
+            else:
+                print(f"  Would update {updated_count} table files")
+            print()
+
+        if args.dry_run:
+            print("DRY RUN COMPLETE - Run without --dry-run to apply changes")
+        else:
+            print("SUCCESS - All files updated")
+            print()
+            print("Next steps:")
+            print(
+                "  1. Open fabric/semantic_model/retail_model.pbip in Power BI Desktop"
+            )
+            print("  2. Refresh the data source to test the connection")
+            print("  3. Publish to your Fabric workspace")
+
+        return 0
+
+    except Exception as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds an automated Python script to update Power BI semantic model lakehouse references, eliminating the need for manual GUID updates when deploying to different Fabric workspaces.

## Changes

- Added `scripts/update_semantic_model.py`:
  - Accepts workspace ID, lakehouse ID, and lakehouse name as command-line arguments
  - Updates `expressions.tmdl` with correct OneLake URL
  - Updates expression name references in all 35 table TMDL files
  - Provides dry-run mode to preview changes before applying
  - Validates GUID format to prevent errors

- Added `scripts/test_update_semantic_model.py`:
  - 10 comprehensive test cases covering all script functionality
  - Tests GUID validation, file parsing, updates, and dry-run mode
  - All tests passing

- Updated `docs/setup/08-semantic-model-deployment.md`:
  - Added Step 2 for updating lakehouse references
  - Documented both automated (recommended) and manual update options
  - Instructions for finding workspace and lakehouse GUIDs
  - Renumbered subsequent steps

## Example Usage

```bash
# Preview changes with dry run
python scripts/update_semantic_model.py \
    --workspace-id "abc12345-1234-5678-90ab-cdef12345678" \
    --lakehouse-id "def67890-1234-5678-90ab-cdef67890123" \
    --lakehouse-name "retail_lakehouse" \
    --dry-run

# Apply updates
python scripts/update_semantic_model.py \
    --workspace-id "abc12345-1234-5678-90ab-cdef12345678" \
    --lakehouse-id "def67890-1234-5678-90ab-cdef67890123" \
    --lakehouse-name "retail_lakehouse"
```

## Test Plan

- [x] All 10 unit tests pass
- [x] Script runs successfully with dry-run mode
- [x] GUID validation works correctly
- [x] ruff check passes with no errors
- [x] ruff format applied
- [x] mypy type checking passes

## Files Modified

- `scripts/update_semantic_model.py` (new)
- `scripts/test_update_semantic_model.py` (new)
- `docs/setup/08-semantic-model-deployment.md` (updated)

Generated with [Claude Code](https://claude.com/claude-code)

Closes #253