### PR TITLE
feat(utility): setup utility — complete (engine, gold, notebooks, CLI, deploy integration)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
       - name: Install retail-setup
         working-directory: utility
         run: |

--- a/docs/superpowers/plans/2026-06-12-setup-utility-plan-2a-engine-core.md
+++ b/docs/superpowers/plans/2026-06-12-setup-utility-plan-2a-engine-core.md
@@ -1334,3 +1334,22 @@ git commit -m "ci: java for utility Spark tests"
 - Remaining 15 fact tables (incl. returns, online orders, inventory window-balances, journey pandas-UDF island), invariant-runner + `setup_run_log`
 - Gold aggregates, notebooks + build script, GitHub dictionary fetch, local E2E harness
 - `GenerationConfig` injectable dictionary root for the Fabric runtime (carried note from Plan 1 final review)
+
+## Carry-notes from the Plan 2a final review (MUST address in 2b/2c plans)
+
+- **`fact_payments` has two producers**: receipts (in-store) + Plan 2b online
+  orders. `write_to_lakehouse` is overwrite — 2b must UNION the payment
+  streams before a single write (same for any shared table).
+- **Returns**: `receipt_type` is hardcoded SALE; 2b returns must union into
+  `fact_receipts`, not regenerate it.
+- Factor the seed-folding draw helpers (`u`/`gauss`/`h64` closures in
+  receipts.py) into `runtime.py` as `seeded_draws(cfg)` before writing more
+  fact generators, to avoid drift. Consider `F.pmod` over `F.abs` for the
+  2^-64 Long.MIN_VALUE edge.
+- **Notebooks (2c) must set `spark.sql.session.timeZone=UTC`** — naive
+  timestamps (LaunchDate, event_ts) rely on it; locally the test fixture
+  sets it.
+- Dims customer build is row-tuple driver-side — switch to column-wise
+  numpy/pandas before real volumes (500k customers) in 2c.
+- `writer.write_table`'s unused `table` param — drop or use when 2c touches
+  the writer.

--- a/docs/superpowers/plans/2026-06-12-setup-utility-plan-2b-facts.md
+++ b/docs/superpowers/plans/2026-06-12-setup-utility-plan-2b-facts.md
@@ -1,0 +1,1273 @@
+# Setup Utility — Plan 2b: Remaining Facts, Returns, Invariants
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate the remaining 15 fact tables Spark-native (plus returns unioned into the receipts group), wire shared-table unions (`fact_payments`, `fact_receipts`/`_lines`), and add the invariant runner + `setup_run_log` so a single orchestrator call produces the full, validated `ag` fact layer.
+
+**Architecture:** Extends Plan 2a's engine (`retail_setup/generation/`). Same rules: schemas.py is the contract (TMDL test is the arbiter), all randomness from seeded xxhash64 draws (factored into `runtime.seeded_draws`), integer cents, every generator a pure function returning DataFrames. Derivation order matters: receipts → returns (union) → promotions/payments/foot-traffic/sensors (derive from receipts) → inventory chain (SALE txns derive from receipt lines; reorders → truck lifecycle → DC/store/truck inventory → balances → stockouts). One orchestrator (`engine.py`) sequences it; `invariants.py` validates before anything is written.
+
+**Tech Stack:** Same as Plan 2a (PySpark 3.5 local tests, conda env `retail-setup`).
+
+**Spec:** `docs/superpowers/specs/2026-06-12-setup-utility-design.md`
+**Ground truth:** extracted 2026-06-12 from `02-historical-data-load.ipynb`, `90-augment-and-dedupe-receipts.ipynb` (post-normalization snake_case names), TMDL tables/relationships, and datagen mixins (constants inlined per task with sources).
+**Carry-notes from Plan 2a final review:** payments union before write; returns union into receipts; factor seed helpers; `F.pmod` over `F.abs`; notebooks must pin session TZ=UTC (2c).
+
+**Scope notes (deliberate, document in code where relevant):**
+- Distribution-faithful, not loop-faithful (per spec): counts via clamped-normal Poisson approximation, balances via windows.
+- `__index_level_0__` legacy pandas-index columns: include in a table's schema ONLY if its TMDL binds it (the contract test decides); populate with `row_number() - 1` over a deterministic order.
+- `fact_stockouts` keeps its PascalCase columns (`StoreID`, `DCID`, `ProductID`, `LastKnownQuantity`) — that is what the TMDL binds.
+- Marketing campaign lifecycle is simplified to the 4 archetypes with their real channel/cost constants; campaign_id = `CAMP{yyyyMMdd}{archetype_idx:02d}`.
+- Backorders, disruptions, and DC↔DC moves are out (demo-irrelevant complexity); online lines still get CANCELLED at the 2% order-cancellation rate.
+
+---
+
+## Environment
+
+Same env as Plan 2a (`retail-setup` conda env, JDK 17, pyspark 3.5). Run tests from `utility/` with `/opt/homebrew/Caskroom/miniforge/base/envs/retail-setup/bin/python -m pytest ... -q`.
+
+---
+
+### Task 1: Factor seeded draws into runtime; receipts.py consumes them
+
+**Files:**
+- Modify: `utility/src/retail_setup/generation/runtime.py`
+- Modify: `utility/src/retail_setup/generation/receipts.py`
+- Test: `utility/tests/generation/test_runtime.py` (extend)
+
+- [ ] **Step 1: Failing tests** — append to `utility/tests/generation/test_runtime.py`:
+
+```python
+def test_seeded_draws_uniform_properties(spark):
+    from pyspark.sql import functions as F
+    from retail_setup.generation.runtime import seeded_draws
+
+    d = seeded_draws(seed=42)
+    df = spark.range(2000).withColumn("u", d.u(["id"], "test"))
+    row = df.agg(F.min("u"), F.max("u"), F.avg("u")).first()
+    assert 0.0 <= row[0] and row[1] < 1.0
+    assert 0.4 < row[2] < 0.6
+    # different salt -> different values; same salt -> identical
+    df2 = df.withColumn("u2", d.u(["id"], "other")).withColumn("u3", d.u(["id"], "test"))
+    assert df2.filter("u = u3").count() == 2000
+    assert df2.filter("u = u2").count() < 100
+
+
+def test_seeded_draws_seed_sensitivity(spark):
+    from retail_setup.generation.runtime import seeded_draws
+
+    a = seeded_draws(seed=1)
+    b = seeded_draws(seed=2)
+    df = spark.range(100)
+    da = [r[0] for r in df.select(a.u(["id"], "s")).collect()]
+    db = [r[0] for r in df.select(b.u(["id"], "s")).collect()]
+    assert da != db
+
+
+def test_pick_by_weights(spark):
+    from retail_setup.generation.runtime import seeded_draws
+
+    d = seeded_draws(seed=42)
+    df = spark.range(5000).withColumn(
+        "pick", d.pick_by_weights(["id"], "p", [("A", 0.7), ("B", 0.2), ("C", 0.1)])
+    )
+    counts = {r["pick"]: r["count"] for r in df.groupBy("pick").count().collect()}
+    assert 0.6 < counts["A"] / 5000 < 0.8
+    assert set(counts) == {"A", "B", "C"}
+```
+
+- [ ] **Step 2: Implement `seeded_draws` in runtime.py**
+
+Move the closure logic out of `receipts.py` (keep semantics; use `F.pmod` so the
+Long.MIN_VALUE edge is structurally impossible):
+
+```python
+class seeded_draws:
+    """Deterministic draw expressions bound to a seed.
+
+    u(cols, salt)        -> uniform [0,1) double
+    gauss(cols, salt)    -> ~N(0,1) (Irwin-Hall of 3 uniforms, scaled)
+    h64(cols, salt)      -> non-negative long hash
+    pick_by_weights(cols, salt, [(value, weight), ...]) -> weighted categorical
+    """
+
+    _U_MOD = 10**12
+
+    def __init__(self, seed: int):
+        self.seed = seed
+
+    def h64(self, cols: list, salt: str):
+        from pyspark.sql import functions as F
+
+        return F.pmod(F.xxhash64(*cols, F.lit(f"{salt}|{self.seed}")), F.lit(2**62))
+
+    def u(self, cols: list, salt: str):
+        from pyspark.sql import functions as F
+
+        return (self.h64(cols, salt) % F.lit(self._U_MOD)) / F.lit(float(self._U_MOD))
+
+    def gauss(self, cols: list, salt: str):
+        from pyspark.sql import functions as F
+
+        s = self.u(cols, f"{salt}|g1") + self.u(cols, f"{salt}|g2") + self.u(cols, f"{salt}|g3")
+        return (s - F.lit(1.5)) * F.lit(2.0)
+
+    def pick_by_weights(self, cols: list, salt: str, weighted: list[tuple[str, float]]):
+        from pyspark.sql import functions as F
+
+        total = sum(w for _, w in weighted)
+        uu = self.u(cols, salt)
+        expr, acc = None, 0.0
+        for value, w in weighted[:-1]:
+            acc += w / total
+            expr = expr.when(uu < acc, value) if expr is not None else F.when(uu < acc, value)
+        return expr.otherwise(weighted[-1][0]) if expr is not None else F.lit(weighted[0][0])
+```
+
+- [ ] **Step 3: Refactor receipts.py to use `seeded_draws(cfg.seed)`** — delete its
+local closures and `_pick_by_weights`/`_pick_hour` duplicates where the new class
+covers them (`_pick_hour` can stay but built on `d.u`). Behavior may shift draw
+values (pmod + salt delimiters) — that's fine; tests assert properties, not bytes.
+
+- [ ] **Step 4: Full suite green (70 + 3 new), commit**
+
+```bash
+git add utility/src/retail_setup/generation/runtime.py utility/src/retail_setup/generation/receipts.py utility/tests/generation/test_runtime.py
+git commit -m "refactor(utility): factor seeded draw helpers into runtime"
+```
+
+---
+
+### Task 2: Schema additions for the 15 tables
+
+**Files:**
+- Modify: `utility/src/retail_setup/generation/schemas.py`
+
+- [ ] **Step 1: Append to `TABLES`** (extracted ground truth; the TMDL contract
+test remains the arbiter — if it flags missing bound columns (e.g.
+`__index_level_0__`, lifecycle `*_ts`), ADD them; if a listed column type
+mismatches TMDL, fix to TMDL. Document every delta in the task report.)
+
+```python
+    "fact_store_ops": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("store_id", "long"),
+        ("operation_type", "string"), ("event_date", "date"),
+    ],
+    "fact_foot_traffic": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("store_id", "long"),
+        ("sensor_id", "string"), ("zone", "string"), ("dwell_seconds", "long"),
+        ("count", "long"), ("event_date", "date"),
+    ],
+    "fact_ble_pings": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("store_id", "long"),
+        ("beacon_id", "string"), ("customer_ble_id", "string"),
+        ("customer_id", "double"), ("rssi", "long"), ("zone", "string"),
+        ("event_date", "date"),
+    ],
+    "fact_customer_zone_changes": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("store_id", "long"),
+        ("customer_ble_id", "string"), ("from_zone", "string"), ("to_zone", "string"),
+        ("event_date", "date"),
+    ],
+    "fact_marketing": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("channel", "string"),
+        ("campaign_id", "string"), ("creative_id", "string"),
+        ("customer_ad_id", "string"), ("customer_id", "double"),
+        ("impression_id_ext", "string"), ("cost", "string"), ("cost_cents", "long"),
+        ("device", "string"), ("event_date", "date"),
+    ],
+    "fact_promotions": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("receipt_id_ext", "string"),
+        ("promo_code", "string"), ("discount_amount", "string"),
+        ("discount_cents", "long"), ("discount_type", "string"),
+        ("product_count", "long"), ("product_ids", "string"), ("store_id", "long"),
+        ("customer_id", "long"), ("event_date", "date"),
+    ],
+    "fact_promo_lines": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("receipt_id_ext", "string"),
+        ("promo_code", "string"), ("line_number", "long"), ("product_id", "long"),
+        ("quantity", "long"), ("discount_amount", "string"), ("discount_cents", "long"),
+        ("event_date", "date"),
+    ],
+    "fact_online_order_headers": [
+        ("order_id_ext", "string"), ("customer_id", "long"),
+        ("subtotal_cents", "long"), ("tax_cents", "long"), ("total_cents", "long"),
+        ("subtotal_amount", "string"), ("tax_amount", "string"),
+        ("total_amount", "string"), ("payment_method", "string"),
+        ("event_ts", "timestamp"), ("event_date", "date"),
+    ],
+    "fact_online_order_lines": [
+        ("order_id", "string"), ("product_id", "long"), ("line_num", "long"),
+        ("quantity", "long"), ("unit_price", "string"), ("unit_cents", "long"),
+        ("ext_price", "string"), ("ext_cents", "long"), ("promo_code", "string"),
+        ("fulfillment_mode", "string"), ("fulfillment_status", "string"),
+        ("node_type", "string"), ("node_id", "long"),
+        ("picked_ts", "timestamp"), ("shipped_ts", "timestamp"),
+        ("delivered_ts", "timestamp"), ("event_ts", "timestamp"), ("event_date", "date"),
+    ],
+    "fact_reorders": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("store_id", "long"),
+        ("dc_id", "long"), ("product_id", "long"), ("current_quantity", "long"),
+        ("reorder_quantity", "long"), ("reorder_point", "long"), ("priority", "string"),
+        ("event_date", "date"),
+    ],
+    "fact_truck_moves": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("truck_id", "long"),
+        ("dc_id", "long"), ("store_id", "long"), ("shipment_id", "string"),
+        ("status", "string"), ("eta", "timestamp"), ("etd", "timestamp"),
+        ("departure_time", "timestamp"), ("actual_unload_duration", "double"),
+        ("event_date", "date"),
+    ],
+    "fact_truck_inventory": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("truck_id", "long"),
+        ("shipment_id", "string"), ("product_id", "long"), ("quantity", "long"),
+        ("action", "string"), ("location_id", "long"), ("location_type", "string"),
+        ("event_date", "date"),
+    ],
+    "fact_dc_inventory_txn": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("dc_id", "long"),
+        ("product_id", "long"), ("quantity", "long"), ("balance", "long"),
+        ("txn_type", "string"), ("source", "string"), ("event_date", "date"),
+    ],
+    "fact_store_inventory_txn": [
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("store_id", "long"),
+        ("product_id", "long"), ("quantity", "long"), ("balance", "long"),
+        ("txn_type", "string"), ("source", "string"), ("event_date", "date"),
+    ],
+    "fact_stockouts": [
+        # PascalCase IS the contract: TMDL binds these names directly
+        ("event_ts", "timestamp"), ("trace_id", "string"), ("StoreID", "double"),
+        ("DCID", "double"), ("ProductID", "long"), ("LastKnownQuantity", "long"),
+        ("event_date", "date"),
+    ],
+```
+
+- [ ] **Step 2: Run the contract test; reconcile against TMDL until green**
+
+```bash
+/opt/homebrew/Caskroom/miniforge/base/envs/retail-setup/bin/python -m pytest tests/generation/test_schema_contract.py -q
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add utility/src/retail_setup/generation/schemas.py
+git commit -m "feat(utility): schema contract entries for remaining 15 fact tables"
+```
+
+---
+
+### Task 3: Returns (union into the receipts group)
+
+**Files:**
+- Create: `utility/src/retail_setup/generation/returns.py`
+- Modify: `utility/src/retail_setup/config/generation.py` (add `return_rate: float = 0.01`)
+- Test: `utility/tests/generation/test_returns.py`
+
+Semantics (datagen utils_mixin): sample ~`return_rate` of SALE receipts per day
+(Dec 26 → 6×, capped at 10% of the day's receipts); return header gets a new
+`receipt_id_ext` prefixed `RET` (same 25-char layout, `RET`+ts+store4+seq6),
+`receipt_type='RETURN'`, `event_ts` noon same day, `customer_id` NULL,
+`tender_type`/`payment_method` `CREDIT_CARD`, discount "0.00", negated cents
+(subtotal/tax/total all negative); lines mirror the original receipt's lines
+with negative quantity and negated ext/cents, `promo_code='RETURN'`; one
+payment per return (negative amount, APPROVED — refunds don't decline).
+
+- [ ] **Step 1: Failing tests** — `utility/tests/generation/test_returns.py`:
+
+```python
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.receipts import generate_receipts_group
+from retail_setup.generation.returns import generate_returns
+from retail_setup.generation.schemas import column_names
+
+
+@pytest.fixture(scope="module")
+def setup(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 12, 20),
+                           end_date=date(2025, 12, 28), store_count=3, dc_count=1,
+                           customer_count=300, seed=5, transactions_per_store_day=60,
+                           return_rate=0.05)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    dims = generate_dimensions(spark, dicts, cfg)
+    sales = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    rets = generate_returns(spark, sales, dims, cfg)
+    return cfg, sales, rets
+
+
+def test_contract_columns(setup):
+    _, _, rets = setup
+    for t in ["fact_receipts", "fact_receipt_lines", "fact_payments"]:
+        assert rets[t].columns == column_names(t)
+
+
+def test_return_semantics(setup):
+    _, sales, rets = setup
+    r = rets["fact_receipts"]
+    assert r.count() > 0
+    assert r.filter(F.col("receipt_type") != "RETURN").count() == 0
+    assert r.filter(~F.col("receipt_id_ext").startswith("RET")).count() == 0
+    assert r.filter(F.col("total_cents") >= 0).count() == 0  # strictly negative
+    assert r.filter(F.col("customer_id").isNotNull()).count() == 0
+    assert r.filter(F.col("tender_type") != "CREDIT_CARD").count() == 0
+    # return ids unique and disjoint from sales ids
+    n = r.count()
+    assert r.select("receipt_id_ext").distinct().count() == n
+    overlap = r.join(sales["fact_receipts"], "receipt_id_ext", "inner")
+    assert overlap.count() == 0
+
+
+def test_return_lines_negative_and_linked(setup):
+    _, _, rets = setup
+    lines = rets["fact_receipt_lines"]
+    assert lines.filter(F.col("quantity") >= 0).count() == 0
+    assert lines.filter(F.col("promo_code") != "RETURN").count() == 0
+    orphans = lines.join(rets["fact_receipts"], "receipt_id_ext", "left_anti")
+    assert orphans.count() == 0
+
+
+def test_return_rate_and_dec26_spike(setup):
+    cfg, sales, rets = setup
+    by_day_sales = {r["event_date"]: r["count"] for r in
+                    sales["fact_receipts"].groupBy("event_date").count().collect()}
+    by_day_rets = {r["event_date"]: r["count"] for r in
+                   rets["fact_receipts"].groupBy("event_date").count().collect()}
+    total_rate = sum(by_day_rets.values()) / sum(by_day_sales.values())
+    assert 0.02 < total_rate < 0.10  # 5% nominal incl. one 6x day, 10% cap
+    dec26 = date(2025, 12, 26)
+    other = [by_day_rets.get(d, 0) / by_day_sales[d] for d in by_day_sales if d != dec26]
+    assert by_day_rets.get(dec26, 0) / by_day_sales[dec26] > 2 * (sum(other) / len(other))
+
+
+def test_return_payment_negative_approved(setup):
+    _, _, rets = setup
+    pay = rets["fact_payments"]
+    assert pay.count() == rets["fact_receipts"].count()
+    assert pay.filter(F.col("amount_cents") >= 0).count() == 0
+    assert pay.filter(F.col("status") != "APPROVED").count() == 0
+```
+
+- [ ] **Step 2: Implement** `generate_returns(spark, sales_group, dims, cfg) -> dict`
+with the same three keys as the receipts group. Sketch: take
+`sales["fact_receipts"]` + `sales["fact_receipt_lines"]`; per receipt draw
+`u(["receipt_id_ext"], "return") < day_rate` where
+`day_rate = least(0.10, return_rate * when(month=12 & day=26, 6.0).otherwise(1.0))`;
+build the return header from the sampled original (negate cents, noon
+`event_ts` = `to_timestamp(concat(event_date,' 12:00:00'))`, new id
+`concat('RET', date_format(event_ts,'yyyyMMddHHmm'), lpad(store_id,4,'0'), lpad(row_number() over (partition by store_id, event_date order by receipt_id_ext), 6, '0'))`,
+`trace_id = concat('TRC', new_id)`); join lines on the original id, negate
+quantity/ext_cents, re-derive formatted strings; payments mirror the receipts
+pattern with status literal APPROVED and the original's payment_method replaced
+by CREDIT_CARD. End every frame with `.select(*column_names(...))`.
+
+- [ ] **Step 3: Tests green; full suite green; commit**
+
+```bash
+git add utility/src/retail_setup/generation/returns.py utility/src/retail_setup/config/generation.py utility/tests/generation/test_returns.py
+git commit -m "feat(utility): returns generation unioned into the receipts contract"
+```
+
+---
+
+### Task 4: Store ops + foot traffic (derive from receipts)
+
+**Files:**
+- Create: `utility/src/retail_setup/generation/store_activity.py`
+- Test: `utility/tests/generation/test_store_activity.py`
+
+Rules (datagen sensors/store_ops mixins):
+- `fact_store_ops`: exactly 2 rows per store-day (`operation_type` in
+  {"opened","closed"}), open/close hours parsed from `dim_stores.operating_hours`
+  ("6-22" style and "24h" — map 24h → 0/24); skip Dec 25 entirely;
+  `trace_id = concat('TRC-OPS-', store_id, '-', event_date, '-', operation_type)`.
+- `fact_foot_traffic`: per store-hour with receipts, `total = greatest(receipts+1, round(receipts / conv))`
+  where conv = 0.20 × 1.3 (hours 12,13,17,18,19) × 0.9 (weekend); split across
+  the 5 sensor zones `ENTRANCE_MAIN, ENTRANCE_SIDE, AISLES_A, AISLES_B, CHECKOUT`
+  with the store_format share table (hypermarket [.20,.10,.35,.25,.10],
+  superstore [.25,.10,.30,.25,.10], standard [.30,.15,.25,.15,.15],
+  neighborhood [.35,.15,.20,.10,.20]); `dwell_seconds` uniform per zone in
+  ([45,90],[30,75],[180,420],[120,300],[90,240]); `sensor_id = format('SENSOR_%03d_%s', store_id, zone)`;
+  one row per store-hour-zone; `event_ts` = the hour boundary.
+
+- [ ] **Step 1: Failing tests** — `utility/tests/generation/test_store_activity.py`:
+
+```python
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.receipts import generate_receipts_group
+from retail_setup.generation.store_activity import generate_foot_traffic, generate_store_ops
+from retail_setup.generation.schemas import column_names
+
+ZONES = ["ENTRANCE_MAIN", "ENTRANCE_SIDE", "AISLES_A", "AISLES_B", "CHECKOUT"]
+
+
+@pytest.fixture(scope="module")
+def setup(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 12, 23),
+                           end_date=date(2025, 12, 27), store_count=2, dc_count=1,
+                           customer_count=200, seed=9, transactions_per_store_day=40)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    dims = generate_dimensions(spark, dicts, cfg)
+    sales = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    return cfg, dims, sales
+
+
+def test_store_ops(spark, setup):
+    cfg, dims, _ = setup
+    ops = generate_store_ops(spark, dims, cfg)
+    assert ops.columns == column_names("fact_store_ops")
+    # 5 days minus Christmas = 4 op-days x 2 stores x 2 events
+    assert ops.count() == 4 * 2 * 2
+    assert ops.filter(F.col("event_date") == date(2025, 12, 25)).count() == 0
+    per = ops.groupBy("store_id", "event_date").count().collect()
+    assert all(r["count"] == 2 for r in per)
+    assert {r.operation_type for r in ops.select("operation_type").distinct().collect()} == \
+        {"opened", "closed"}
+
+
+def test_foot_traffic(spark, setup):
+    cfg, dims, sales = setup
+    ft = generate_foot_traffic(spark, sales["fact_receipts"], dims, cfg)
+    assert ft.columns == column_names("fact_foot_traffic")
+    assert {r.zone for r in ft.select("zone").distinct().collect()} <= set(ZONES)
+    assert ft.filter(F.col("count") < 0).count() == 0
+    assert ft.filter((F.col("dwell_seconds") < 30) | (F.col("dwell_seconds") > 420)).count() == 0
+    # traffic exceeds receipts for matching store-hours
+    rc = sales["fact_receipts"].groupBy(
+        "store_id", F.date_trunc("hour", "event_ts").alias("hr")).count()
+    tt = ft.groupBy("store_id", F.col("event_ts").alias("hr")) \
+           .agg(F.sum("count").alias("traffic"))
+    j = rc.join(tt, ["store_id", "hr"])
+    assert j.count() > 0
+    assert j.filter(F.col("traffic") < F.col("count")).count() == 0
+```
+
+- [ ] **Step 2: Implement** `generate_store_ops(spark, dims, cfg)` (store×day grid
+minus Dec 25, parse operating_hours with a small `F.when` chain over the four
+known formats, two rows via explode of a 2-element array) and
+`generate_foot_traffic(spark, receipts, dims, cfg)` (groupBy store/hour from
+`fact_receipts`, conv-rate arithmetic, explode the 5-zone share array as
+`(zone, share, dwell_lo, dwell_hi)` structs, `count = round(total * share)`,
+dwell via `d.u`). End with `.select(*column_names(...))`.
+
+- [ ] **Step 3: Green + full suite + commit**
+
+```bash
+git add utility/src/retail_setup/generation/store_activity.py utility/tests/generation/test_store_activity.py
+git commit -m "feat(utility): store ops + foot traffic generators"
+```
+
+---
+
+### Task 5: Online orders (headers, lines, payments stream)
+
+**Files:**
+- Create: `utility/src/retail_setup/generation/online_orders.py`
+- Modify: `utility/src/retail_setup/config/generation.py` (add `online_orders_per_day: int | None = None`, derived default `store_count * 8` in `_derive_scale_defaults`)
+- Test: `utility/tests/generation/test_online_orders.py`
+
+Rules (datagen online_order_generator.py): network-wide daily volume
+(monthly-weight scaled, clamped-normal); `order_id_ext = concat('ONL', yyyyMMdd, lpad(seq,5,'0'), 3-digit draw)`;
+basket sizes 60%→1-3, 30%→2-5, 10%→5-8 lines, qty 1-3 weighted [.7,.25,.05];
+fulfillment per LINE 60% SHIP_FROM_DC / 30% SHIP_FROM_STORE / 10% BOPIS
+(`node_type` DC|STORE, `node_id` a valid dc/store id); tender 60% CREDIT_CARD /
+25% DEBIT_CARD / 10% PAYPAL / 5% OTHER; 2% of orders CANCELLED (all lines
+CANCELLED, financials zeroed); promos on 10-30% of lines, codes
+PROMO05/PROMO10/PROMO20 with matching 5/10/20% line discount; tax via the
+customer-geography store-rate fallback — SIMPLIFICATION: use the mean store
+tax_rate (document it); lifecycle per non-cancelled line: picked_ts = event_ts +
+30-240min (BOPIS: 4-24h), shipped_ts = picked + 2-4h (BOPIS: NULL),
+delivered_ts = shipped + 1-3 days (BOPIS: picked); statuses DELIVERED
+(or CANCELLED). Payments: one per order, `order_id_ext` set,
+`receipt_id_ext`/`store_id` NULL, amount = total_cents, decline multipliers
+PAYPAL 1.1 / OTHER 0.5 added to the Plan-2a table, processing PAYPAL 2000-5000ms,
+OTHER 1500-4000ms; CANCELLED orders still pay then refund? NO — cancelled
+orders get NO payment row (document; keeps amount==total invariant).
+
+- [ ] **Step 1: Failing tests** — `utility/tests/generation/test_online_orders.py`:
+
+```python
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.online_orders import generate_online_orders
+from retail_setup.generation.schemas import column_names
+
+
+@pytest.fixture(scope="module")
+def setup(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 4, 7),
+                           end_date=date(2025, 4, 13), store_count=3, dc_count=2,
+                           customer_count=300, seed=13, online_orders_per_day=40)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    dims = generate_dimensions(spark, dicts, cfg)
+    return cfg, dims, generate_online_orders(spark, dims, dicts.profile, cfg)
+
+
+def test_contract_columns(setup):
+    _, _, g = setup
+    assert g["fact_online_order_headers"].columns == column_names("fact_online_order_headers")
+    assert g["fact_online_order_lines"].columns == column_names("fact_online_order_lines")
+    assert g["payments"].columns == column_names("fact_payments")
+
+
+def test_volume_and_ids(setup):
+    cfg, _, g = setup
+    h = g["fact_online_order_headers"]
+    n = h.count()
+    assert 0.4 * 7 * cfg.online_orders_per_day < n < 2.0 * 7 * cfg.online_orders_per_day
+    assert h.select("order_id_ext").distinct().count() == n
+    assert h.filter(~F.col("order_id_ext").startswith("ONL")).count() == 0
+
+
+def test_lines_link_and_money(setup):
+    _, _, g = setup
+    h, l = g["fact_online_order_headers"], g["fact_online_order_lines"]
+    assert l.join(h, l.order_id == h.order_id_ext, "left_anti").count() == 0
+    live = l.filter(F.col("fulfillment_status") != "CANCELLED")
+    sums = live.groupBy("order_id").agg(F.sum("ext_cents").alias("s"))
+    j = h.join(sums, h.order_id_ext == sums.order_id)
+    assert j.filter(F.col("subtotal_cents") != F.col("s")).count() == 0
+    assert h.filter(F.col("total_cents") != F.col("subtotal_cents") + F.col("tax_cents")).count() == 0
+
+
+def test_fulfillment_modes_and_nodes(setup):
+    _, dims, g = setup
+    l = g["fact_online_order_lines"]
+    modes = {r.fulfillment_mode for r in l.select("fulfillment_mode").distinct().collect()}
+    assert modes <= {"SHIP_FROM_DC", "SHIP_FROM_STORE", "BOPIS"}
+    dc_ids = {r.ID for r in dims["dim_distribution_centers"].select("ID").collect()}
+    st_ids = {r.ID for r in dims["dim_stores"].select("ID").collect()}
+    bad_dc = l.filter((F.col("node_type") == "DC") & ~F.col("node_id").isin(*dc_ids))
+    bad_st = l.filter((F.col("node_type") == "STORE") & ~F.col("node_id").isin(*st_ids))
+    assert bad_dc.count() == 0 and bad_st.count() == 0
+
+
+def test_lifecycle_ordering(setup):
+    _, _, g = setup
+    l = g["fact_online_order_lines"].filter(F.col("fulfillment_status") == "DELIVERED")
+    assert l.count() > 0
+    assert l.filter(F.col("picked_ts") < F.col("event_ts")).count() == 0
+    shipped = l.filter(F.col("shipped_ts").isNotNull())
+    assert shipped.filter(F.col("shipped_ts") < F.col("picked_ts")).count() == 0
+    assert shipped.filter(F.col("delivered_ts") < F.col("shipped_ts")).count() == 0
+
+
+def test_cancellations_zeroed_no_payment(setup):
+    _, _, g = setup
+    h, pay = g["fact_online_order_headers"], g["payments"]
+    cancelled = h.join(
+        g["fact_online_order_lines"].filter("fulfillment_status = 'CANCELLED'")
+        .select(F.col("order_id").alias("order_id_ext")).distinct(),
+        "order_id_ext")
+    assert cancelled.filter(F.col("total_cents") != 0).count() == 0
+    assert pay.join(cancelled.select("order_id_ext"), "order_id_ext").count() == 0
+    # payments basics
+    assert pay.filter(F.col("receipt_id_ext").isNotNull()).count() == 0
+    assert pay.filter(F.col("store_id").isNotNull()).count() == 0
+```
+
+- [ ] **Step 2: Implement** `generate_online_orders(spark, dims, profile, cfg)`
+returning `{"fact_online_order_headers", "fact_online_order_lines", "payments"}`.
+Build a day grid (single-partition keys: day + seq via explode of
+clamped-normal counts), draw customer/tender/cancel per order; explode basket
+sizes to lines; product pick = uniform over the full catalog (online ignores
+department weights — document); per-line mode/node/promo/lifecycle from draws;
+aggregate live lines → header money with the receipts tax formula (mean store
+rate); zero out cancelled orders' financials. Payments mirror Task 5 rules.
+
+- [ ] **Step 3: Green + full suite + commit**
+
+```bash
+git add utility/src/retail_setup/generation/online_orders.py utility/src/retail_setup/config/generation.py utility/tests/generation/test_online_orders.py
+git commit -m "feat(utility): online orders group with line lifecycle + payments stream"
+```
+
+---
+
+### Task 6: Promotions + promo lines (pure derivation from receipt lines)
+
+**Files:**
+- Create: `utility/src/retail_setup/generation/promotions.py`
+- Test: `utility/tests/generation/test_promotions.py`
+
+Rules (datagen promotions_mixin): `fact_promo_lines` = one row per SALE receipt
+line with `promo_code` NOT NULL and a positive line discount
+(`discount_cents = unit_cents*quantity - ext_cents`); `fact_promotions` = one
+row per (receipt_id_ext, promo_code) aggregating those lines: discount sums,
+`product_count` distinct products, `product_ids` comma-joined sorted ids,
+`discount_type` = 'PERCENTAGE' (our generated codes are percent-style —
+document), store/customer/event fields from the receipt header,
+`trace_id = concat('TRC-PRM-', receipt_id_ext, '-', promo_code)`.
+
+- [ ] **Step 1: Failing tests** — `utility/tests/generation/test_promotions.py`:
+
+```python
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.promotions import generate_promotions
+from retail_setup.generation.receipts import generate_receipts_group
+from retail_setup.generation.schemas import column_names
+
+
+@pytest.fixture(scope="module")
+def setup(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 5, 5),
+                           end_date=date(2025, 5, 11), store_count=2, dc_count=1,
+                           customer_count=200, seed=21, transactions_per_store_day=50)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    dims = generate_dimensions(spark, dicts, cfg)
+    sales = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    promos, promo_lines = generate_promotions(spark, sales)
+    return sales, promos, promo_lines
+
+
+def test_contract_columns(setup):
+    _, promos, promo_lines = setup
+    assert promos.columns == column_names("fact_promotions")
+    assert promo_lines.columns == column_names("fact_promo_lines")
+
+
+def test_promo_lines_match_discounted_receipt_lines(setup):
+    sales, _, promo_lines = setup
+    discounted = sales["fact_receipt_lines"].filter(
+        F.col("promo_code").isNotNull()
+        & (F.col("unit_cents") * F.col("quantity") - F.col("ext_cents") > 0))
+    assert promo_lines.count() == discounted.count()
+    assert promo_lines.filter(F.col("discount_cents") <= 0).count() == 0
+
+
+def test_promotions_aggregate(setup):
+    _, promos, promo_lines = setup
+    agg = promo_lines.groupBy("receipt_id_ext", "promo_code").agg(
+        F.sum("discount_cents").alias("d"),
+        F.countDistinct("product_id").alias("pc"))
+    j = promos.join(agg, ["receipt_id_ext", "promo_code"])
+    assert j.count() == promos.count()
+    assert j.filter(F.col("discount_cents") != F.col("d")).count() == 0
+    assert j.filter(F.col("product_count") != F.col("pc")).count() == 0
+
+
+def test_promotions_link_to_receipts(setup):
+    sales, promos, _ = setup
+    assert promos.join(sales["fact_receipts"], "receipt_id_ext", "left_anti").count() == 0
+    assert promos.filter(F.col("discount_type") != "PERCENTAGE").count() == 0
+```
+
+- [ ] **Step 2: Implement** `generate_promotions(spark, sales_group) -> (promos_df, promo_lines_df)` — pure joins/groupBys, no draws.
+
+- [ ] **Step 3: Green + full suite + commit**
+
+```bash
+git add utility/src/retail_setup/generation/promotions.py utility/tests/generation/test_promotions.py
+git commit -m "feat(utility): promotions + promo lines derived from receipt lines"
+```
+
+---### Task 7: Marketing
+
+**Files:**
+- Create: `utility/src/retail_setup/generation/marketing.py`
+- Test: `utility/tests/generation/test_marketing.py`
+
+Rules (datagen marketing_campaign.py constants): 4 archetypes —
+`seasonal_sale` (channels FACEBOOK/GOOGLE/EMAIL, 1000 imp/day),
+`product_launch` (INSTAGRAM/YOUTUBE/DISPLAY, 2000),
+`loyalty_program` (EMAIL/SOCIAL, 500), `flash_sale` (SOCIAL/SEARCH, 5000 but
+only ~1 day in 7). Scale all volumes by `cfg.store_count / 86` (legacy fleet
+size — document). Channel cost ranges (uniform draw, dollars):
+EMAIL .005-.05, DISPLAY .10-.50, SOCIAL .08-.25, SEARCH .15-.75,
+FACEBOOK .10-.40, GOOGLE .25-1.50, INSTAGRAM .08-.35, YOUTUBE .30-1.50.
+Device pick MOBILE .6 / DESKTOP .3 / TABLET .1 with cost multiplier
+1.2/0.8/0.9. `campaign_id = concat('CAMP', yyyyMMdd, lpad(archetype_idx,2,'0'))`;
+`impression_id_ext = concat('IMP', campaign_id, lpad(seq,7,'0'))`;
+`creative_id = concat('CREAT', substring(impression_id_ext, 4, 30))`;
+customer assignment: uniform customer per impression, `customer_ad_id` from
+`dim_customers.AdId`; `customer_id` (double) populated for 5% of impressions,
+else NULL. `cost_cents = round(cost_dollars*100)`, `cost = format '%.2f'`.
+event_ts uniform within the day.
+
+- [ ] **Step 1: Failing tests** — `utility/tests/generation/test_marketing.py`:
+
+```python
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.marketing import CHANNEL_COSTS, generate_marketing
+from retail_setup.generation.schemas import column_names
+
+
+@pytest.fixture(scope="module")
+def setup(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 6, 2),
+                           end_date=date(2025, 6, 8), store_count=4, dc_count=1,
+                           customer_count=200, seed=31)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    dims = generate_dimensions(spark, dicts, cfg)
+    return cfg, dims, generate_marketing(spark, dims, cfg)
+
+
+def test_contract_columns(setup):
+    *_, mk = setup
+    assert mk.columns == column_names("fact_marketing")
+
+
+def test_ids_and_costs(setup):
+    *_, mk = setup
+    n = mk.count()
+    assert n > 0
+    assert mk.select("impression_id_ext").distinct().count() == n
+    assert mk.filter(~F.col("campaign_id").startswith("CAMP")).count() == 0
+    # cost_cents within channel band x device multiplier envelope
+    for r in mk.select("channel", "cost_cents").collect():
+        lo, hi = CHANNEL_COSTS[r.channel]
+        assert lo * 100 * 0.8 - 1 <= r.cost_cents <= hi * 100 * 1.2 + 1, r
+
+
+def test_crm_match_share(setup):
+    *_, mk = setup
+    share = mk.filter(F.col("customer_id").isNotNull()).count() / mk.count()
+    assert 0.01 < share < 0.12  # 5% nominal
+
+
+def test_device_mix(setup):
+    *_, mk = setup
+    mob = mk.filter("device = 'MOBILE'").count() / mk.count()
+    assert 0.45 < mob < 0.75
+```
+
+- [ ] **Step 2: Implement** `generate_marketing(spark, dims, cfg)` with module
+constants `ARCHETYPES` and `CHANNEL_COSTS` (dict channel → (lo, hi) dollars).
+Day grid × archetypes (flash_sale gated by `u < 1/7`), per-day impression
+counts clamped-normal, explode to impressions, channel pick uniform over the
+archetype's channels, device/cost/CRM draws as above.
+
+- [ ] **Step 3: Green + full suite + commit**
+
+```bash
+git add utility/src/retail_setup/generation/marketing.py utility/tests/generation/test_marketing.py
+git commit -m "feat(utility): marketing impressions generator"
+```
+
+---
+
+### Task 8: BLE pings + customer zone changes
+
+**Files:**
+- Create: `utility/src/retail_setup/generation/sensors.py`
+- Test: `utility/tests/generation/test_sensors.py`
+
+Rules (datagen sensors_mixin / zone_changes_mixin), Spark-native (the
+correlation is mild enough for window functions — document the deviation from
+the spec's "pandas-UDF island" expectation):
+- Visits = SALE receipts (one visit per receipt): 30% "known" → `customer_ble_id`
+  from `dim_customers.BLEId` of the receipt's customer, `customer_id` set
+  (double); 70% anonymous → `concat('ANON-', store_id, '-', h64 % 900000 + 100000)`,
+  `customer_id` NULL.
+- Zones `ENTRANCE, ELECTRONICS, GROCERY, CLOTHING, CHECKOUT`; zones-per-visit
+  2-5, pings-per-zone 2-5; rssi uniform [-80,-29]; ping times = receipt
+  event_ts ± 15 min spread (clamped ordering: assign each ping
+  `offset_min = (zone_rank - 1) * 7 + ping_seq + u` so zone sequence is
+  time-ordered within the visit — entry near ENTRANCE first is NOT required;
+  keep it simple and document).
+- `beacon_id = format('BEACON_%03d_%s', store_id, zone)`;
+  `trace_id = concat('TRC-BLE-', receipt_id_ext, '-', seq)`.
+- `fact_customer_zone_changes` derived from pings: window per
+  (store_id, customer_ble_id, visit) ordered by event_ts, `lag(zone)`,
+  keep rows where zone changed; `from_zone`/`to_zone`;
+  `trace_id = concat('TRC-ZC-', ...)`.
+
+- [ ] **Step 1: Failing tests** — `utility/tests/generation/test_sensors.py`:
+
+```python
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.receipts import generate_receipts_group
+from retail_setup.generation.sensors import generate_ble
+from retail_setup.generation.schemas import column_names
+
+BLE_ZONES = {"ENTRANCE", "ELECTRONICS", "GROCERY", "CLOTHING", "CHECKOUT"}
+
+
+@pytest.fixture(scope="module")
+def setup(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 7, 7),
+                           end_date=date(2025, 7, 9), store_count=2, dc_count=1,
+                           customer_count=150, seed=17, transactions_per_store_day=30)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    dims = generate_dimensions(spark, dicts, cfg)
+    sales = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    pings, zc = generate_ble(spark, sales["fact_receipts"], dims, cfg)
+    return sales, pings, zc
+
+
+def test_contract_columns(setup):
+    _, pings, zc = setup
+    assert pings.columns == column_names("fact_ble_pings")
+    assert zc.columns == column_names("fact_customer_zone_changes")
+
+
+def test_ping_properties(setup):
+    sales, pings, _ = setup
+    n_receipts = sales["fact_receipts"].count()
+    # 2-5 zones x 2-5 pings per visit => 4-25 pings per receipt
+    assert 4 * n_receipts <= pings.count() <= 25 * n_receipts
+    assert pings.filter((F.col("rssi") < -80) | (F.col("rssi") > -29)).count() == 0
+    assert {r.zone for r in pings.select("zone").distinct().collect()} <= BLE_ZONES
+    known = pings.filter(F.col("customer_id").isNotNull()).count() / pings.count()
+    assert 0.15 < known < 0.45  # 30% of visits nominal
+    anon = pings.filter(F.col("customer_ble_id").startswith("ANON-"))
+    assert anon.filter(F.col("customer_id").isNotNull()).count() == 0
+
+
+def test_zone_changes_derive_from_pings(setup):
+    _, pings, zc = setup
+    assert zc.count() > 0
+    assert zc.filter(F.col("from_zone") == F.col("to_zone")).count() == 0
+    # every (store, ble) in zone-changes exists in pings
+    zk = zc.select("store_id", "customer_ble_id").distinct()
+    pk = pings.select("store_id", "customer_ble_id").distinct()
+    assert zk.join(pk, ["store_id", "customer_ble_id"], "left_anti").count() == 0
+```
+
+- [ ] **Step 2: Implement** `generate_ble(spark, receipts, dims, cfg) -> (pings_df, zone_changes_df)` per the rules above. Zone selection without
+replacement: rank the 5 zones by `d.u(["receipt_id_ext"], f"z{z}")` per visit
+and take the top `n_zones` — Spark-native via posexplode of the zone array +
+per-zone draw + window rank.
+
+- [ ] **Step 3: Green + full suite + commit**
+
+```bash
+git add utility/src/retail_setup/generation/sensors.py utility/tests/generation/test_sensors.py
+git commit -m "feat(utility): BLE pings + zone changes generators"
+```
+
+---
+
+### Task 9: Inventory & logistics chain
+
+**Files:**
+- Create: `utility/src/retail_setup/generation/inventory.py`
+- Test: `utility/tests/generation/test_inventory.py`
+
+The flow (one function, internally staged; all draws via `seeded_draws`):
+
+1. **Store demand** = SALE txns derived 1:1 from `fact_receipt_lines`
+   (quantity → negative, `txn_type='SALE'`, `source='CUSTOMER_PURCHASE'`,
+   event fields from the line) plus RETURN add-backs from return lines
+   (positive qty, `txn_type='RETURN'`, `source=receipt_id_ext`).
+2. **Reorders**: per store-day, aggregate that day's demand per product; for
+   the top-demand products draw `reorder_point` 5-20 and emit a reorder when
+   cumulative demand since last shipment exceeds it — SIMPLIFICATION: emit one
+   `fact_reorders` row per (store, day) for each of the day's top-N demanded
+   products where `u < 0.4` (N=5), `current_quantity = greatest(0, reorder_point - demand_today)`,
+   `reorder_quantity` 50-200, priority from deficit pct (URGENT ≥50%,
+   HIGH ≥25%, else NORMAL), `event_ts` = day 23:00, dc_id = store's assigned
+   DC (store_id % dc_count + 1 — document the deterministic store→DC map).
+3. **Shipments**: one per (store, day) having reorders — `shipment_id =
+   concat('SHIP', yyyyMMdd, lpad(dc,2,'0'), lpad(store,3,'0'))`; truck =
+   assigned truck of that DC (round-robin by day); departure next day 06:00,
+   travel hours 2-12 (draw), unload 0.5-2.0h; emit the 6 `fact_truck_moves`
+   status rows (SCHEDULED day 23:30, LOADING dep-2h... wait: LOADING = dep
+   - 2h? datagen: departure+2h was relative to creation; SIMPLIFY and
+   document: SCHEDULED 23:30 day0, LOADING 04:00, IN_TRANSIT 06:00 (=
+   departure), ARRIVED 06:00+travel (=eta), UNLOADING eta+0.25h, COMPLETED
+   eta+unload (=etd, departure_time=etd, actual_unload_duration=unload
+   minutes, min 30).
+4. **Truck inventory**: LOAD rows (one per shipment product, location DC,
+   ts=LOADING) and UNLOAD rows (location store, ts=UNLOADING). Shipment
+   products = that store-day's reorder rows (qty = reorder_quantity).
+5. **DC txns**: `INBOUND_SHIPMENT` supplier deliveries — per (dc, day) 1-3
+   shipments × 5 products × qty 50-500, `source = concat('SUPPLIER-', ...)`;
+   `OUTBOUND_SHIPMENT` rows mirroring truck LOADs (negative qty,
+   source=shipment_id).
+6. **Store inbound**: `INBOUND_SHIPMENT` rows mirroring truck UNLOADs
+   (positive qty, source=shipment_id) at the UNLOADING ts.
+7. **Balances**: per (node, product) window `sum(quantity) over (order by
+   event_ts, txn ordinal rows unbounded preceding)` + an initial-stock seed
+   (store: 40-120 per product seen; DC: 500-2000) folded in as a day-0
+   synthetic txn (`txn_type='INITIAL'`, `source='SEED'`) so balances rarely go
+   negative; clamp NOT applied — negatives become stockout signals.
+8. **Stockouts**: rows where balance ≤ 0 and the previous balance > 0
+   (window lag), one per (node, product, day) max — `StoreID`/`DCID` mutually
+   exclusive doubles, `ProductID`, `LastKnownQuantity = abs(quantity)` of the
+   crossing txn, event fields from it.
+
+Returns `dict` with keys: `fact_store_inventory_txn`, `fact_dc_inventory_txn`,
+`fact_truck_moves`, `fact_truck_inventory`, `fact_reorders`, `fact_stockouts`.
+
+- [ ] **Step 1: Failing tests** — `utility/tests/generation/test_inventory.py`:
+
+```python
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.inventory import generate_inventory_chain
+from retail_setup.generation.receipts import generate_receipts_group
+from retail_setup.generation.returns import generate_returns
+from retail_setup.generation.schemas import column_names
+
+TABLES = ["fact_store_inventory_txn", "fact_dc_inventory_txn", "fact_truck_moves",
+          "fact_truck_inventory", "fact_reorders", "fact_stockouts"]
+
+
+@pytest.fixture(scope="module")
+def setup(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 8, 4),
+                           end_date=date(2025, 8, 10), store_count=2, dc_count=1,
+                           customer_count=200, seed=23, transactions_per_store_day=40)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    dims = generate_dimensions(spark, dicts, cfg)
+    sales = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    rets = generate_returns(spark, sales, dims, cfg)
+    inv = generate_inventory_chain(spark, sales, rets, dims, cfg)
+    return cfg, dims, sales, inv
+
+
+def test_contract_columns(setup):
+    *_, inv = setup
+    for t in TABLES:
+        assert inv[t].columns == column_names(t), t
+
+
+def test_sales_txns_mirror_receipt_lines(setup):
+    _, _, sales, inv = setup
+    txn = inv["fact_store_inventory_txn"].filter("txn_type = 'SALE'")
+    assert txn.count() == sales["fact_receipt_lines"].count()
+    assert txn.filter(F.col("quantity") >= 0).count() == 0
+
+
+def test_balances_are_running(setup):
+    *_, inv = setup
+    txn = inv["fact_store_inventory_txn"]
+    # spot-check one (store, product): balance deltas equal quantities
+    key = txn.groupBy("store_id", "product_id").count().orderBy(F.desc("count")).first()
+    seq = (txn.filter((F.col("store_id") == key.store_id)
+                      & (F.col("product_id") == key.product_id))
+           .orderBy("event_ts").collect())
+    running = 0
+    for r in seq:
+        running += r.quantity
+        assert r.balance == running, (r.event_ts, r.balance, running)
+
+
+def test_truck_lifecycle(setup):
+    *_, inv = setup
+    moves = inv["fact_truck_moves"]
+    if moves.count() == 0:
+        pytest.skip("no shipments triggered in this window")
+    per = moves.groupBy("shipment_id").agg(
+        F.collect_set("status").alias("statuses"), F.count("*").alias("n"))
+    for r in per.collect():
+        assert set(r.statuses) == {"SCHEDULED", "LOADING", "IN_TRANSIT", "ARRIVED",
+                                   "UNLOADING", "COMPLETED"}
+        assert r.n == 6
+    done = moves.filter("status = 'COMPLETED'")
+    assert done.filter(F.col("actual_unload_duration") < 30).count() == 0
+    # load/unload pairs exist per shipment product
+    ti = inv["fact_truck_inventory"]
+    loads = ti.filter("action = 'LOAD'").groupBy("shipment_id", "product_id").count()
+    unloads = ti.filter("action = 'UNLOAD'").groupBy("shipment_id", "product_id").count()
+    assert loads.join(unloads, ["shipment_id", "product_id"], "left_anti").count() == 0
+
+
+def test_reorder_priorities(setup):
+    *_, inv = setup
+    ro = inv["fact_reorders"]
+    if ro.count() == 0:
+        pytest.skip("no reorders in window")
+    assert {r.priority for r in ro.select("priority").distinct().collect()} <= \
+        {"NORMAL", "HIGH", "URGENT"}
+    assert ro.filter((F.col("reorder_quantity") < 50) | (F.col("reorder_quantity") > 200)).count() == 0
+    assert ro.filter((F.col("reorder_point") < 5) | (F.col("reorder_point") > 20)).count() == 0
+
+
+def test_stockouts_mutually_exclusive(setup):
+    *_, inv = setup
+    so = inv["fact_stockouts"]
+    both = so.filter(F.col("StoreID").isNotNull() & F.col("DCID").isNotNull())
+    neither = so.filter(F.col("StoreID").isNull() & F.col("DCID").isNull())
+    assert both.count() == 0 and neither.count() == 0
+```
+
+- [ ] **Step 2: Implement** per the staged flow. This is the largest module —
+keep stages as private functions (`_sale_txns`, `_reorders`, `_shipments`,
+`_truck_frames`, `_dc_txns`, `_with_balances`, `_stockouts`) inside
+`inventory.py`; if it exceeds ~400 lines, split balance/stockout helpers into
+`inventory_balances.py` and report the split.
+
+- [ ] **Step 3: Green + full suite + commit**
+
+```bash
+git add utility/src/retail_setup/generation/inventory.py utility/tests/generation/test_inventory.py
+git commit -m "feat(utility): inventory + logistics chain (txns, reorders, trucks, stockouts)"
+```
+
+---
+
+### Task 10: Orchestrator, payments/receipts unions, invariants, run log
+
+**Files:**
+- Create: `utility/src/retail_setup/generation/engine.py`
+- Create: `utility/src/retail_setup/generation/invariants.py`
+- Test: `utility/tests/generation/test_engine.py`
+
+- [ ] **Step 1: Failing tests** — `utility/tests/generation/test_engine.py`:
+
+```python
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.engine import generate_all
+from retail_setup.generation.invariants import run_invariants
+from retail_setup.generation.schemas import TABLES, column_names
+
+
+@pytest.fixture(scope="module")
+def result(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 9, 1),
+                           end_date=date(2025, 9, 7), store_count=2, dc_count=1,
+                           customer_count=200, seed=99, transactions_per_store_day=30,
+                           online_orders_per_day=20)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    return cfg, generate_all(spark, dicts, cfg)
+
+
+def test_all_contract_tables_present(result):
+    _, out = result
+    fact_tables = [t for t in TABLES if t.startswith("fact_")]
+    for t in fact_tables:
+        assert t in out.tables, t
+        assert out.tables[t].columns == column_names(t), t
+    for t in ["dim_stores", "dim_products", "dim_date"]:
+        assert t in out.tables
+
+
+def test_unions_applied(result):
+    _, out = result
+    receipts = out.tables["fact_receipts"]
+    assert receipts.filter("receipt_type = 'RETURN'").count() > 0
+    assert receipts.filter("receipt_type = 'SALE'").count() > 0
+    pay = out.tables["fact_payments"]
+    assert pay.filter(F.col("order_id_ext").isNotNull()).count() > 0   # online
+    assert pay.filter(F.col("receipt_id_ext").isNotNull()).count() > 0  # in-store + returns
+    both = pay.filter(F.col("order_id_ext").isNotNull() & F.col("receipt_id_ext").isNotNull())
+    assert both.count() == 0
+
+
+def test_invariants_pass_and_report(result, spark):
+    _, out = result
+    report = run_invariants(spark, out.tables)
+    assert report.passed, report.failures
+    assert report.row_counts["fact_receipts"] > 0
+    assert len(report.checks) >= 10
+
+
+def test_invariants_catch_violations(result, spark):
+    _, out = result
+    broken = dict(out.tables)
+    broken["fact_receipt_lines"] = out.tables["fact_receipt_lines"].withColumn(
+        "receipt_id_ext", F.lit("RCPBOGUS"))
+    report = run_invariants(spark, broken)
+    assert not report.passed
+    assert any("fact_receipt_lines" in f for f in report.failures)
+```
+
+- [ ] **Step 2: Implement engine.py**
+
+```python
+"""Orchestrates full generation. Returns DataFrames; writing happens in 2c."""
+
+from dataclasses import dataclass
+
+from pyspark.sql import DataFrame, SparkSession
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import DictionarySet
+from retail_setup.generation import (
+    dims as dims_mod, inventory, marketing, online_orders, promotions,
+    receipts as receipts_mod, returns as returns_mod, sensors, store_activity,
+)
+
+
+@dataclass
+class GenerationResult:
+    tables: dict[str, DataFrame]
+
+
+def generate_all(spark: SparkSession, dicts: DictionarySet, cfg: GenerationConfig) -> GenerationResult:
+    t: dict[str, DataFrame] = {}
+    t.update(dims_mod.generate_dimensions(spark, dicts, cfg))
+    t["dim_date"] = dims_mod.generate_dim_date(
+        spark, cfg.start_date.replace(year=cfg.start_date.year - 5),
+        cfg.end_date.replace(year=cfg.end_date.year + 5))
+
+    sales = receipts_mod.generate_receipts_group(spark, t_dims := t, dicts.profile, cfg)
+    rets = returns_mod.generate_returns(spark, sales, t, cfg)
+    t["fact_receipts"] = sales["fact_receipts"].unionByName(rets["fact_receipts"])
+    t["fact_receipt_lines"] = sales["fact_receipt_lines"].unionByName(rets["fact_receipt_lines"])
+
+    online = online_orders.generate_online_orders(spark, t, dicts.profile, cfg)
+    t["fact_online_order_headers"] = online["fact_online_order_headers"]
+    t["fact_online_order_lines"] = online["fact_online_order_lines"]
+    # single-writer union for the shared payments table (2a carry-note)
+    t["fact_payments"] = (sales["fact_payments"]
+                          .unionByName(rets["fact_payments"])
+                          .unionByName(online["payments"]))
+
+    promos, promo_lines = promotions.generate_promotions(spark, sales)
+    t["fact_promotions"], t["fact_promo_lines"] = promos, promo_lines
+    t["fact_store_ops"] = store_activity.generate_store_ops(spark, t, cfg)
+    t["fact_foot_traffic"] = store_activity.generate_foot_traffic(
+        spark, sales["fact_receipts"], t, cfg)
+    pings, zc = sensors.generate_ble(spark, sales["fact_receipts"], t, cfg)
+    t["fact_ble_pings"], t["fact_customer_zone_changes"] = pings, zc
+    t.update(inventory.generate_inventory_chain(spark, sales, rets, t, cfg))
+    return GenerationResult(tables=t)
+```
+
+(Resolve the `t_dims := t` drafting artifact — just pass `t`. Match the actual
+signatures from Tasks 3–9; if a signature differs, adapt the orchestrator, not
+the generator.)
+
+- [ ] **Step 3: Implement invariants.py**
+
+```python
+"""Cross-table invariant checks. Pure reads; raises nothing — returns a report."""
+
+from dataclasses import dataclass, field
+
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
+
+
+@dataclass
+class InvariantReport:
+    checks: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    row_counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return not self.failures
+
+
+def _check(report: InvariantReport, name: str, bad_count: int) -> None:
+    report.checks.append(name)
+    if bad_count:
+        report.failures.append(f"{name}: {bad_count} violations")
+
+
+def run_invariants(spark: SparkSession, t: dict[str, DataFrame]) -> InvariantReport:
+    r = InvariantReport()
+    for name, df in t.items():
+        r.row_counts[name] = df.count()
+
+    receipts, lines, pay = t["fact_receipts"], t["fact_receipt_lines"], t["fact_payments"]
+    _check(r, "fact_receipts.receipt_id_ext unique",
+           r.row_counts["fact_receipts"] - receipts.select("receipt_id_ext").distinct().count())
+    _check(r, "fact_receipt_lines -> fact_receipts FK",
+           lines.join(receipts, "receipt_id_ext", "left_anti").count())
+    _check(r, "fact_payments xor keys",
+           pay.filter(F.col("receipt_id_ext").isNotNull() == F.col("order_id_ext").isNotNull()).count())
+    _check(r, "fact_payments -> receipts FK",
+           pay.filter(F.col("receipt_id_ext").isNotNull())
+              .join(receipts, "receipt_id_ext", "left_anti").count())
+
+    products = t["dim_products"].select(F.col("ID").alias("product_id"))
+    for tbl in ["fact_receipt_lines", "fact_online_order_lines", "fact_promo_lines",
+                "fact_store_inventory_txn", "fact_dc_inventory_txn", "fact_reorders"]:
+        _check(r, f"{tbl} -> dim_products FK",
+               t[tbl].join(products, "product_id", "left_anti").count())
+
+    stores = t["dim_stores"].select(F.col("ID").alias("store_id"))
+    for tbl in ["fact_receipts", "fact_store_inventory_txn", "fact_reorders",
+                "fact_store_ops", "fact_foot_traffic", "fact_ble_pings"]:
+        _check(r, f"{tbl} -> dim_stores FK",
+               t[tbl].join(stores, "store_id", "left_anti").count())
+
+    for tbl, df in t.items():
+        if tbl.startswith("fact_") and "event_date" in df.columns:
+            _check(r, f"{tbl}.event_date not null",
+                   df.filter(F.col("event_date").isNull()).count())
+
+    oh, ol = t["fact_online_order_headers"], t["fact_online_order_lines"]
+    _check(r, "online order ids unique",
+           r.row_counts["fact_online_order_headers"]
+           - oh.select("order_id_ext").distinct().count())
+    _check(r, "online lines -> headers FK",
+           ol.join(oh, ol.order_id == oh.order_id_ext, "left_anti").count())
+
+    so = t["fact_stockouts"]
+    _check(r, "stockouts StoreID xor DCID",
+           so.filter(F.col("StoreID").isNotNull() == F.col("DCID").isNotNull()).count())
+    return r
+```
+
+- [ ] **Step 4: Green (target ~full suite + ~4 new); FULL suite; commit**
+
+```bash
+git add utility/src/retail_setup/generation/engine.py utility/src/retail_setup/generation/invariants.py utility/tests/generation/test_engine.py
+git commit -m "feat(utility): generation orchestrator, shared-table unions, invariant runner"
+```
+
+---
+
+## Self-review checklist (after all tasks)
+
+- [ ] Full suite green from clean checkout; total runtime < ~5 min locally
+- [ ] Contract test green for ALL `TABLES` entries; every TMDL-driven schema delta documented in task reports
+- [ ] `grep -rn "F.rand\|applyInPandas" utility/src` → empty
+- [ ] Determinism: `generate_all` twice with same cfg → same `fact_receipts` count and id set; different seed → different
+- [ ] Every fact frame ends with `.select(*column_names(...))`
+- [ ] No file named with "credentials"/"secret"
+
+## Deferred to Plan 2c
+
+- Gold aggregates (9 `au.*` tables), the four notebooks + build script,
+  GitHub dictionary fetch (pinned ref + local-first), `setup_run_log` Delta
+  write + writer wiring of `generate_all` output, local E2E harness,
+  injectable dictionary root for the Fabric runtime, notebooks pin
+  `spark.sql.session.timeZone=UTC`, column-wise customer build for 500k-scale.

--- a/utility/pyproject.toml
+++ b/utility/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.4", "ruff>=0.4", "mypy>=1.8"]
+dev = ["pytest>=7.4", "ruff>=0.4", "mypy>=1.8", "pyspark>=3.4,<3.6", "pandas>=2.0", "numpy>=1.26"]
 spark = ["pyspark>=3.4,<3.6"]  # local testing; Fabric provides Spark at runtime
 
 [project.scripts]

--- a/utility/src/retail_setup/config/generation.py
+++ b/utility/src/retail_setup/config/generation.py
@@ -18,6 +18,13 @@ class GenerationConfig(BaseModel):
     silver_db: str = "ag"
     gold_db: str = "au"
 
+    # scale knobs; None -> derived from store_count in the validator below
+    dc_count: int | None = Field(default=None, gt=0)
+    customer_count: int | None = Field(default=None, gt=0)
+    # base in-store transactions per store-day at multiplier 1.0; profiles'
+    # hourly/daily/monthly weights shape it, store daily_traffic_multiplier scales it
+    transactions_per_store_day: int = Field(default=400, gt=0)
+
     @field_validator("store_type")
     @classmethod
     def _known_store_type(cls, v: str) -> str:
@@ -30,6 +37,14 @@ class GenerationConfig(BaseModel):
     def _date_order(self) -> "GenerationConfig":
         if self.end_date < self.start_date:
             raise ValueError("end_date must be on or after start_date")
+        return self
+
+    @model_validator(mode="after")
+    def _derive_scale_defaults(self) -> "GenerationConfig":
+        if self.dc_count is None:
+            self.dc_count = max(1, self.store_count // 10)
+        if self.customer_count is None:
+            self.customer_count = self.store_count * 1000
         return self
 
 

--- a/utility/src/retail_setup/generation/dims.py
+++ b/utility/src/retail_setup/generation/dims.py
@@ -1,0 +1,198 @@
+"""Dimension generation: driver-side numpy/pandas -> Spark DataFrames.
+
+Semantics ported from datagen master_generators (ID schemes, tax lookup,
+pricing rules); column names/types from schemas.TABLES, which the TMDL
+contract test guards.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+
+import numpy as np
+from pyspark.sql import DataFrame, SparkSession
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import DictionarySet
+from retail_setup.generation.runtime import derive_seed
+from retail_setup.generation.schemas import spark_schema
+
+# datagen StoreProfiler equivalents (volume class -> traffic multiplier range)
+VOLUME_CLASSES = [
+    ("flagship", 0.05, (1.8, 2.5)),
+    ("high_volume", 0.20, (1.3, 1.8)),
+    ("standard", 0.55, (0.8, 1.3)),
+    ("low_volume", 0.20, (0.4, 0.8)),
+]
+STORE_FORMATS = ["hypermarket", "superstore", "standard", "neighborhood"]
+OPERATING_HOURS = ["6-22", "7-22", "7-23", "24h"]
+DEFAULT_TAX_RATE = 0.07407  # datagen receipts_mixin fallback
+REFRIGERATED_CATEGORIES = {"Produce", "Dairy & Eggs", "Dairy & Alternatives",
+                           "Meat & Poultry", "Meat & Seafood", "Seafood", "Frozen"}
+
+
+def _addr(rng: np.random.Generator) -> str:
+    return (
+        f"{int(rng.integers(100, 9999))} "
+        f"{str(rng.choice(['Main', 'Oak', 'Maple', 'Market', 'Commerce', 'Liberty']))} "
+        f"{str(rng.choice(['St', 'Ave', 'Blvd', 'Rd']))}"
+    )
+
+
+def generate_dimensions(
+    spark: SparkSession, dicts: DictionarySet, cfg: GenerationConfig
+) -> dict[str, DataFrame]:
+    rng = np.random.default_rng(derive_seed(cfg.seed, "dims", 0, cfg.start_date))
+    out: dict[str, DataFrame] = {}
+
+    # --- geographies: sample from dictionary, sequential IDs
+    n_geo = min(len(dicts.geographies), max(cfg.store_count * 2, cfg.dc_count * 2, 20))
+    geo_idx = rng.choice(len(dicts.geographies), size=n_geo, replace=False)
+    geos = [dicts.geographies[i] for i in geo_idx]
+    geo_rows = [
+        (i + 1, g.City, g.State, g.Zip, g.District, g.Region)
+        for i, g in enumerate(geos)
+    ]
+    out["dim_geographies"] = spark.createDataFrame(geo_rows, spark_schema("dim_geographies"))
+
+    # tax lookup: (State, City) -> rate, else state mean, else default
+    by_city = {(t.StateCode, t.City): float(t.CombinedRate) for t in dicts.tax_rates}
+    state_rates: dict[str, list[float]] = {}
+    for t in dicts.tax_rates:
+        state_rates.setdefault(t.StateCode, []).append(float(t.CombinedRate))
+
+    def tax_for(state: str, city: str) -> float:
+        if (state, city) in by_city:
+            return by_city[(state, city)]
+        if state in state_rates:
+            return float(np.mean(state_rates[state]))
+        return DEFAULT_TAX_RATE
+
+    # --- DCs first (datagen: stores constrained to DC states)
+    dc_geo_idx = rng.choice(n_geo, size=cfg.dc_count, replace=cfg.dc_count > n_geo)
+    dc_rows = [
+        (i + 1, f"DC{i + 1:03d}", _addr(rng), int(dc_geo_idx[i]) + 1)
+        for i in range(cfg.dc_count)
+    ]
+    out["dim_distribution_centers"] = spark.createDataFrame(
+        dc_rows, spark_schema("dim_distribution_centers")
+    )
+
+    # --- stores in DC states
+    dc_states = {geos[int(g)].State for g in dc_geo_idx}
+    eligible = [i for i, g in enumerate(geos) if g.State in dc_states] or list(range(n_geo))
+    store_rows = []
+    for sid in range(1, cfg.store_count + 1):
+        gi = int(rng.choice(eligible))
+        g = geos[gi]
+        classes, probs = zip(*[(c, p) for c, p, _ in VOLUME_CLASSES])
+        vc = str(rng.choice(classes, p=probs))
+        lo, hi = next(r for c, _, r in VOLUME_CLASSES if c == vc)
+        store_rows.append((
+            sid,
+            f"S{sid:06d}",
+            _addr(rng),
+            gi + 1,
+            tax_for(g.State, g.City),
+            vc,
+            str(rng.choice(STORE_FORMATS)),
+            str(rng.choice(OPERATING_HOURS)),
+            float(np.round(rng.uniform(lo, hi), 2)),
+        ))
+    out["dim_stores"] = spark.createDataFrame(store_rows, spark_schema("dim_stores"))
+
+    # --- trucks: 85% assigned round-robin to DCs, 15% pool (DCID NULL); 40% refrigerated
+    n_trucks = max(cfg.dc_count * 3, 6)
+    n_assigned = int(round(n_trucks * 0.85))
+    truck_rows = []
+    for tid in range(1, n_trucks + 1):
+        plate = f"TRK{tid:04d}{chr(65 + tid % 26)}"
+        refrig = bool(rng.random() < 0.4)
+        dcid = float((tid - 1) % cfg.dc_count + 1) if tid <= n_assigned else None
+        truck_rows.append((tid, plate, refrig, dcid))
+    out["dim_trucks"] = spark.createDataFrame(truck_rows, spark_schema("dim_trucks"))
+
+    # --- customers
+    first = [n.Name for n in dicts.first_names]
+    last = [n.Name for n in dicts.last_names]
+    cust_rows = []
+    for cid in range(1, cfg.customer_count + 1):
+        gi = int(rng.integers(0, n_geo))
+        cust_rows.append((
+            cid,
+            str(rng.choice(first)),
+            str(rng.choice(last)),
+            _addr(rng),
+            gi + 1,
+            f"LC{cid:06d}{int(rng.integers(0, 1000)):03d}",
+            f"555-{int(rng.integers(200, 999))}-{int(rng.integers(1000, 9999))}",
+            "BLE" + np.base_repr(cid, 36).rjust(6, "0"),
+            f"AD{cid:08d}",
+        ))
+    out["dim_customers"] = spark.createDataFrame(cust_rows, spark_schema("dim_customers"))
+
+    # --- products from dictionary; pricing: SalePrice = BasePrice,
+    #     MSRP = SalePrice * U(1.0, 1.25), Cost = SalePrice * U(0.50, 0.85) (datagen rule)
+    brand_names = [b.Brand for b in dicts.brands]
+    brand_company = {b.Brand: b.Company for b in dicts.brands}
+    tags_by_product = {t.ProductName: t.Tags for t in dicts.tags}
+    # Use naive UTC datetimes — Spark session timezone is UTC (set in conftest fixture)
+    hist_start = datetime.combine(cfg.start_date, datetime.min.time())
+    prod_rows = []
+    for pid, p in enumerate(dicts.products, start=1):
+        sale = float(p.BasePrice)
+        brand = str(rng.choice(brand_names))
+        taxability = (
+            "NON_TAXABLE" if p.Department in {"Fresh", "Grocery"} and "Candy" not in p.Category
+            else "REDUCED_RATE" if p.Department in {"Clothing", "Apparel"}
+            else "TAXABLE"
+        )
+        launch_r = float(rng.random())  # 60% before history, 30% first half, 10% later
+        if launch_r < 0.6:
+            launch = hist_start - timedelta(days=int(rng.integers(30, 1500)))
+        elif launch_r < 0.9:
+            launch = hist_start + timedelta(days=int(rng.integers(0, 183)))
+        else:
+            launch = hist_start + timedelta(days=int(rng.integers(183, 366)))
+        cost = round(sale * float(rng.uniform(0.50, 0.85)), 2)
+        msrp = round(sale * float(rng.uniform(1.0, 1.25)), 2)
+        prod_rows.append((
+            pid,
+            p.ProductName,
+            brand,
+            brand_company[brand],
+            p.Department,
+            p.Category,
+            p.Subcategory,
+            cost,
+            msrp,
+            sale,
+            bool(p.Category in REFRIGERATED_CATEGORIES),
+            launch,
+            taxability,
+            p.Tags or tags_by_product.get(p.ProductName),
+        ))
+    out["dim_products"] = spark.createDataFrame(prod_rows, spark_schema("dim_products"))
+    return out
+
+
+def generate_dim_date(spark: SparkSession, start: date, end: date) -> DataFrame:
+    """Exact port of 02-historical-data-load's dim_date (fiscal year starts July)."""
+    rows = []
+    d = start
+    while d <= end:
+        rows.append((
+            int(d.strftime("%Y%m%d")),
+            d,
+            d.year,
+            (d.month - 1) // 3 + 1,
+            d.month,
+            d.strftime("%B"),
+            d.day,
+            d.isoweekday(),
+            d.strftime("%A"),
+            int(d.strftime("%U")),
+            1 if d.isoweekday() >= 6 else 0,
+            d.year if d.month >= 7 else d.year - 1,
+            ((d.month - 7) % 12) // 3 + 1,
+        ))
+        d += timedelta(days=1)
+    return spark.createDataFrame(rows, spark_schema("dim_date"))

--- a/utility/src/retail_setup/generation/receipts.py
+++ b/utility/src/retail_setup/generation/receipts.py
@@ -1,0 +1,270 @@
+"""Receipts fact group, Spark-native.
+
+Randomness: every stochastic decision derives a uniform double from
+xxhash64(key columns, salt) — partition-arrangement-independent, so output is
+deterministic for a (config, seed) pair regardless of cluster shape. The
+config seed is folded into every salt so different seeds produce different
+draws (deviation from the plan reference, which omitted the seed from salts).
+
+Count distributions (store-day receipt counts, basket sizes) use a clamped
+normal approximation of Poisson — `max(1, round(N(lambda, sqrt(lambda))))` —
+a documented deviation from datagen's per-row RNG; statistically equivalent
+at demo scale and fully vectorizable.
+
+Money is integer cents end-to-end; tax replicates datagen's basis-point
+integer formula exactly:
+    rate_bps = round(rate * 10000); mult = 100/50/0 by taxability;
+    tax = (ext_cents * rate_bps * mult + 500_000) // 1_000_000
+implemented with Spark integer `DIV` so no float rounding is involved.
+"""
+
+from pyspark.sql import Column, DataFrame, SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.window import Window
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.models import StoreTypeProfile
+from retail_setup.generation.runtime import store_day_grid
+from retail_setup.generation.schemas import column_names
+
+# (method, mix weight, decline multiplier, processing_ms lo, processing_ms hi)
+TENDERS = [
+    ("CREDIT_CARD", 0.4, 1.0, 1500, 4000),
+    ("DEBIT_CARD", 0.3, 0.8, 1200, 3500),
+    ("CASH", 0.2, 0.0, 500, 2000),
+    ("MOBILE_PAY", 0.1, 1.2, 800, 2500),
+]
+BASE_DECLINE = 0.025
+DECLINE_REASONS = [
+    "INSUFFICIENT_FUNDS", "CARD_EXPIRED", "INVALID_CVV", "NETWORK_ERROR",
+    "FRAUD_SUSPECTED", "CARD_BLOCKED", "LIMIT_EXCEEDED",
+]
+
+_U_MOD = 10**12  # uniform resolution 1e-12 (precision requirement >= 1e-6)
+
+
+def _u(cols: list, salt: str) -> Column:
+    """Uniform [0,1) double from a stable hash of cols + salt."""
+    return (F.abs(F.xxhash64(*cols, F.lit(salt))) % F.lit(_U_MOD)) / F.lit(float(_U_MOD))
+
+
+def _gauss(cols: list, salt: str) -> Column:
+    """Approx standard normal via sum of 3 uniforms (Irwin-Hall), rescaled to sd ~1."""
+    s = _u(cols, salt + "1") + _u(cols, salt + "2") + _u(cols, salt + "3")
+    return (s - F.lit(1.5)) * F.lit(2.0)  # mean 0, sd ~1
+
+
+def _fmt(cents_col: Column) -> Column:
+    """Integer cents -> 'XX.XX' string (no thousands separators)."""
+    return F.format_string("%.2f", cents_col / F.lit(100.0))
+
+
+def _pick_by_weights(u: Column, items: list[tuple[str, float]]) -> Column:
+    """Inverse-CDF categorical pick: ascending cumulative bounds, last as otherwise."""
+    total = sum(w for _, w in items)
+    chain: Column | None = None
+    acc = 0.0
+    for name, w in items[:-1]:
+        acc += w / total
+        cond = u < F.lit(acc)
+        chain = F.when(cond, name) if chain is None else chain.when(cond, name)
+    last = F.lit(items[-1][0])
+    return last if chain is None else chain.otherwise(last)
+
+
+def _pick_hour(u: Column, hourly_weights: list[float]) -> Column:
+    """Inverse-CDF hour pick over the 24 relative weights."""
+    total = sum(hourly_weights)
+    chain: Column | None = None
+    acc = 0.0
+    for h, w in enumerate(hourly_weights[:-1]):
+        acc += w / total
+        cond = u < F.lit(acc)
+        chain = F.when(cond, F.lit(h)) if chain is None else chain.when(cond, F.lit(h))
+    return F.lit(23) if chain is None else chain.otherwise(F.lit(23))
+
+
+def generate_receipts_group(
+    spark: SparkSession,
+    dims: dict[str, DataFrame],
+    profile: StoreTypeProfile,
+    cfg: GenerationConfig,
+) -> dict[str, DataFrame]:
+    """Generate fact_receipts, fact_receipt_lines, fact_payments (in-store only)."""
+
+    def u(cols: list, salt: str) -> Column:
+        return _u(cols, f"{salt}|{cfg.seed}")
+
+    def gauss(cols: list, salt: str) -> Column:
+        return _gauss(cols, f"{salt}|{cfg.seed}")
+
+    def h64(cols: list, salt: str) -> Column:
+        return F.abs(F.xxhash64(*cols, F.lit(f"{salt}|{cfg.seed}")))
+
+    stores = dims["dim_stores"].select(
+        F.col("ID").alias("store_id"), "tax_rate", "daily_traffic_multiplier")
+    store_ids = [r.store_id for r in stores.select("store_id").collect()]
+    grid = store_day_grid(
+        spark, store_ids, cfg.start_date, cfg.end_date, cfg.seed, "receipts"
+    ).join(stores, "store_id")
+
+    # --- per store-day receipt counts: base * daily * monthly * store multiplier
+    dw = profile.daily_weights
+    mw = profile.monthly_weights
+    d_mean = sum(dw) / 7.0
+    m_mean = sum(mw) / 12.0
+    # dayofweek: 1=Sunday..7=Saturday; profile lists Monday-first -> Mon=1..Sun=7
+    daily_w = F.element_at(
+        F.array(*[F.lit(w / d_mean) for w in dw]),
+        ((F.dayofweek(F.col("day")) + 5) % 7) + 1,
+    )
+    monthly_w = F.element_at(F.array(*[F.lit(w / m_mean) for w in mw]), F.month("day"))
+    lam = (F.lit(float(cfg.transactions_per_store_day)) * daily_w * monthly_w
+           * F.col("daily_traffic_multiplier"))
+    n_rcpt = F.greatest(
+        F.lit(1), F.round(lam + gauss(["store_id", "day"], "n") * F.sqrt(lam)))
+    grid = grid.withColumn("n_receipts", n_rcpt.cast("int"))
+
+    # --- explode to receipts; hour from hourly weights (inverse CDF over 24 bins)
+    receipts = (
+        grid.withColumn("seq", F.explode(F.sequence(F.lit(1), F.col("n_receipts"))))
+        .withColumn("hour", _pick_hour(
+            u(["store_id", "day", "seq"], "hour"), profile.hourly_weights))
+        .withColumn("minute", (h64(["store_id", "day", "seq"], "min") % 60).cast("int"))
+        .withColumn("second", (h64(["store_id", "day", "seq"], "sec") % 60).cast("int"))
+        .withColumn("event_ts", F.make_timestamp(
+            F.year("day"), F.month("day"), F.dayofmonth("day"),
+            F.col("hour"), F.col("minute"), F.col("second")))
+        .withColumn("event_date", F.col("day"))
+        # RCP(3) + yyyyMMddHHmm(12) + store(4) + seq(6) = 25 chars, unique by
+        # construction (store_id, day, seq) is a key
+        .withColumn("receipt_id_ext", F.concat(
+            F.lit("RCP"), F.date_format("event_ts", "yyyyMMddHHmm"),
+            F.lpad(F.col("store_id").cast("string"), 4, "0"),
+            F.lpad(F.col("seq").cast("string"), 6, "0")))
+        .withColumn("trace_id", F.concat(F.lit("TRC"), F.col("receipt_id_ext")))
+        .withColumn("customer_id", (h64(["receipt_id_ext"], "cust")
+                                    % F.lit(cfg.customer_count) + 1).cast("long"))
+        .withColumn("basket_n", F.greatest(F.lit(1), F.round(
+            F.lit(profile.basket_lambda)
+            + gauss(["receipt_id_ext"], "basket") * F.sqrt(F.lit(profile.basket_lambda))
+        )).cast("int"))
+        .withColumn("tender_type", _pick_by_weights(
+            u(["receipt_id_ext"], "tender"), [(n, w) for n, w, _, _, _ in TENDERS]))
+    )
+
+    # --- lines: explode baskets, weighted department -> uniform product within dept
+    products = dims["dim_products"].select(
+        F.col("ID").alias("product_id"), F.col("SalePrice"), F.col("taxability"),
+        F.col("Department").alias("department"))
+    pw = Window.partitionBy("department").orderBy("product_id")
+    products_ranked = products.withColumn("dept_rank", F.row_number().over(pw))
+    dept_sizes = products.groupBy("department").agg(F.count("*").alias("dept_size"))
+
+    dept_expr = _pick_by_weights(
+        u(["receipt_id_ext", "line_num"], "dept"),
+        list(profile.department_weights.items()))
+
+    lines = (
+        receipts.select("receipt_id_ext", "event_ts", "event_date", "store_id",
+                        "tax_rate", "basket_n")
+        .withColumn("line_num", F.explode(F.sequence(F.lit(1), F.col("basket_n"))))
+        .withColumn("department", dept_expr)
+        .join(dept_sizes, "department")
+        .withColumn("dept_rank", (h64(["receipt_id_ext", "line_num"], "prod")
+                                  % F.col("dept_size") + 1).cast("int"))
+        .join(products_ranked, ["department", "dept_rank"])
+        .withColumn("quantity", F.greatest(F.lit(1), F.least(F.lit(5), F.round(
+            u(["receipt_id_ext", "line_num"], "qty") * 3 + 0.7).cast("int"))))
+        .withColumn("unit_cents", F.round(F.col("SalePrice") * 100).cast("long"))
+        .withColumn("ext_before", F.col("unit_cents") * F.col("quantity"))
+        .withColumn("has_promo", u(["receipt_id_ext", "line_num"], "promo")
+                    < F.lit(profile.promo_rate))
+        .withColumn("promo_code", F.when(F.col("has_promo"), F.concat(
+            F.lit("PROMO"), F.lit(cfg.store_type[:3].upper()),
+            F.lpad(((h64(["receipt_id_ext", "line_num"], "pcode") % 5) + 1)
+                   .cast("string"), 2, "0"))))
+        .withColumn("discount_cents", F.when(F.col("has_promo"), F.round(
+            F.col("ext_before")
+            * (u(["receipt_id_ext", "line_num"], "disc") * 0.2 + 0.1))
+            .cast("long")).otherwise(F.lit(0).cast("long")))
+        .withColumn("ext_cents",
+                    F.greatest(F.lit(0).cast("long"),
+                               F.col("ext_before") - F.col("discount_cents")))
+        # tax: integer basis-point math, replicating datagen _tax_cents exactly
+        .withColumn("rate_bps", F.round(F.col("tax_rate") * 10000).cast("long"))
+        .withColumn("tax_mult", F.when(F.col("taxability") == "TAXABLE", 100)
+                    .when(F.col("taxability") == "REDUCED_RATE", 50)
+                    .otherwise(0).cast("long"))
+        .withColumn("line_tax_cents", F.floor(
+            (F.col("ext_cents") * F.col("rate_bps") * F.col("tax_mult")
+             + F.lit(500_000)) / F.lit(1_000_000)).cast("long"))
+    )
+
+    fact_receipt_lines = lines.select(
+        "receipt_id_ext", "event_ts", "event_date", "line_num", "product_id",
+        "quantity", _fmt(F.col("unit_cents")).alias("unit_price"), "unit_cents",
+        _fmt(F.col("ext_cents")).alias("ext_price"), "ext_cents", "promo_code",
+    ).select(*column_names("fact_receipt_lines"))
+
+    # --- header rollup
+    hdr = lines.groupBy("receipt_id_ext").agg(
+        F.sum("ext_cents").alias("subtotal_cents"),
+        F.sum("discount_cents").alias("discount_cents"),
+        F.sum("line_tax_cents").alias("tax_cents"))
+    fact_receipts = (
+        receipts.join(hdr, "receipt_id_ext")
+        .withColumn("total_cents", F.col("subtotal_cents") + F.col("tax_cents"))
+        .withColumn("receipt_type", F.lit("SALE"))
+        .withColumn("payment_method", F.col("tender_type"))
+        .select(
+            "receipt_id_ext", "trace_id", "event_ts", "event_date", "store_id",
+            "customer_id", "receipt_type", "tender_type", "subtotal_cents",
+            _fmt(F.col("discount_cents")).alias("discount_amount"), "tax_cents",
+            "total_cents", _fmt(F.col("subtotal_cents")).alias("subtotal_amount"),
+            _fmt(F.col("tax_cents")).alias("tax_amount"),
+            _fmt(F.col("total_cents")).alias("total_amount"), "payment_method",
+            # Legacy semantic-model column (sourceColumn: Subtotal); same value
+            # as subtotal_amount per the TMDL contract.
+            _fmt(F.col("subtotal_cents")).alias("Subtotal"),
+        ).select(*column_names("fact_receipts"))
+    )
+
+    # --- payments (one per receipt; in-store, so order_id_ext is NULL)
+    u_dec = u(["receipt_id_ext"], "decline")
+    decline_p: Column = F.lit(0.0)
+    for name, _, mult, _, _ in TENDERS:
+        decline_p = F.when(
+            F.col("payment_method") == name, F.lit(BASE_DECLINE * mult)
+        ).otherwise(decline_p)
+    proc_lo: Column = F.lit(TENDERS[-1][3])
+    proc_hi: Column = F.lit(TENDERS[-1][4])
+    for name, _, _, lo, hi in TENDERS[:-1]:
+        proc_lo = F.when(F.col("payment_method") == name, F.lit(lo)).otherwise(proc_lo)
+        proc_hi = F.when(F.col("payment_method") == name, F.lit(hi)).otherwise(proc_hi)
+    reason_idx = (h64(["receipt_id_ext"], "reason") % len(DECLINE_REASONS)).cast("int")
+    fact_payments = (
+        fact_receipts
+        .withColumn("order_id_ext", F.lit(None).cast("string"))
+        .withColumn("amount_cents", F.col("total_cents"))
+        .withColumn("transaction_id", F.concat(
+            F.lit("TXN_"), F.unix_timestamp("event_ts").cast("string"), F.lit("_"),
+            F.lpad((h64(["receipt_id_ext"], "txn") % 1_000_000).cast("string"), 6, "0")))
+        .withColumn("status",
+                    F.when(u_dec < decline_p, "DECLINED").otherwise("APPROVED"))
+        .withColumn("decline_reason", F.when(
+            F.col("status") == "DECLINED",
+            F.element_at(F.array(*[F.lit(r) for r in DECLINE_REASONS]),
+                         reason_idx + 1)))
+        .withColumn("processing_time_ms",
+                    (proc_lo + u(["receipt_id_ext"], "proc")
+                     * (proc_hi - proc_lo)).cast("long"))
+        .withColumn("amount", _fmt(F.col("amount_cents")))
+        .select(*column_names("fact_payments"))
+    )
+
+    return {
+        "fact_receipts": fact_receipts,
+        "fact_receipt_lines": fact_receipt_lines,
+        "fact_payments": fact_payments,
+    }

--- a/utility/src/retail_setup/generation/receipts.py
+++ b/utility/src/retail_setup/generation/receipts.py
@@ -157,6 +157,14 @@ def generate_receipts_group(
     products = dims["dim_products"].select(
         F.col("ID").alias("product_id"), F.col("SalePrice"), F.col("taxability"),
         F.col("Department").alias("department"))
+
+    product_departments = {r.department for r in products.select("department").distinct().collect()}
+    unknown = set(profile.department_weights) - product_departments
+    if unknown:
+        raise ValueError(
+            f"profile department_weights reference departments missing from the catalog: {sorted(unknown)}"
+        )
+
     pw = Window.partitionBy("department").orderBy("product_id")
     products_ranked = products.withColumn("dept_rank", F.row_number().over(pw))
     dept_sizes = products.groupBy("department").agg(F.count("*").alias("dept_size"))

--- a/utility/src/retail_setup/generation/runtime.py
+++ b/utility/src/retail_setup/generation/runtime.py
@@ -1,0 +1,45 @@
+"""Deterministic seeding + partition grids for the generation engine."""
+
+import hashlib
+from datetime import date
+
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
+
+
+def derive_seed(global_seed: int, section: str, key: int, day: date) -> int:
+    """Stable 31-bit seed from (global_seed, section, key, day).
+
+    Independent of Spark partitioning/execution order — safe for per-row
+    or per-group RNG seeding.
+    """
+    payload = f"{global_seed}|{section}|{key}|{day.isoformat()}".encode()
+    return int.from_bytes(hashlib.sha256(payload).digest()[:4], "big") % (2**31)
+
+
+def store_day_grid(
+    spark: SparkSession,
+    store_ids: list[int],
+    start: date,
+    end: date,
+    global_seed: int,
+    section: str,
+) -> DataFrame:
+    """store_id x day cross grid with a precomputed per-partition seed column.
+
+    Seeds are computed driver-side (small grid: stores x days) so the engine
+    never depends on F.rand()'s partition-arrangement semantics for keys.
+    """
+    days = spark.sql(
+        f"SELECT explode(sequence(to_date('{start.isoformat()}'), "
+        f"to_date('{end.isoformat()}'), interval 1 day)) AS day"
+    )
+    stores = spark.createDataFrame([(s,) for s in store_ids], "store_id long")
+    grid = stores.crossJoin(days)
+    seed_udf_rows = [
+        (s, d, derive_seed(global_seed, section, s, d))
+        for s in store_ids
+        for d in [r.day for r in days.collect()]
+    ]
+    seeds = spark.createDataFrame(seed_udf_rows, "store_id long, day date, partition_seed long")
+    return grid.join(seeds, ["store_id", "day"])

--- a/utility/src/retail_setup/generation/runtime.py
+++ b/utility/src/retail_setup/generation/runtime.py
@@ -1,10 +1,9 @@
 """Deterministic seeding + partition grids for the generation engine."""
 
 import hashlib
-from datetime import date
+from datetime import date, timedelta
 
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql import functions as F
 
 
 def derive_seed(global_seed: int, section: str, key: int, day: date) -> int:
@@ -32,17 +31,16 @@ def store_day_grid(
     (hundreds of stores x a year ~ 10^5 rows collected on the driver); if a
     grid ever grows past ~10^6, switch the seed column to F.xxhash64 and keep
     derive_seed as the reference with a parity test.
+
+    partition_seed is consumed by pandas-UDF generators (Plan 2b's journey
+    island); fully Spark-native generators derive their own draws via xxhash64
+    and may ignore it.
     """
-    days = spark.sql(
-        f"SELECT explode(sequence(to_date('{start.isoformat()}'), "
-        f"to_date('{end.isoformat()}'), interval 1 day)) AS day"
-    )
-    stores = spark.createDataFrame([(s,) for s in store_ids], "store_id long")
-    grid = stores.crossJoin(days)
-    seed_udf_rows = [
+    day_list = [start + timedelta(days=i) for i in range((end - start).days + 1)]
+    rows = [
         (s, d, derive_seed(global_seed, section, s, d))
         for s in store_ids
-        for d in [r.day for r in days.collect()]
+        for d in day_list
     ]
-    seeds = spark.createDataFrame(seed_udf_rows, "store_id long, day date, partition_seed long")
-    return grid.join(seeds, ["store_id", "day"])
+    # the seeded rows ARE the full grid — no crossJoin/join round-trip needed
+    return spark.createDataFrame(rows, "store_id long, day date, partition_seed long")

--- a/utility/src/retail_setup/generation/runtime.py
+++ b/utility/src/retail_setup/generation/runtime.py
@@ -27,8 +27,11 @@ def store_day_grid(
 ) -> DataFrame:
     """store_id x day cross grid with a precomputed per-partition seed column.
 
-    Seeds are computed driver-side (small grid: stores x days) so the engine
-    never depends on F.rand()'s partition-arrangement semantics for keys.
+    Seeds are computed driver-side so the engine never depends on F.rand()'s
+    partition-arrangement semantics for keys. Fine for realistic grids
+    (hundreds of stores x a year ~ 10^5 rows collected on the driver); if a
+    grid ever grows past ~10^6, switch the seed column to F.xxhash64 and keep
+    derive_seed as the reference with a parity test.
     """
     days = spark.sql(
         f"SELECT explode(sequence(to_date('{start.isoformat()}'), "

--- a/utility/src/retail_setup/generation/schemas.py
+++ b/utility/src/retail_setup/generation/schemas.py
@@ -1,0 +1,124 @@
+"""Authoritative output schemas for generated tables (Plan 2a scope).
+
+Spark simple type strings. Dimension columns keep the legacy PascalCase names
+because the semantic model TMDL binds sourceColumn to them (e.g. StoreNumber,
+Cost, MSRP). Fact tables are snake_case. The TMDL contract test verifies this
+module against fabric/powerbi/retail_model.SemanticModel.
+
+Columns added vs plan (from TMDL audit 2026-06-12):
+  fact_receipts: added ("Subtotal", "string") — legacy trace/aggregate string
+    column bound as sourceColumn: Subtotal in the semantic model. Not a
+    snake_case column; appears to be a pre-existing legacy column the model
+    still references.
+
+Columns in plan but NOT in TMDL (allowed — Direct Lake ignores extra columns):
+  fact_receipts: trace_id, tender_type
+  fact_payments: tender_type (not in payments TMDL at all)
+"""
+
+# table -> list of (column, spark_type)
+TABLES: dict[str, list[tuple[str, str]]] = {
+    "dim_geographies": [
+        ("ID", "long"), ("City", "string"), ("State", "string"), ("ZipCode", "string"),
+        ("District", "string"), ("Region", "string"),
+    ],
+    "dim_stores": [
+        ("ID", "long"), ("StoreNumber", "string"), ("Address", "string"),
+        ("GeographyID", "long"), ("tax_rate", "double"), ("volume_class", "string"),
+        ("store_format", "string"), ("operating_hours", "string"),
+        ("daily_traffic_multiplier", "double"),
+    ],
+    "dim_distribution_centers": [
+        ("ID", "long"), ("DCNumber", "string"), ("Address", "string"),
+        ("GeographyID", "long"),
+    ],
+    "dim_trucks": [
+        ("ID", "long"), ("LicensePlate", "string"), ("Refrigeration", "boolean"),
+        # double, not long: NULL for pool trucks + Direct Lake nullability
+        ("DCID", "double"),
+    ],
+    "dim_customers": [
+        ("ID", "long"), ("FirstName", "string"), ("LastName", "string"),
+        ("Address", "string"), ("GeographyID", "long"), ("LoyaltyCard", "string"),
+        ("Phone", "string"), ("BLEId", "string"), ("AdId", "string"),
+    ],
+    "dim_products": [
+        ("ID", "long"), ("ProductName", "string"), ("Brand", "string"),
+        ("Company", "string"), ("Department", "string"), ("Category", "string"),
+        ("Subcategory", "string"), ("Cost", "double"), ("MSRP", "double"),
+        ("SalePrice", "double"), ("RequiresRefrigeration", "boolean"),
+        ("LaunchDate", "timestamp"), ("taxability", "string"), ("Tags", "string"),
+    ],
+    "dim_date": [
+        ("date_key", "long"), ("date", "date"), ("year", "long"), ("quarter", "long"),
+        ("month", "long"), ("month_name", "string"), ("day", "long"),
+        ("day_of_week", "long"), ("day_name", "string"), ("week_of_year", "long"),
+        ("is_weekend", "long"), ("fiscal_year", "long"), ("fiscal_quarter", "long"),
+    ],
+    "fact_receipts": [
+        ("receipt_id_ext", "string"), ("trace_id", "string"), ("event_ts", "timestamp"),
+        ("event_date", "date"), ("store_id", "long"), ("customer_id", "long"),
+        ("receipt_type", "string"), ("tender_type", "string"),
+        ("subtotal_cents", "long"), ("discount_amount", "string"),
+        ("tax_cents", "long"), ("total_cents", "long"),
+        ("subtotal_amount", "string"), ("tax_amount", "string"),
+        ("total_amount", "string"), ("payment_method", "string"),
+        # Legacy column bound by the semantic model (sourceColumn: Subtotal).
+        # Present in fact_receipts.tmdl as a string column; added here to
+        # satisfy the TMDL contract test (TMDL arbiter rule).
+        ("Subtotal", "string"),
+    ],
+    "fact_receipt_lines": [
+        ("receipt_id_ext", "string"), ("event_ts", "timestamp"), ("event_date", "date"),
+        ("line_num", "int"), ("product_id", "long"), ("quantity", "int"),
+        ("unit_price", "string"), ("unit_cents", "long"),
+        ("ext_price", "string"), ("ext_cents", "long"), ("promo_code", "string"),
+    ],
+    "fact_payments": [
+        ("receipt_id_ext", "string"), ("order_id_ext", "string"),
+        ("event_ts", "timestamp"), ("event_date", "date"),
+        ("payment_method", "string"), ("amount_cents", "long"), ("amount", "string"),
+        ("transaction_id", "string"), ("status", "string"),
+        ("decline_reason", "string"), ("processing_time_ms", "long"),
+        ("store_id", "long"), ("customer_id", "long"),
+    ],
+}
+
+
+_SPARK_TYPE_MAP = None
+
+
+def _type_map():
+    """Lazy-import PySpark type map (avoids import cost when pyspark not installed)."""
+    global _SPARK_TYPE_MAP
+    if _SPARK_TYPE_MAP is None:
+        from pyspark.sql.types import (
+            BooleanType, DateType, DoubleType, IntegerType,
+            LongType, StringType, TimestampType,
+        )
+        _SPARK_TYPE_MAP = {
+            "long": LongType(),
+            "int": IntegerType(),
+            "string": StringType(),
+            "double": DoubleType(),
+            "boolean": BooleanType(),
+            "timestamp": TimestampType(),
+            "date": DateType(),
+        }
+    return _SPARK_TYPE_MAP
+
+
+def spark_schema(table: str):
+    """Build a StructType for createDataFrame with explicit types."""
+    from pyspark.sql.types import StructField, StructType
+
+    tmap = _type_map()
+    fields = [
+        StructField(name, tmap[typ], nullable=True)
+        for name, typ in TABLES[table]
+    ]
+    return StructType(fields)
+
+
+def column_names(table: str) -> list[str]:
+    return [name for name, _ in TABLES[table]]

--- a/utility/src/retail_setup/generation/writer.py
+++ b/utility/src/retail_setup/generation/writer.py
@@ -1,0 +1,13 @@
+"""Thin write layer. Notebooks call write_to_lakehouse; tests use write_table
+with a format/location override (no delta-spark dependency locally)."""
+
+from pyspark.sql import DataFrame
+
+
+def write_table(df: DataFrame, table: str, location: str, fmt: str = "delta") -> None:
+    df.write.format(fmt).mode("overwrite").save(location)
+
+
+def write_to_lakehouse(df: DataFrame, lakehouse: str, schema: str, table: str) -> None:
+    """Overwrite-by-design, matching 02-historical-data-load semantics."""
+    df.write.format("delta").mode("overwrite").saveAsTable(f"{lakehouse}.{schema}.{table}")

--- a/utility/tests/conftest.py
+++ b/utility/tests/conftest.py
@@ -5,3 +5,30 @@ from pathlib import Path
 
 # Make utility/scripts importable so catalog_builder and catalogs/* can be imported directly.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def spark():
+    """Local Spark for unit tests. Small and quiet; one JVM per test session."""
+    import os
+    from pyspark.sql import SparkSession
+
+    # Redirect JVM temp dir to sandbox-writable TMPDIR (macOS sandbox blocks /var/folders).
+    tmpdir = os.environ.get("TMPDIR", "/tmp")
+    java_opts = f"-Djava.io.tmpdir={tmpdir}"
+
+    session = (
+        SparkSession.builder.master("local[2]")
+        .appName("retail-setup-tests")
+        .config("spark.sql.shuffle.partitions", "4")
+        .config("spark.ui.enabled", "false")
+        .config("spark.sql.session.timeZone", "UTC")
+        .config("spark.local.dir", tmpdir)
+        .config("spark.driver.extraJavaOptions", java_opts)
+        .config("spark.executor.extraJavaOptions", java_opts)
+        .getOrCreate()
+    )
+    yield session
+    session.stop()

--- a/utility/tests/conftest.py
+++ b/utility/tests/conftest.py
@@ -13,11 +13,27 @@ import pytest
 def spark():
     """Local Spark for unit tests. Small and quiet; one JVM per test session."""
     import os
+    from pathlib import Path
     from pyspark.sql import SparkSession
 
     # Redirect JVM temp dir to sandbox-writable TMPDIR (macOS sandbox blocks /var/folders).
-    tmpdir = os.environ.get("TMPDIR", "/tmp")
+    # `or` guards CI environments where TMPDIR is set but empty.
+    tmpdir = os.environ.get("TMPDIR") or "/tmp"
     java_opts = f"-Djava.io.tmpdir={tmpdir}"
+
+    # Pin worker Python to the driver's interpreter — otherwise local mode can
+    # pick up a different system Python and fail with a version mismatch.
+    os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
+
+    # Prefer the conda-env JDK (17) over any system JDK when available.
+    # PySpark 3.5 is incompatible with Java 21+ due to Subject.getSubject removal.
+    if "JAVA_HOME" not in os.environ:
+        # Derive conda env root from the running Python interpreter path.
+        _python = Path(sys.executable).resolve()
+        # Typical layout: <env>/bin/python  -> <env>/lib/jvm
+        _env_jdk = _python.parents[1] / "lib" / "jvm"
+        if _env_jdk.exists():
+            os.environ["JAVA_HOME"] = str(_env_jdk)
 
     session = (
         SparkSession.builder.master("local[2]")

--- a/utility/tests/generation/test_dims.py
+++ b/utility/tests/generation/test_dims.py
@@ -1,0 +1,89 @@
+from datetime import date
+
+import pytest
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dim_date, generate_dimensions
+from retail_setup.generation.schemas import column_names
+
+
+@pytest.fixture(scope="module")
+def small_cfg():
+    return GenerationConfig(
+        store_type="grocery", start_date=date(2025, 1, 1), end_date=date(2025, 1, 7),
+        store_count=4, dc_count=2, customer_count=200, seed=42,
+    )
+
+
+@pytest.fixture(scope="module")
+def dicts():
+    return load_dictionaries(default_dictionary_root(), "grocery")
+
+
+@pytest.fixture(scope="module")
+def dims(spark, small_cfg, dicts):
+    return generate_dimensions(spark, dicts, small_cfg)
+
+
+def test_all_dims_present_with_contract_columns(dims):
+    for table in ["dim_geographies", "dim_stores", "dim_distribution_centers",
+                  "dim_trucks", "dim_customers", "dim_products"]:
+        assert table in dims
+        assert dims[table].columns == column_names(table)
+
+
+def test_row_counts(dims, small_cfg, dicts):
+    assert dims["dim_stores"].count() == small_cfg.store_count
+    assert dims["dim_distribution_centers"].count() == small_cfg.dc_count
+    assert dims["dim_customers"].count() == small_cfg.customer_count
+    assert dims["dim_products"].count() == len(dicts.products)
+
+
+def test_fk_integrity(dims):
+    geo_ids = {r.ID for r in dims["dim_geographies"].select("ID").collect()}
+    for t in ["dim_stores", "dim_distribution_centers", "dim_customers"]:
+        refs = {r.GeographyID for r in dims[t].select("GeographyID").collect()}
+        assert refs <= geo_ids, t
+
+
+def test_store_fields(dims):
+    rows = dims["dim_stores"].collect()
+    assert all(r.StoreNumber == f"S{r.ID:06d}" for r in rows)
+    assert all(0 < r.tax_rate < 0.20 for r in rows)
+    assert all(r.daily_traffic_multiplier > 0 for r in rows)
+
+
+def test_product_pricing_invariants(dims):
+    rows = dims["dim_products"].collect()
+    for r in rows:
+        assert 0 < r.Cost < r.SalePrice <= r.MSRP, r.ProductName
+        assert r.taxability in {"TAXABLE", "NON_TAXABLE", "REDUCED_RATE"}
+
+
+def test_trucks_dc_assignment(dims):
+    rows = dims["dim_trucks"].collect()
+    dc_ids = {float(r.ID) for r in dims["dim_distribution_centers"].collect()}
+    assigned = [r for r in rows if r.DCID is not None]
+    pool = [r for r in rows if r.DCID is None]
+    assert assigned and pool  # both populations exist
+    assert {r.DCID for r in assigned} <= dc_ids
+
+
+def test_determinism(spark, small_cfg, dicts):
+    a = generate_dimensions(spark, dicts, small_cfg)
+    b = generate_dimensions(spark, dicts, small_cfg)
+    assert sorted(map(tuple, a["dim_customers"].collect())) == \
+           sorted(map(tuple, b["dim_customers"].collect()))
+
+
+def test_dim_date(spark):
+    df = generate_dim_date(spark, date(2025, 1, 1), date(2025, 12, 31))
+    assert df.columns == column_names("dim_date")
+    rows = {r.date_key: r for r in df.collect()}
+    assert len(rows) == 365
+    r = rows[20250704]  # 2025-07-04, a Friday
+    assert (r.year, r.month, r.day, r.day_of_week) == (2025, 7, 4, 5)
+    assert r.fiscal_year == 2025 and r.fiscal_quarter == 1  # July = FY start
+    sat = rows[20250705]
+    assert sat.is_weekend == 1

--- a/utility/tests/generation/test_profile_effects.py
+++ b/utility/tests/generation/test_profile_effects.py
@@ -1,0 +1,35 @@
+from datetime import date
+
+from pyspark.sql import functions as F
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.receipts import generate_receipts_group
+
+
+def _avg_ticket(spark, store_type: str) -> float:
+    cfg = GenerationConfig(store_type=store_type, start_date=date(2025, 6, 2),
+                           end_date=date(2025, 6, 8), store_count=2, dc_count=1,
+                           customer_count=200, seed=11, transactions_per_store_day=30)
+    dicts = load_dictionaries(default_dictionary_root(), store_type)
+    dims = generate_dimensions(spark, dicts, cfg)
+    g = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    return g["fact_receipts"].agg(F.avg("total_cents")).first()[0] / 100.0
+
+
+def test_luxury_ticket_dwarfs_grocery(spark):
+    lux, gro = _avg_ticket(spark, "luxury"), _avg_ticket(spark, "grocery")
+    assert lux > gro * 5, (lux, gro)
+
+
+def test_grocery_promo_rate_visible(spark):
+    cfg = GenerationConfig(store_type="grocery", start_date=date(2025, 6, 2),
+                           end_date=date(2025, 6, 8), store_count=2, dc_count=1,
+                           customer_count=200, seed=11, transactions_per_store_day=30)
+    dicts = load_dictionaries(default_dictionary_root(), "grocery")
+    dims = generate_dimensions(spark, dicts, cfg)
+    g = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    lines = g["fact_receipt_lines"]
+    promo_share = lines.filter(F.col("promo_code").isNotNull()).count() / lines.count()
+    assert 0.12 < promo_share < 0.32  # profile promo_rate 0.22, loose bounds

--- a/utility/tests/generation/test_receipts.py
+++ b/utility/tests/generation/test_receipts.py
@@ -105,3 +105,32 @@ def test_determinism(spark, cfg, dicts):
     b = generate_receipts_group(spark, dims, dicts.profile, cfg)
     assert sorted(r.receipt_id_ext for r in a["fact_receipts"].collect()) == \
            sorted(r.receipt_id_ext for r in b["fact_receipts"].collect())
+
+
+def test_different_seeds_differ(spark, dicts):
+    def gen(seed):
+        cfg = GenerationConfig(
+            store_type="grocery", start_date=date(2025, 3, 3),
+            end_date=date(2025, 3, 4), store_count=2, dc_count=1,
+            customer_count=100, seed=seed, transactions_per_store_day=20,
+        )
+        dims = generate_dimensions(spark, dicts, cfg)
+        g = generate_receipts_group(spark, dims, dicts.profile, cfg)
+        return {r.receipt_id_ext for r in g["fact_receipts"].collect()}
+
+    assert gen(7) != gen(8)
+
+
+def test_unknown_department_raises(spark, cfg, dicts):
+    dims = generate_dimensions(spark, dicts, cfg)
+    bad_profile = dicts.profile.model_copy(
+        update={"department_weights": {**dicts.profile.department_weights, "Bogus": 0.1}}
+    )
+    with pytest.raises(ValueError, match="Bogus"):
+        generate_receipts_group(spark, dims, bad_profile, cfg)
+
+
+def test_subtotal_mirrors_subtotal_amount(group):
+    from pyspark.sql import functions as F
+    receipts = group["fact_receipts"]
+    assert receipts.filter(F.col("Subtotal") != F.col("subtotal_amount")).count() == 0

--- a/utility/tests/generation/test_receipts.py
+++ b/utility/tests/generation/test_receipts.py
@@ -1,0 +1,107 @@
+from datetime import date
+
+import pytest
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.dictionaries.loader import default_dictionary_root, load_dictionaries
+from retail_setup.generation.dims import generate_dimensions
+from retail_setup.generation.receipts import generate_receipts_group
+from retail_setup.generation.schemas import column_names
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    return GenerationConfig(
+        store_type="grocery", start_date=date(2025, 3, 3), end_date=date(2025, 3, 9),
+        store_count=3, dc_count=1, customer_count=300, seed=7,
+        transactions_per_store_day=40,
+    )
+
+
+@pytest.fixture(scope="module")
+def dicts():
+    return load_dictionaries(default_dictionary_root(), "grocery")
+
+
+@pytest.fixture(scope="module")
+def group(spark, cfg, dicts):
+    dims = generate_dimensions(spark, dicts, cfg)
+    return generate_receipts_group(spark, dims, dicts.profile, cfg)
+
+
+def test_contract_columns(group):
+    for t in ["fact_receipts", "fact_receipt_lines", "fact_payments"]:
+        assert group[t].columns == column_names(t), t
+
+
+def test_receipt_ids_unique_and_formatted(group):
+    df = group["fact_receipts"]
+    n = df.count()
+    assert n > 0
+    assert df.select("receipt_id_ext").distinct().count() == n
+    r = df.first()
+    assert r.receipt_id_ext.startswith("RCP") and len(r.receipt_id_ext) == 25
+
+
+def test_event_fields_populated(group):
+    from pyspark.sql import functions as F
+    for t in ["fact_receipts", "fact_receipt_lines", "fact_payments"]:
+        df = group[t]
+        assert df.filter(F.col("event_ts").isNull() | F.col("event_date").isNull()).count() == 0, t
+
+
+def test_lines_fk_and_math(group, spark):
+    from pyspark.sql import functions as F
+    lines, receipts = group["fact_receipt_lines"], group["fact_receipts"]
+    # every line belongs to a receipt
+    orphans = lines.join(receipts, "receipt_id_ext", "left_anti")
+    assert orphans.count() == 0
+    # ext_cents = unit_cents*quantity - discount  (>= 0)
+    bad = lines.filter(F.col("ext_cents") > F.col("unit_cents") * F.col("quantity"))
+    assert bad.count() == 0
+    assert lines.filter(F.col("ext_cents") < 0).count() == 0
+    # header subtotal equals sum of line ext_cents
+    sums = lines.groupBy("receipt_id_ext").agg(F.sum("ext_cents").alias("line_sum"))
+    joined = receipts.join(sums, "receipt_id_ext")
+    mismatch = joined.filter(F.col("subtotal_cents") != F.col("line_sum"))
+    assert mismatch.count() == 0
+    # total = subtotal + tax (discounts already applied at line level)
+    bad_total = receipts.filter(
+        F.col("total_cents") != F.col("subtotal_cents") + F.col("tax_cents"))
+    assert bad_total.count() == 0
+
+
+def test_payments_one_per_receipt(group):
+    from pyspark.sql import functions as F
+    pay, receipts = group["fact_payments"], group["fact_receipts"]
+    assert pay.count() == receipts.count()
+    assert pay.filter(F.col("order_id_ext").isNotNull()).count() == 0  # in-store only here
+    joined = pay.join(receipts.select("receipt_id_ext", "total_cents"), "receipt_id_ext")
+    assert joined.filter(F.col("amount_cents") != F.col("total_cents")).count() == 0
+    cash_declines = pay.filter((F.col("payment_method") == "CASH") &
+                               (F.col("status") == "DECLINED"))
+    assert cash_declines.count() == 0
+    declined = pay.filter(F.col("status") == "DECLINED")
+    assert declined.filter(F.col("decline_reason").isNull()).count() == 0
+
+
+def test_tender_mix_roughly_matches(group):
+    pay = group["fact_payments"]
+    n = pay.count()
+    cc = pay.filter("payment_method = 'CREDIT_CARD'").count()
+    assert 0.25 < cc / n < 0.55  # 40% nominal, loose bounds for small n
+
+
+def test_volume_in_expected_range(group, cfg):
+    n_days, n_stores = 7, 3
+    expected = cfg.transactions_per_store_day * n_days * n_stores
+    actual = group["fact_receipts"].count()
+    assert 0.4 * expected < actual < 2.0 * expected  # weights+multipliers move it
+
+
+def test_determinism(spark, cfg, dicts):
+    dims = generate_dimensions(spark, dicts, cfg)
+    a = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    b = generate_receipts_group(spark, dims, dicts.profile, cfg)
+    assert sorted(r.receipt_id_ext for r in a["fact_receipts"].collect()) == \
+           sorted(r.receipt_id_ext for r in b["fact_receipts"].collect())

--- a/utility/tests/generation/test_runtime.py
+++ b/utility/tests/generation/test_runtime.py
@@ -1,0 +1,30 @@
+from datetime import date
+
+from retail_setup.generation.runtime import derive_seed, store_day_grid
+
+
+def test_derive_seed_deterministic_and_distinct():
+    a = derive_seed(42, "receipts", 7, date(2025, 3, 1))
+    b = derive_seed(42, "receipts", 7, date(2025, 3, 1))
+    c = derive_seed(42, "receipts", 8, date(2025, 3, 1))
+    d = derive_seed(43, "receipts", 7, date(2025, 3, 1))
+    assert a == b
+    assert len({a, c, d}) == 3
+    assert 0 <= a < 2**31  # numpy-seedable
+
+
+def test_store_day_grid(spark):
+    grid = store_day_grid(
+        spark,
+        store_ids=[1, 2],
+        start=date(2025, 1, 1),
+        end=date(2025, 1, 3),
+        global_seed=42,
+        section="receipts",
+    )
+    rows = grid.collect()
+    assert len(rows) == 6  # 2 stores x 3 days
+    cols = set(grid.columns)
+    assert {"store_id", "day", "partition_seed"} <= cols
+    seeds = {(r.store_id, str(r.day)): r.partition_seed for r in rows}
+    assert len(set(seeds.values())) == 6  # all distinct

--- a/utility/tests/generation/test_schema_contract.py
+++ b/utility/tests/generation/test_schema_contract.py
@@ -1,0 +1,75 @@
+"""Verify schemas.py against the semantic model's TMDL bindings.
+
+For every Plan-2a table that exists in the model: every TMDL sourceColumn must
+exist in our schema with a compatible type. (Our schema MAY have extra columns
+the model doesn't bind — Direct Lake ignores them.)
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from retail_setup.generation.schemas import TABLES
+
+TMDL_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "fabric" / "powerbi" / "retail_model.SemanticModel" / "definition" / "tables"
+)
+
+# TMDL dataType -> acceptable spark types in schemas.py
+TYPE_COMPAT = {
+    "int64": {"long", "int"},
+    "string": {"string"},
+    "double": {"double"},
+    "boolean": {"boolean"},
+    "dateTime": {"timestamp", "date"},
+    "decimal": {"double"},
+}
+
+# column lines look like:  column 'Store Number'  / column StoreNumber
+# with properties dataType: ... and sourceColumn: ... in the following lines
+COLUMN_RE = re.compile(r"^\tcolumn\s+(?:'([^']+)'|(\S+))\s*$", re.MULTILINE)
+
+
+def parse_tmdl_columns(text: str) -> list[tuple[str, str]]:
+    """Return [(sourceColumn, dataType)] for every column block in a TMDL file.
+
+    Splits on tab-indented 'column' lines (the real TMDL format uses tabs).
+    Each block is scanned for dataType and sourceColumn properties.
+    """
+    out = []
+    blocks = re.split(r"^\tcolumn\s+", text, flags=re.MULTILINE)[1:]
+    for block in blocks:
+        dt = re.search(r"dataType:\s*(\w+)", block)
+        sc = re.search(r"sourceColumn:\s*(\S+)", block)
+        name = block.splitlines()[0].strip().strip("'")
+        if dt is None:
+            continue
+        source = sc.group(1).strip("'\"") if sc else name
+        out.append((source, dt.group(1)))
+    return out
+
+
+@pytest.mark.parametrize("table", sorted(TABLES))
+def test_schema_covers_tmdl_bindings(table):
+    tmdl_path = TMDL_DIR / f"{table}.tmdl"
+    if not tmdl_path.exists():
+        pytest.skip(f"{table} not in semantic model")
+    ours = dict(TABLES[table])
+    missing, mismatched = [], []
+    for source_col, tmdl_type in parse_tmdl_columns(tmdl_path.read_text()):
+        if source_col not in ours:
+            missing.append(source_col)
+        elif tmdl_type in TYPE_COMPAT and ours[source_col] not in TYPE_COMPAT[tmdl_type]:
+            mismatched.append((source_col, tmdl_type, ours[source_col]))
+    assert not missing, f"{table}: TMDL binds columns we don't generate: {missing}"
+    assert not mismatched, f"{table}: type mismatches (col, tmdl, ours): {mismatched}"
+
+
+def test_spark_schema_builds(spark):
+    from retail_setup.generation.schemas import spark_schema
+
+    for table in TABLES:
+        schema = spark_schema(table)
+        assert len(schema.fields) == len(TABLES[table])

--- a/utility/tests/generation/test_schema_contract.py
+++ b/utility/tests/generation/test_schema_contract.py
@@ -27,11 +27,6 @@ TYPE_COMPAT = {
     "decimal": {"double"},
 }
 
-# column lines look like:  column 'Store Number'  / column StoreNumber
-# with properties dataType: ... and sourceColumn: ... in the following lines
-COLUMN_RE = re.compile(r"^\tcolumn\s+(?:'([^']+)'|(\S+))\s*$", re.MULTILINE)
-
-
 def parse_tmdl_columns(text: str) -> list[tuple[str, str]]:
     """Return [(sourceColumn, dataType)] for every column block in a TMDL file.
 
@@ -45,6 +40,9 @@ def parse_tmdl_columns(text: str) -> list[tuple[str, str]]:
         sc = re.search(r"sourceColumn:\s*(\S+)", block)
         name = block.splitlines()[0].strip().strip("'")
         if dt is None:
+            continue
+        # DAX calculated columns have no physical sourceColumn — skip them
+        if sc is None and re.search(r"^\t\t(?:expression\s*=|\s*=)", block, re.MULTILINE):
             continue
         source = sc.group(1).strip("'\"") if sc else name
         out.append((source, dt.group(1)))

--- a/utility/tests/generation/test_spark_fixture.py
+++ b/utility/tests/generation/test_spark_fixture.py
@@ -1,0 +1,8 @@
+def test_spark_session_works(spark):
+    df = spark.range(3)
+    assert df.count() == 3
+
+
+def test_spark_session_is_session_scoped(spark):
+    # same JVM across tests — cheap sanity check that the fixture is reused
+    assert spark.sparkContext.appName == "retail-setup-tests"

--- a/utility/tests/generation/test_writer.py
+++ b/utility/tests/generation/test_writer.py
@@ -1,0 +1,16 @@
+from retail_setup.generation.writer import write_table
+
+
+def test_write_table_parquet_roundtrip(spark, tmp_path):
+    df = spark.range(5).withColumnRenamed("id", "ID")
+    # format override lets unit tests avoid delta-spark; Fabric uses the default
+    write_table(df, table="t_demo", location=str(tmp_path / "t_demo"), fmt="parquet")
+    back = spark.read.parquet(str(tmp_path / "t_demo"))
+    assert back.count() == 5
+
+
+def test_write_table_to_catalog_signature():
+    import inspect
+    from retail_setup.generation.writer import write_to_lakehouse
+    params = list(inspect.signature(write_to_lakehouse).parameters)
+    assert params == ["df", "lakehouse", "schema", "table"]

--- a/utility/tests/test_generation_config.py
+++ b/utility/tests/test_generation_config.py
@@ -37,3 +37,18 @@ def test_yaml_round_trip(tmp_path: Path):
     cfg = load_generation_config(p)
     assert cfg.store_type == "grocery"
     assert cfg.store_count == 10
+
+
+def test_scale_defaults_derive_from_store_count():
+    cfg = GenerationConfig(start_date=date(2025, 1, 1), end_date=date(2025, 1, 31),
+                           store_count=40)
+    assert cfg.dc_count == 4          # ~1 DC per 10 stores, min 1
+    assert cfg.customer_count == 40_000  # 1000 per store
+    assert cfg.transactions_per_store_day == 400
+
+
+def test_scale_overrides_respected():
+    cfg = GenerationConfig(start_date=date(2025, 1, 1), end_date=date(2025, 1, 31),
+                           store_count=40, dc_count=2, customer_count=500,
+                           transactions_per_store_day=50)
+    assert (cfg.dc_count, cfg.customer_count, cfg.transactions_per_store_day) == (2, 500, 50)


### PR DESCRIPTION
## Summary

The complete `utility/` setup stack, implementing the full spec (`docs/superpowers/specs/2026-06-12-setup-utility-design.md`) across Plans 2a, 2b, 2c, and 3. Stacked on PR #264 (dictionaries). **174 tests green** (160 utility + 14 deploy framework).

### Generation engine (Plans 2a+2b)
- TMDL-contract-verified schemas; deterministic xxhash64 draws (zero `F.rand`); 7 dims + `dim_date` + all 18 facts + returns; integer-cents money with datagen's exact basis-point tax math; `engine.generate_all` + 38-check invariant runner

### Gold + notebooks (Plan 2c)
- 9 `au.*` Gold aggregates (exact legacy port, explicit money casts)
- `write_all` (catalog + path modes) with `setup_run_log`
- Four committed setup notebooks: pinned-SHA GitHub dictionary fetch with local-first fallback (setup-01), inlined engine source built from `src/` by `scripts/build_notebooks.py` with CI drift check (02–04), UTC session pin, `{{TOKEN}}` parameters with working defaults
- Local E2E harness (full pipeline, no Fabric needed); hash-derived legacy index columns (kills the single-partition write bottleneck)

### CLI + deploy integration (Plan 3)
- `retail-setup configure` — fronts `deploy/config/*.yml` (validated by the framework's own loader, restore-on-failure) + `utility/config.yaml`
- `retail-setup render` — injects the nine settled tokens into `utility/out/`, `DICTIONARY_REF` pinned to the current commit SHA
- `retail-setup deploy` — gated orchestrator over the framework workflow (terraform confirm gate, `--skip-terraform`, `--dry-run`, abort-on-decline), zero credential handling
- `deploy/scripts/build_artifacts.py`: new `setup` notebook group staging rendered notebooks; `lakehouse_name` threaded through `build_workspace`

## Test Plan
- [x] 160/160 utility + 14/14 deploy tests; notebook drift check clean; E2E pipeline test (hardware store type) green
- [x] `retail-setup deploy --dry-run` prints the full 10-step plan, executes nothing (verified in and outside the repo)
- [x] Four final whole-branch reviews across the plans: READY

## Notable review-driven catches across the run
Seed-folding plan bug; source/Source Delta case-collision (now guarded by a permanent test); rank() tie defect; inventory seed timezone bug; notebook drift from hand-edited outputs (fixed at template level); configure env-file crash; dry-run config dependency. Several reviewer false-positives dismissed with evidence (phantom fact tables, departure_time semantics, department 'mismatch').

## Post-merge / manual
Real Fabric deployment (terraform + fabric-cicd + KQL + notebook runs) needs workspace access. Eventstream + pipeline/dashboard item deployment remain framework-gated backlog.