### PR TITLE
fix(utility): handle missing deploy tools

### DIFF
--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -503,6 +503,17 @@ def _echo_step(index: int, total: int, step: DeployStep) -> None:
     typer.echo(f"    {' '.join(step.cmd)}{redirect}")
 
 
+def _missing_executable_message(executable: str) -> str:
+    if executable.lower() == "terraform":
+        return (
+            "Required executable not found: terraform\n"
+            "Install Terraform and ensure it is on PATH, or rerun with "
+            "`retail-setup deploy --skip-terraform` if the Fabric resources "
+            "already exist."
+        )
+    return f"Required executable not found: {executable}\nInstall it and ensure it is on PATH."
+
+
 @app.command()
 def deploy(
     repo_root: Path = typer.Option(
@@ -549,18 +560,27 @@ def deploy(
             if not typer.confirm("Apply this Terraform plan?"):
                 typer.echo("Aborted by user.")
                 raise typer.Exit(code=1)
-        if step.output_file:
-            out_path = repo_root / step.output_file
-            out_path.parent.mkdir(parents=True, exist_ok=True)
-            result = subprocess.run(
-                step.cmd, cwd=repo_root, capture_output=True, text=True
+        try:
+            if step.output_file:
+                out_path = repo_root / step.output_file
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                result = subprocess.run(
+                    step.cmd, cwd=repo_root, capture_output=True, text=True
+                )
+                if result.returncode == 0:
+                    out_path.write_text(result.stdout)
+                elif result.stderr:
+                    typer.echo(result.stderr, err=True)
+            else:
+                result = subprocess.run(step.cmd, cwd=repo_root)
+        except FileNotFoundError:
+            executable = step.cmd[0] if step.cmd else "<unknown>"
+            typer.echo(
+                f"Deploy failed at step {i}/{total}: {step.description}",
+                err=True,
             )
-            if result.returncode == 0:
-                out_path.write_text(result.stdout)
-            elif result.stderr:
-                typer.echo(result.stderr, err=True)
-        else:
-            result = subprocess.run(step.cmd, cwd=repo_root)
+            typer.echo(_missing_executable_message(executable), err=True)
+            raise typer.Exit(code=127) from None
         if result.returncode != 0:
             typer.echo(
                 f"Deploy failed at step {i}/{total} "

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from typer.testing import CliRunner
 
 from retail_setup.cli.main import app, _deploy_plan
@@ -33,3 +35,17 @@ def test_plan_orders_steps_and_gates_apply():
     build_idx = next(i for i, c in enumerate(cmds) if "build_artifacts" in c)
     deploy_idx = next(i for i, c in enumerate(cmds) if "deploy_items" in c)
     assert apply_idx < build_idx < deploy_idx
+
+
+def test_deploy_reports_missing_terraform_without_traceback(monkeypatch):
+    def fake_run(cmd, *args, **kwargs):
+        if cmd and cmd[0] == "terraform":
+            raise FileNotFoundError("terraform")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    result = runner.invoke(app, ["deploy", "--env", "dev", "--yes"])
+    assert result.exit_code == 127, result.output
+    assert "Required executable not found: terraform" in result.output
+    assert "--skip-terraform" in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## Summary
- Catch missing subprocess executables during `retail-setup deploy`.
- Print actionable guidance instead of a Python traceback.
- Add Terraform-specific guidance to install Terraform or rerun with `--skip-terraform` when resources already exist.

## Validation
- `python -m pytest .\utility\tests\test_cli_deploy.py -q`
- `python -m ruff check .\src\retail_setup\cli\main.py .\tests\test_cli_deploy.py`
- `git diff --check origin/main..HEAD`