### PR TITLE
feat(setup): add guided bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,38 @@ only needed for utility development/tests.
 
 Run these commands from PowerShell unless noted otherwise.
 
-### 1. Clone and install the setup utility
+### 1. Clone and run the guided setup
 
 ```powershell
 git clone https://github.com/amattas/retail-demo.git
 Set-Location retail-demo
+python .\scripts\setup.py
+```
 
+The guided setup detects Windows, macOS, or Linux; offers to install missing
+CLI prerequisites with the OS package manager; asks whether to use conda when it
+is available; falls back to `.venv`; installs Python dependencies; runs
+`retail-setup configure`; renders notebooks; and finally asks whether to deploy.
+
+Use `--env` to select the deployment environment file under
+`deploy\config\environments\`. For example, `--env dev` uses
+`deploy\config\environments\dev.yml` and writes generated deployment files under
+`deploy\.generated\dev\`.
+
+```powershell
+python .\scripts\setup.py --env dev
+python .\scripts\setup.py --env dev --deploy
+python .\scripts\setup.py --env dev --dry-run
+```
+
+### 2. Manual install path
+
+Use this path if you prefer to run each step yourself.
+
+```powershell
 py -3.11 -m venv .venv
 .\.venv\Scripts\Activate.ps1
+
 python -m pip install --upgrade pip
 python -m pip install -e .\utility
 ```
@@ -61,7 +85,7 @@ For automated deployment, also install the deployment helpers:
 python -m pip install azure-identity fabric-cicd
 ```
 
-### 2. Configure the target workspace and data generation
+### 3. Configure the target workspace and data generation
 
 Interactive:
 
@@ -99,7 +123,7 @@ This updates:
 `utility\config.yaml` is intentionally ignored by Git because it contains local
 environment choices.
 
-### 3. Render the setup notebooks
+### 4. Render the setup notebooks
 
 ```powershell
 retail-setup render --env dev
@@ -112,7 +136,7 @@ This writes rendered setup notebooks to `utility\out\`:
 - `setup-03-generate-facts.ipynb`
 - `setup-04-build-gold.ipynb`
 
-### 4. Deploy or import the artifacts
+### 5. Deploy or import the artifacts
 
 Manual path:
 
@@ -137,7 +161,7 @@ with `fabric-cicd`, and writes a combined KQL database script to
 The KQL script is not executed automatically. Open the generated script and run
 it in the target Fabric KQL database after the Eventhouse/KQL database exists.
 
-### 5. Run the setup notebooks in Fabric
+### 6. Run the setup notebooks in Fabric
 
 Run these notebooks in order:
 
@@ -159,7 +183,7 @@ Expected Lakehouse output:
   `truck_dwell_daily`, `online_sales_daily`, `zone_dwell_minute`,
   `marketing_cost_daily`, and `tender_mix_daily`.
 
-### 6. Optional live event generation
+### 7. Optional live event generation
 
 `setup-05-stream-events.ipynb` is committed under `utility\notebooks\`, but it is
 not currently rendered to `utility\out\` or staged by `retail-setup deploy`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,28 @@
 
 Utility scripts for configuring and deploying the retail demo components.
 
+## setup.py
+
+Guided cross-platform setup for a new Fabric workspace.
+
+### Purpose
+
+`setup.py` is the single entry point for local setup. It detects the operating
+system, offers to install missing CLI prerequisites with the OS package manager,
+sets up Python with conda or venv, installs Python dependencies, runs
+`retail-setup configure`, renders notebooks, and asks whether to deploy.
+
+### Usage
+
+```powershell
+python scripts\setup.py
+python scripts\setup.py --env dev --dry-run
+python scripts\setup.py --env dev --deploy
+```
+
+`--env` selects `deploy\config\environments\<env>.yml` and scopes generated
+deployment output under `deploy\.generated\<env>\`.
+
 ## configure_semantic_model.py
 
 Configures the Power BI semantic model to connect to your Fabric lakehouse.

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python
+"""Guided cross-platform setup for the retail-demo workspace.
+
+This script intentionally uses only the Python standard library so it can run
+before project dependencies are installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_URL = "https://github.com/amattas/retail-demo/blob/main/README.md"
+MIN_PYTHON = (3, 11)
+
+
+@dataclass(frozen=True)
+class PackageManager:
+    """OS package manager metadata."""
+
+    name: str
+    install_commands: dict[str, list[list[str]]]
+
+
+@dataclass(frozen=True)
+class PythonEnv:
+    """Resolved Python environment used for setup commands."""
+
+    python: Path
+    description: str
+
+
+def _command_exists(command: str) -> bool:
+    return shutil.which(command) is not None
+
+
+def detect_package_manager(system: str | None = None) -> PackageManager | None:
+    """Return the preferred package manager for the current OS."""
+
+    os_name = (system or platform.system()).lower()
+    if os_name == "windows":
+        if _command_exists("winget"):
+            return PackageManager(
+                "winget",
+                {
+                    "git": [
+                        [
+                            "winget",
+                            "install",
+                            "--id",
+                            "Git.Git",
+                            "-e",
+                            "--accept-package-agreements",
+                            "--accept-source-agreements",
+                        ]
+                    ],
+                    "terraform": [
+                        [
+                            "winget",
+                            "install",
+                            "--id",
+                            "Hashicorp.Terraform",
+                            "-e",
+                            "--accept-package-agreements",
+                            "--accept-source-agreements",
+                        ]
+                    ],
+                    "az": [
+                        [
+                            "winget",
+                            "install",
+                            "--id",
+                            "Microsoft.AzureCLI",
+                            "-e",
+                            "--accept-package-agreements",
+                            "--accept-source-agreements",
+                        ]
+                    ],
+                },
+            )
+        if _command_exists("choco"):
+            return PackageManager(
+                "choco",
+                {
+                    "git": [["choco", "install", "git", "-y"]],
+                    "terraform": [["choco", "install", "terraform", "-y"]],
+                    "az": [["choco", "install", "azure-cli", "-y"]],
+                },
+            )
+        return None
+
+    if os_name == "darwin":
+        if not _command_exists("brew"):
+            return None
+        return PackageManager(
+            "brew",
+            {
+                "git": [["brew", "install", "git"]],
+                "terraform": [
+                    ["brew", "tap", "hashicorp/tap"],
+                    ["brew", "install", "hashicorp/tap/terraform"],
+                ],
+                "az": [["brew", "install", "azure-cli"]],
+            },
+        )
+
+    if os_name == "linux":
+        if _command_exists("apt-get"):
+            return PackageManager(
+                "apt-get",
+                {
+                    "git": [["sudo", "apt-get", "install", "-y", "git"]],
+                    "terraform": [
+                        ["sudo", "apt-get", "install", "-y", "terraform"]
+                    ],
+                    "az": [["sudo", "apt-get", "install", "-y", "azure-cli"]],
+                },
+            )
+        if _command_exists("dnf"):
+            return PackageManager(
+                "dnf",
+                {
+                    "git": [["sudo", "dnf", "install", "-y", "git"]],
+                    "terraform": [["sudo", "dnf", "install", "-y", "terraform"]],
+                    "az": [["sudo", "dnf", "install", "-y", "azure-cli"]],
+                },
+            )
+        if _command_exists("yum"):
+            return PackageManager(
+                "yum",
+                {
+                    "git": [["sudo", "yum", "install", "-y", "git"]],
+                    "terraform": [["sudo", "yum", "install", "-y", "terraform"]],
+                    "az": [["sudo", "yum", "install", "-y", "azure-cli"]],
+                },
+            )
+    return None
+
+
+def prerequisites() -> dict[str, str]:
+    """Executables required or commonly used by the setup flow."""
+
+    return {
+        "git": "clone and inspect the repository",
+        "terraform": "provision Fabric resources during deploy",
+        "az": "authenticate with Azure CLI for fabric-cicd",
+    }
+
+
+def missing_prerequisites() -> list[str]:
+    return [command for command in prerequisites() if not _command_exists(command)]
+
+
+def prompt_yes_no(message: str, *, default: bool) -> bool:
+    """Prompt for a yes/no answer."""
+
+    suffix = "Y/n" if default else "y/N"
+    answer = input(f"{message} [{suffix}]: ").strip().lower()
+    if not answer:
+        return default
+    return answer in {"y", "yes"}
+
+
+def prompt_text(message: str, *, default: str) -> str:
+    answer = input(f"{message} [{default}]: ").strip()
+    return answer or default
+
+
+def run_command(command: list[str], *, cwd: Path = REPO_ROOT, dry_run: bool = False) -> None:
+    rendered = " ".join(command)
+    print(f"$ {rendered}")
+    if dry_run:
+        return
+    try:
+        subprocess.run(command, cwd=cwd, check=True)
+    except FileNotFoundError:
+        raise SystemExit(
+            f"Required executable not found: {command[0]}. Install it and ensure it is on PATH."
+        ) from None
+
+
+def install_prerequisites(
+    missing: list[str],
+    *,
+    package_manager: PackageManager | None,
+    dry_run: bool,
+    assume_yes: bool,
+) -> None:
+    """Install missing CLI tools with the detected package manager."""
+
+    if not missing:
+        print("All CLI prerequisites are already on PATH.")
+        return
+
+    descriptions = prerequisites()
+    print("Missing prerequisites:")
+    for command in missing:
+        print(f"  - {command}: {descriptions[command]}")
+
+    if package_manager is None:
+        print("No supported OS package manager was detected.")
+        print("Install the missing tools manually, then rerun this script.")
+        return
+
+    if not assume_yes and not prompt_yes_no(
+        f"Install missing tools with {package_manager.name}?", default=True
+    ):
+        print("Skipping prerequisite installation.")
+        return
+
+    for command in missing:
+        for install_command in package_manager.install_commands.get(command, []):
+            run_command(install_command, dry_run=dry_run)
+
+
+def _conda_env_exists(name: str) -> bool:
+    result = subprocess.run(
+        ["conda", "env", "list"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    return any(line.split() and line.split()[0] == name for line in result.stdout.splitlines())
+
+
+def _conda_python(env_name: str) -> Path:
+    result = subprocess.run(
+        [
+            "conda",
+            "run",
+            "-n",
+            env_name,
+            "python",
+            "-c",
+            "import sys; print(sys.executable)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def ensure_python_env(*, dry_run: bool, assume_yes: bool) -> PythonEnv:
+    """Create or select the Python environment for setup commands."""
+
+    conda_available = _command_exists("conda")
+    use_conda = False
+    if conda_available:
+        use_conda = assume_yes or prompt_yes_no(
+            "Use conda for the Python environment?", default=True
+        )
+
+    if use_conda:
+        env_name = (
+            "retail"
+            if assume_yes
+            else prompt_text("Conda environment name", default="retail")
+        )
+        if not dry_run and not _conda_env_exists(env_name):
+            run_command(
+                [
+                    "conda",
+                    "create",
+                    "-n",
+                    env_name,
+                    f"python={MIN_PYTHON[0]}.{MIN_PYTHON[1]}",
+                    "-y",
+                ]
+            )
+        elif dry_run:
+            run_command(
+                [
+                    "conda",
+                    "create",
+                    "-n",
+                    env_name,
+                    f"python={MIN_PYTHON[0]}.{MIN_PYTHON[1]}",
+                    "-y",
+                ],
+                dry_run=True,
+            )
+        python = (
+            _conda_python(env_name)
+            if not dry_run
+            else Path("conda") / "envs" / env_name / "python"
+        )
+        return PythonEnv(python=python, description=f"conda environment {env_name!r}")
+
+    if sys.version_info < MIN_PYTHON:
+        raise SystemExit(
+            "Python 3.11 or later is required for venv setup. "
+            "Install Python 3.11+ or rerun with conda available."
+        )
+
+    venv_dir = REPO_ROOT / ".venv"
+    if not venv_dir.exists() or dry_run:
+        run_command([sys.executable, "-m", "venv", str(venv_dir)], dry_run=dry_run)
+    python = venv_dir / (
+        "Scripts/python.exe" if platform.system().lower() == "windows" else "bin/python"
+    )
+    return PythonEnv(python=python, description=f"virtual environment at {venv_dir}")
+
+
+def install_python_dependencies(env: PythonEnv, *, dry_run: bool) -> None:
+    print(f"Installing Python dependencies into {env.description}.")
+    run_command(
+        [str(env.python), "-m", "pip", "install", "--upgrade", "pip"],
+        dry_run=dry_run,
+    )
+    run_command(
+        [str(env.python), "-m", "pip", "install", "-e", str(REPO_ROOT / "utility")],
+        dry_run=dry_run,
+    )
+    run_command(
+        [str(env.python), "-m", "pip", "install", "azure-identity", "fabric-cicd"],
+        dry_run=dry_run,
+    )
+
+
+def run_retail_setup(
+    env: PythonEnv,
+    *,
+    deploy_env: str,
+    dry_run: bool,
+    assume_yes: bool,
+    deploy_requested: bool,
+) -> None:
+    run_command(
+        [str(env.python), "-m", "retail_setup.cli.main", "configure", "--env", deploy_env],
+        dry_run=dry_run,
+    )
+    run_command(
+        [str(env.python), "-m", "retail_setup.cli.main", "render", "--env", deploy_env],
+        dry_run=dry_run,
+    )
+    deploy = deploy_requested
+    if not assume_yes and not deploy:
+        deploy = prompt_yes_no("Run `retail-setup deploy` now?", default=False)
+    if deploy:
+        deploy_command = [
+            str(env.python),
+            "-m",
+            "retail_setup.cli.main",
+            "deploy",
+            "--env",
+            deploy_env,
+        ]
+        if assume_yes:
+            deploy_command.append("--yes")
+        run_command(deploy_command, dry_run=dry_run)
+    else:
+        print("Skipping deploy.")
+        print(f"Deployment docs: {DOCS_URL}")
+        print("Run later with: retail-setup deploy --env " + deploy_env)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Guided retail-demo setup")
+    parser.add_argument(
+        "--env",
+        default="dev",
+        help=(
+            "Deployment environment name. This selects deploy/config/environments/<env>.yml "
+            "and scopes generated files under deploy/.generated/<env>/."
+        ),
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without running them.")
+    parser.add_argument("--yes", action="store_true", help="Accept setup prompts with defaults.")
+    parser.add_argument("--deploy", action="store_true", help="Run deploy after configure/render.")
+    parser.add_argument(
+        "--skip-prereqs",
+        action="store_true",
+        help="Skip OS package-manager prerequisite installation.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    print(f"Repository: {REPO_ROOT}")
+    print(f"Deployment environment: {args.env}")
+    print(
+        "`--env` selects deploy/config/environments/"
+        f"{args.env}.yml and deploy/.generated/{args.env}/ outputs."
+    )
+
+    if not args.skip_prereqs:
+        install_prerequisites(
+            missing_prerequisites(),
+            package_manager=detect_package_manager(),
+            dry_run=args.dry_run,
+            assume_yes=args.yes,
+        )
+
+    env = ensure_python_env(dry_run=args.dry_run, assume_yes=args.yes)
+    install_python_dependencies(env, dry_run=args.dry_run)
+    run_retail_setup(
+        env,
+        deploy_env=args.env,
+        dry_run=args.dry_run,
+        assume_yes=args.yes,
+        deploy_requested=args.deploy,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_setup_bootstrap.py
+++ b/tests/scripts/test_setup_bootstrap.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_setup_module():
+    path = Path(__file__).resolve().parents[2] / "scripts" / "setup.py"
+    spec = importlib.util.spec_from_file_location("retail_demo_setup", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+setup = _load_setup_module()
+
+
+def test_detect_package_manager_prefers_winget_on_windows(monkeypatch):
+    monkeypatch.setattr(setup, "_command_exists", lambda command: command == "winget")
+
+    manager = setup.detect_package_manager("Windows")
+
+    assert manager is not None
+    assert manager.name == "winget"
+    assert manager.install_commands["terraform"][0][:4] == [
+        "winget",
+        "install",
+        "--id",
+        "Hashicorp.Terraform",
+    ]
+
+
+def test_detect_package_manager_uses_brew_on_macos(monkeypatch):
+    monkeypatch.setattr(setup, "_command_exists", lambda command: command == "brew")
+
+    manager = setup.detect_package_manager("Darwin")
+
+    assert manager is not None
+    assert manager.name == "brew"
+    assert ["brew", "install", "azure-cli"] in manager.install_commands["az"]
+
+
+def test_install_prerequisites_dry_run_records_commands(monkeypatch):
+    commands = []
+    manager = setup.PackageManager(
+        "testpm",
+        {"terraform": [["testpm", "install", "terraform"]]},
+    )
+    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+
+    setup.install_prerequisites(
+        ["terraform"],
+        package_manager=manager,
+        dry_run=True,
+        assume_yes=True,
+    )
+
+    assert commands == [["testpm", "install", "terraform"]]
+
+
+def test_run_retail_setup_dry_run_without_deploy(monkeypatch):
+    commands = []
+    env = setup.PythonEnv(Path("python"), "test")
+    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+    monkeypatch.setattr(setup, "prompt_yes_no", lambda *_, **__: False)
+
+    setup.run_retail_setup(
+        env,
+        deploy_env="qa",
+        dry_run=True,
+        assume_yes=False,
+        deploy_requested=False,
+    )
+
+    assert commands == [
+        ["python", "-m", "retail_setup.cli.main", "configure", "--env", "qa"],
+        ["python", "-m", "retail_setup.cli.main", "render", "--env", "qa"],
+    ]
+
+
+def test_run_retail_setup_deploy_flag_runs_deploy(monkeypatch):
+    commands = []
+    env = setup.PythonEnv(Path("python"), "test")
+    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+
+    setup.run_retail_setup(
+        env,
+        deploy_env="qa",
+        dry_run=True,
+        assume_yes=True,
+        deploy_requested=True,
+    )
+
+    assert commands[-1] == [
+        "python",
+        "-m",
+        "retail_setup.cli.main",
+        "deploy",
+        "--env",
+        "qa",
+        "--yes",
+    ]

--- a/utility/README.md
+++ b/utility/README.md
@@ -9,7 +9,7 @@ legacy reference only.
 
 ## Supported workflow
 
-1. Install the utility.
+1. Run the guided setup script, or install the utility manually.
 2. Run `retail-setup configure` to write deployment and generation settings.
 3. Run `retail-setup render` to produce workspace-specific setup notebooks.
 4. Import notebooks manually, or run `retail-setup deploy`.
@@ -33,7 +33,38 @@ Required only for `retail-setup deploy`:
 Fabric provides Spark for the notebooks. Local PySpark is only needed for
 development tests.
 
-## Install
+## Guided setup
+
+From the repository root:
+
+```powershell
+python .\scripts\setup.py
+```
+
+The guided setup script:
+
+1. Detects Windows, macOS, or Linux.
+2. Offers to install missing CLI prerequisites with the OS package manager
+   (`winget`/Chocolatey, Homebrew, `apt-get`, `dnf`, or `yum`).
+3. Uses conda when available and accepted; otherwise creates `.venv`.
+4. Installs Python dependencies.
+5. Runs `retail-setup configure`.
+6. Runs `retail-setup render`.
+7. Asks whether to run `retail-setup deploy`.
+
+Examples:
+
+```powershell
+python .\scripts\setup.py --env dev
+python .\scripts\setup.py --env dev --deploy
+python .\scripts\setup.py --env dev --dry-run
+```
+
+`--env` selects `deploy\config\environments\<env>.yml` and generated outputs
+under `deploy\.generated\<env>\`. Use separate environment names for separate
+workspace targets, such as `dev`, `test`, or `prod`.
+
+## Manual install
 
 From the repository root:
 

--- a/website/docs/setup/01-data-generation.md
+++ b/website/docs/setup/01-data-generation.md
@@ -4,14 +4,34 @@ The current data-generation path runs inside Fabric Spark through rendered setup
 notebooks. You do not need to run the deprecated local FastAPI data generator for
 a new workspace.
 
-## Step 1.1: Install `retail-setup`
+## Step 1.1: Run guided setup
 
 From PowerShell:
 
 ```powershell
 git clone https://github.com/amattas/retail-demo.git
 Set-Location retail-demo
+python .\scripts\setup.py
+```
 
+The guided setup detects your OS, offers to install missing prerequisites,
+sets up Python with conda or venv, installs dependencies, runs configure,
+renders notebooks, and asks whether to deploy.
+
+`--env` selects `deploy/config/environments/<env>.yml` and writes generated
+deployment files under `deploy/.generated/<env>/`.
+
+```powershell
+python .\scripts\setup.py --env dev
+python .\scripts\setup.py --env dev --deploy
+python .\scripts\setup.py --env dev --dry-run
+```
+
+## Step 1.2: Manual install path
+
+Use this path if you prefer to run each command yourself.
+
+```powershell
 py -3.11 -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
@@ -24,7 +44,7 @@ For automated deployment, also install:
 python -m pip install azure-identity fabric-cicd
 ```
 
-## Step 1.2: Configure workspace and generation settings
+## Step 1.3: Configure workspace and generation settings
 
 Interactive:
 
@@ -61,7 +81,7 @@ This writes:
 
 `utility/config.yaml` is ignored by Git.
 
-## Step 1.3: Render notebooks
+## Step 1.4: Render notebooks
 
 ```powershell
 retail-setup render --env dev
@@ -74,7 +94,7 @@ Rendered notebooks are written to `utility/out/`:
 - `setup-03-generate-facts.ipynb`
 - `setup-04-build-gold.ipynb`
 
-## Step 1.4: Choose deployment path
+## Step 1.5: Choose deployment path
 
 Manual import:
 

--- a/website/docs/setup/configuration.md
+++ b/website/docs/setup/configuration.md
@@ -7,6 +7,11 @@ The current setup path stores configuration in two places:
 
 Run `retail-setup configure` to update both.
 
+The `--env` flag names the deployment environment. For example, `--env dev`
+uses `deploy/config/environments/dev.yml` and writes generated deployment
+artifacts under `deploy/.generated/dev/`. Use separate environment names for
+separate workspace targets.
+
 ## Deployment settings
 
 `retail-setup configure` updates:


### PR DESCRIPTION
## Summary
- Add `scripts/setup.py`, a single guided setup/configuration entry point for Windows, macOS, and Linux.
- Detect OS package managers (`winget`/Chocolatey, Homebrew, `apt-get`, `dnf`, `yum`) and offer to install missing CLI prerequisites.
- Ask to use conda when available, create/select the requested conda env, or fall back to `.venv`.
- Install Python dependencies, run `retail-setup configure`, run `retail-setup render`, and optionally deploy.
- Update root, utility, script, and website setup docs; clarify what `--env` selects.

## Validation
- `python -m pytest .\tests\scripts\test_setup_bootstrap.py -q`
- `python -m ruff check .\scripts\setup.py .\tests\scripts\test_setup_bootstrap.py`
- `python .\scripts\setup.py --dry-run --yes --skip-prereqs --env qa`
- `python .\scripts\setup.py --dry-run --yes --skip-prereqs --env qa --deploy`
- `npm ci --no-audit --no-fund` and `npm run build` under `website\`
- `git diff --check`

## Notes
- The bootstrapper is standard-library only so it can run before project dependencies are installed.
- Actual package-manager installs remain interactive unless `--yes` is passed.