### PR TITLE
fix(setup): use current Python environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ python .\scripts\setup.py
 The guided setup detects Windows, macOS, or Linux; offers to install missing
 CLI prerequisites with the OS package manager; installs Python dependencies into
 the environment that launched the script; runs `retail-setup configure`; renders
-notebooks; and finally asks whether to deploy.
+notebooks; and finally asks whether to deploy. When you deploy, it signs in to
+the configured Azure tenant with `az login --tenant <tenant_id>` first (unless
+the active Azure CLI tenant already matches).
 
 Use `--env` to select the deployment environment file under
 `deploy\config\environments\`. For example, `--env dev` uses

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Use `--env` to select the deployment environment file under
 .\scripts\setup.ps1 --env dev
 .\scripts\setup.ps1 --env dev --deploy
 .\scripts\setup.ps1 --env dev --dry-run
+.\scripts\setup.ps1 --env dev --recreate   # clean slate: destroy + recreate the workspace
 ```
 
 ### 2. Manual install path

--- a/README.md
+++ b/README.md
@@ -48,15 +48,21 @@ Run these commands from PowerShell unless noted otherwise.
 ```powershell
 git clone https://github.com/amattas/retail-demo.git
 Set-Location retail-demo
-python .\scripts\setup.py
+.\scripts\setup.ps1
 ```
+
+`setup.ps1` is the Windows entry point — it works even with nothing installed.
+It uses Python 3.11+ if present, otherwise installs Miniforge with winget and
+creates a conda environment, then runs the guided setup. On macOS and Linux,
+activate a Python 3.11+ environment and run `python ./scripts/setup.py` instead.
 
 The guided setup detects Windows, macOS, or Linux; offers to install missing
 CLI prerequisites with the OS package manager; installs Python dependencies into
 the environment that launched the script; runs `retail-setup configure`; renders
-notebooks; and finally asks whether to deploy. When you deploy, it signs in to
-the configured Azure tenant with `az login --tenant <tenant_id>` first (unless
-the active Azure CLI tenant already matches).
+notebooks; and finally asks whether to deploy. When you deploy, it always signs
+in to the configured Azure tenant first (`az login --tenant <tenant_id>` for
+`auth.mode: azure_cli`, or `Connect-AzAccount` for `auth.mode: azure_powershell`)
+so deployment never runs under the wrong account.
 
 Use `--env` to select the deployment environment file under
 `deploy\config\environments\`. For example, `--env dev` uses
@@ -64,9 +70,9 @@ Use `--env` to select the deployment environment file under
 `deploy\.generated\dev\`.
 
 ```powershell
-python .\scripts\setup.py --env dev
-python .\scripts\setup.py --env dev --deploy
-python .\scripts\setup.py --env dev --dry-run
+.\scripts\setup.ps1 --env dev
+.\scripts\setup.ps1 --env dev --deploy
+.\scripts\setup.ps1 --env dev --dry-run
 ```
 
 ### 2. Manual install path

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ python .\scripts\setup.py
 ```
 
 The guided setup detects Windows, macOS, or Linux; offers to install missing
-CLI prerequisites with the OS package manager; asks whether to use conda when it
-is available; falls back to `.venv`; installs Python dependencies; runs
-`retail-setup configure`; renders notebooks; and finally asks whether to deploy.
+CLI prerequisites with the OS package manager; installs Python dependencies into
+the environment that launched the script; runs `retail-setup configure`; renders
+notebooks; and finally asks whether to deploy.
 
 Use `--env` to select the deployment environment file under
 `deploy\config\environments\`. For example, `--env dev` uses
@@ -69,7 +69,9 @@ python .\scripts\setup.py --env dev --dry-run
 
 ### 2. Manual install path
 
-Use this path if you prefer to run each step yourself.
+Use this path if you prefer to create or activate an environment yourself before
+running setup. If you use conda, activate the conda environment first; if you use
+venv, create and activate it first.
 
 ```powershell
 py -3.11 -m venv .venv

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -104,5 +104,5 @@ After the Eventhouse and KQL database exist:
 | `setup notebooks not rendered` | Run `retail-setup render --env <env>` before building/deploying the `setup` notebook group. |
 | `terraform` command not found | Install Terraform or use `--skip-terraform` when resources already exist. |
 | `fabric_cicd` import error | Install `fabric-cicd` in the active Python environment. |
-| Authentication failure | Run `az login --tenant <tenant-id>` for `azure_cli`, or `Connect-AzAccount -Tenant <tenant-id>` for `azure_powershell`. |
+| Authentication failure | Run `az account show --query "{tenantId:tenantId,user:user.name,name:name}" -o table` and confirm it matches deploy config. Run `az login --tenant <tenant-id>` for `azure_cli`, or `Connect-AzAccount -Tenant <tenant-id>` for `azure_powershell`. |
 | KQL tables missing | Run the generated `database.kql` script manually in the target KQL database. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,8 +10,9 @@ Guided cross-platform setup for a new Fabric workspace.
 
 `setup.py` is the single entry point for local setup. It detects the operating
 system, offers to install missing CLI prerequisites with the OS package manager,
-sets up Python with conda or venv, installs Python dependencies, runs
-`retail-setup configure`, renders notebooks, and asks whether to deploy.
+uses the Python environment that launched the script, installs Python
+dependencies, runs `retail-setup configure`, renders notebooks, and asks whether
+to deploy.
 
 ### Usage
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,17 +2,33 @@
 
 Utility scripts for configuring and deploying the retail demo components.
 
+## setup.ps1 (Windows entry point)
+
+Guided Windows bootstrap. It ensures a Python 3.11+ environment exists —
+using Python on PATH if suitable, otherwise installing Miniforge with winget and
+creating a conda environment — then delegates to `setup.py`. All arguments are
+forwarded.
+
+```powershell
+.\scripts\setup.ps1
+.\scripts\setup.ps1 --env dev --dry-run
+.\scripts\setup.ps1 --env dev --deploy
+```
+
+On macOS and Linux, activate a Python 3.11+ environment and run `setup.py`
+directly.
+
 ## setup.py
 
-Guided cross-platform setup for a new Fabric workspace.
+Guided cross-platform setup engine for a new Fabric workspace.
 
 ### Purpose
 
-`setup.py` is the single entry point for local setup. It detects the operating
-system, offers to install missing CLI prerequisites with the OS package manager,
-uses the Python environment that launched the script, installs Python
-dependencies, runs `retail-setup configure`, renders notebooks, and asks whether
-to deploy.
+`setup.py` is the single entry point for local setup logic. It detects the
+operating system, offers to install missing CLI prerequisites with the OS
+package manager, uses the Python environment that launched the script, installs
+Python dependencies, runs `retail-setup configure`, renders notebooks, signs in
+to the configured Azure tenant, and asks whether to deploy.
 
 ### Usage
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,106 @@
+<#
+.SYNOPSIS
+    Windows bootstrap for the retail-demo guided setup.
+
+.DESCRIPTION
+    Ensures a Python 3.11+ environment exists, then delegates to
+    scripts/setup.py. When neither a suitable Python nor conda is found, this
+    script installs Miniforge with winget and creates a conda environment so
+    users with nothing installed can still run the guided setup.
+
+    All arguments are forwarded to scripts/setup.py, for example:
+        ./scripts/setup.ps1 --env dev
+        ./scripts/setup.ps1 --env dev --deploy
+        ./scripts/setup.ps1 --env dev --dry-run
+
+.NOTES
+    On macOS and Linux, run scripts/setup.py directly with an activated
+    Python 3.11+ environment.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $ForwardArgs
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$SetupPy = Join-Path $PSScriptRoot 'setup.py'
+$CondaEnvName = 'retail'
+
+function Test-PythonVersion {
+    param([string] $PythonExe)
+    try {
+        $version = & $PythonExe -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>$null
+        if (-not $version) { return $false }
+        $parts = $version.Trim().Split('.')
+        return ([int]$parts[0] -gt 3) -or ([int]$parts[0] -eq 3 -and [int]$parts[1] -ge 11)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Resolve-Conda {
+    $conda = Get-Command conda -ErrorAction SilentlyContinue
+    if ($conda) { return $conda.Source }
+    $candidates = @(
+        (Join-Path $env:USERPROFILE 'miniforge3\Scripts\conda.exe'),
+        (Join-Path $env:USERPROFILE 'miniconda3\Scripts\conda.exe'),
+        'C:\ProgramData\miniforge3\Scripts\conda.exe',
+        'C:\ProgramData\miniconda3\Scripts\conda.exe'
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) { return $candidate }
+    }
+    return $null
+}
+
+function Install-Miniforge {
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        throw 'winget is not available. Install Python 3.11+ or Miniforge manually, then re-run.'
+    }
+    Write-Host 'Installing Miniforge with winget...'
+    winget install --id CondaForge.Miniforge3 -e `
+        --accept-package-agreements --accept-source-agreements
+    $conda = Resolve-Conda
+    if (-not $conda) {
+        throw 'Miniforge install completed but conda was not found. Open a new shell and re-run.'
+    }
+    return $conda
+}
+
+function Get-CondaPython {
+    param([string] $Conda, [string] $EnvName)
+    $envs = & $Conda env list
+    $exists = $envs | Where-Object { ($_ -split '\s+')[0] -eq $EnvName }
+    if (-not $exists) {
+        Write-Host "Creating conda environment '$EnvName' (Python 3.11)..."
+        & $Conda create -n $EnvName 'python=3.11' -y
+    }
+    $python = & $Conda run -n $EnvName python -c 'import sys; print(sys.executable)'
+    return $python.Trim()
+}
+
+# 1) Use the active interpreter when it is already Python 3.11+.
+$python = $null
+$current = Get-Command python -ErrorAction SilentlyContinue
+if ($current -and (Test-PythonVersion $current.Source)) {
+    $python = $current.Source
+    Write-Host "Using Python on PATH: $python"
+}
+
+# 2) Otherwise use (or create) a conda environment, installing Miniforge if needed.
+if (-not $python) {
+    $conda = Resolve-Conda
+    if (-not $conda) {
+        $conda = Install-Miniforge
+    }
+    $python = Get-CondaPython -Conda $conda -EnvName $CondaEnvName
+    Write-Host "Using conda environment '$CondaEnvName': $python"
+}
+
+# 3) Delegate to the Python guided setup engine.
+& $python $SetupPy @ForwardArgs
+exit $LASTEXITCODE

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -178,6 +178,10 @@ def run_command(command: list[str], *, cwd: Path = REPO_ROOT, dry_run: bool = Fa
         raise SystemExit(
             f"Required executable not found: {command[0]}. Install it and ensure it is on PATH."
         ) from None
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(
+            f"Command failed with exit code {exc.returncode}: {rendered}"
+        ) from None
 
 
 def install_prerequisites(

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -167,11 +167,6 @@ def prompt_yes_no(message: str, *, default: bool) -> bool:
     return answer in {"y", "yes"}
 
 
-def prompt_text(message: str, *, default: str) -> str:
-    answer = input(f"{message} [{default}]: ").strip()
-    return answer or default
-
-
 def run_command(command: list[str], *, cwd: Path = REPO_ROOT, dry_run: bool = False) -> None:
     rendered = " ".join(command)
     print(f"$ {rendered}")
@@ -219,95 +214,15 @@ def install_prerequisites(
             run_command(install_command, dry_run=dry_run)
 
 
-def _conda_env_exists(name: str) -> bool:
-    result = subprocess.run(
-        ["conda", "env", "list"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        return False
-    return any(line.split() and line.split()[0] == name for line in result.stdout.splitlines())
-
-
-def _conda_python(env_name: str) -> Path:
-    result = subprocess.run(
-        [
-            "conda",
-            "run",
-            "-n",
-            env_name,
-            "python",
-            "-c",
-            "import sys; print(sys.executable)",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return Path(result.stdout.strip())
-
-
-def ensure_python_env(*, dry_run: bool, assume_yes: bool) -> PythonEnv:
-    """Create or select the Python environment for setup commands."""
-
-    conda_available = _command_exists("conda")
-    use_conda = False
-    if conda_available:
-        use_conda = assume_yes or prompt_yes_no(
-            "Use conda for the Python environment?", default=True
-        )
-
-    if use_conda:
-        env_name = (
-            "retail"
-            if assume_yes
-            else prompt_text("Conda environment name", default="retail")
-        )
-        if not dry_run and not _conda_env_exists(env_name):
-            run_command(
-                [
-                    "conda",
-                    "create",
-                    "-n",
-                    env_name,
-                    f"python={MIN_PYTHON[0]}.{MIN_PYTHON[1]}",
-                    "-y",
-                ]
-            )
-        elif dry_run:
-            run_command(
-                [
-                    "conda",
-                    "create",
-                    "-n",
-                    env_name,
-                    f"python={MIN_PYTHON[0]}.{MIN_PYTHON[1]}",
-                    "-y",
-                ],
-                dry_run=True,
-            )
-        python = (
-            _conda_python(env_name)
-            if not dry_run
-            else Path("conda") / "envs" / env_name / "python"
-        )
-        return PythonEnv(python=python, description=f"conda environment {env_name!r}")
+def current_python_env() -> PythonEnv:
+    """Use the Python interpreter that launched this setup script."""
 
     if sys.version_info < MIN_PYTHON:
         raise SystemExit(
-            "Python 3.11 or later is required for venv setup. "
-            "Install Python 3.11+ or rerun with conda available."
+            "Python 3.11 or later is required. Activate a Python 3.11+ conda "
+            "environment or virtual environment, then rerun this script."
         )
-
-    venv_dir = REPO_ROOT / ".venv"
-    if not venv_dir.exists() or dry_run:
-        run_command([sys.executable, "-m", "venv", str(venv_dir)], dry_run=dry_run)
-    python = venv_dir / (
-        "Scripts/python.exe" if platform.system().lower() == "windows" else "bin/python"
-    )
-    return PythonEnv(python=python, description=f"virtual environment at {venv_dir}")
+    return PythonEnv(python=Path(sys.executable), description="current Python environment")
 
 
 def install_python_dependencies(env: PythonEnv, *, dry_run: bool) -> None:
@@ -401,7 +316,7 @@ def main() -> int:
             assume_yes=args.yes,
         )
 
-    env = ensure_python_env(dry_run=args.dry_run, assume_yes=args.yes)
+    env = current_python_env()
     install_python_dependencies(env, dry_run=args.dry_run)
     run_retail_setup(
         env,

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -292,27 +292,34 @@ def read_deploy_auth(deploy_env: str) -> tuple[str, str | None]:
     return auth_mode, tenant_id
 
 
-def _active_az_tenant(az: str) -> str | None:
-    result = subprocess.run(
-        [az, "account", "show", "--query", "tenantId", "-o", "tsv"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
+def _powershell_login_command(tenant_id: str) -> list[str] | None:
+    pwsh = shutil.which("pwsh") or shutil.which("powershell")
+    if pwsh is None:
         return None
-    return result.stdout.strip() or None
+    return [pwsh, "-NoProfile", "-Command", f"Connect-AzAccount -Tenant {tenant_id}"]
 
 
 def ensure_azure_login(deploy_env: str, *, dry_run: bool) -> None:
-    """Sign in to the configured Azure tenant before deploy when needed.
+    """Sign in to the configured Azure tenant before deploy.
 
-    Only acts for `auth.mode: azure_cli`. Skips login when the active Azure CLI
-    tenant already matches the configured tenant_id.
+    Always runs the login command so deploy never proceeds under the wrong
+    account or tenant. Supports `auth.mode: azure_cli` (`az login`) and
+    `auth.mode: azure_powershell` (`Connect-AzAccount`).
     """
 
     auth_mode, tenant_id = read_deploy_auth(deploy_env)
-    if auth_mode != "azure_cli" or not tenant_id:
+    if not tenant_id:
+        return
+
+    if auth_mode == "azure_powershell":
+        login = _powershell_login_command(tenant_id)
+        if login is None:
+            raise SystemExit(
+                "PowerShell is required for auth.mode=azure_powershell but was "
+                "not found on PATH."
+            )
+        print(f"Signing in to Azure tenant {tenant_id} with Azure PowerShell.")
+        run_command(login, dry_run=dry_run)
         return
 
     az = _resolve_az()
@@ -321,19 +328,7 @@ def ensure_azure_login(deploy_env: str, *, dry_run: bool) -> None:
             "Azure CLI (az) is required for deploy but was not found on PATH. "
             "Install Azure CLI, or set deploy config auth.mode to azure_powershell."
         )
-
-    active_tenant = None if dry_run else _active_az_tenant(az)
-    if active_tenant and active_tenant.lower() == tenant_id.lower():
-        print(f"Azure CLI already signed in to tenant {tenant_id}.")
-        return
-
-    if active_tenant:
-        print(
-            f"Active Azure CLI tenant {active_tenant} does not match "
-            f"configured tenant {tenant_id}; signing in."
-        )
-    else:
-        print(f"Signing in to Azure tenant {tenant_id}.")
+    print(f"Signing in to Azure tenant {tenant_id}.")
     run_command([az, "login", "--tenant", tenant_id], dry_run=dry_run)
 
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -339,6 +339,7 @@ def run_retail_setup(
     dry_run: bool,
     assume_yes: bool,
     deploy_requested: bool,
+    recreate: bool = False,
 ) -> None:
     run_command(
         [str(env.python), "-m", "retail_setup.cli.main", "configure", "--env", deploy_env],
@@ -361,6 +362,8 @@ def run_retail_setup(
             "--env",
             deploy_env,
         ]
+        if recreate:
+            deploy_command.append("--recreate")
         if assume_yes:
             deploy_command.append("--yes")
         run_command(deploy_command, dry_run=dry_run)
@@ -383,6 +386,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dry-run", action="store_true", help="Print commands without running them.")
     parser.add_argument("--yes", action="store_true", help="Accept setup prompts with defaults.")
     parser.add_argument("--deploy", action="store_true", help="Run deploy after configure/render.")
+    parser.add_argument(
+        "--recreate",
+        action="store_true",
+        help="Destroy and recreate the workspace during deploy (clean slate).",
+    )
     parser.add_argument(
         "--skip-prereqs",
         action="store_true",
@@ -415,7 +423,8 @@ def main() -> int:
         deploy_env=args.env,
         dry_run=args.dry_run,
         assume_yes=args.yes,
-        deploy_requested=args.deploy,
+        deploy_requested=args.deploy or args.recreate,
+        recreate=args.recreate,
     )
     return 0
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -245,6 +246,97 @@ def install_python_dependencies(env: PythonEnv, *, dry_run: bool) -> None:
     )
 
 
+def _resolve_az() -> str | None:
+    """Resolve the Azure CLI executable, including the Windows az.cmd shim."""
+
+    return shutil.which("az") or shutil.which("az.cmd") or shutil.which("az.exe")
+
+
+def _extract_tenant_id(text: str) -> str | None:
+    match = re.search(r"^tenant_id:\s*(.+)$", text, re.MULTILINE)
+    if not match:
+        return None
+    value = match.group(1).strip().strip('"').strip("'")
+    if value in ("", "null", "~"):
+        return None
+    return value
+
+
+def _extract_auth_mode(text: str) -> str | None:
+    match = re.search(
+        r"^auth:\s*\n(?:[ \t]+.*\n)*?[ \t]+mode:\s*(.+)$", text, re.MULTILINE
+    )
+    if not match:
+        return None
+    return match.group(1).strip().strip('"').strip("'")
+
+
+def read_deploy_auth(deploy_env: str) -> tuple[str, str | None]:
+    """Return (auth_mode, tenant_id) from the merged deploy config.
+
+    The environment overlay wins over the shared deploy.yml. Parsed with the
+    standard library so it works before project dependencies are installed.
+    """
+
+    base = REPO_ROOT / "deploy" / "config" / "deploy.yml"
+    overlay = REPO_ROOT / "deploy" / "config" / "environments" / f"{deploy_env}.yml"
+    base_text = base.read_text() if base.is_file() else ""
+    overlay_text = overlay.read_text() if overlay.is_file() else ""
+
+    tenant_id = _extract_tenant_id(overlay_text) or _extract_tenant_id(base_text)
+    auth_mode = (
+        _extract_auth_mode(overlay_text)
+        or _extract_auth_mode(base_text)
+        or "azure_cli"
+    )
+    return auth_mode, tenant_id
+
+
+def _active_az_tenant(az: str) -> str | None:
+    result = subprocess.run(
+        [az, "account", "show", "--query", "tenantId", "-o", "tsv"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def ensure_azure_login(deploy_env: str, *, dry_run: bool) -> None:
+    """Sign in to the configured Azure tenant before deploy when needed.
+
+    Only acts for `auth.mode: azure_cli`. Skips login when the active Azure CLI
+    tenant already matches the configured tenant_id.
+    """
+
+    auth_mode, tenant_id = read_deploy_auth(deploy_env)
+    if auth_mode != "azure_cli" or not tenant_id:
+        return
+
+    az = _resolve_az()
+    if az is None:
+        raise SystemExit(
+            "Azure CLI (az) is required for deploy but was not found on PATH. "
+            "Install Azure CLI, or set deploy config auth.mode to azure_powershell."
+        )
+
+    active_tenant = None if dry_run else _active_az_tenant(az)
+    if active_tenant and active_tenant.lower() == tenant_id.lower():
+        print(f"Azure CLI already signed in to tenant {tenant_id}.")
+        return
+
+    if active_tenant:
+        print(
+            f"Active Azure CLI tenant {active_tenant} does not match "
+            f"configured tenant {tenant_id}; signing in."
+        )
+    else:
+        print(f"Signing in to Azure tenant {tenant_id}.")
+    run_command([az, "login", "--tenant", tenant_id], dry_run=dry_run)
+
+
 def run_retail_setup(
     env: PythonEnv,
     *,
@@ -265,6 +357,7 @@ def run_retail_setup(
     if not assume_yes and not deploy:
         deploy = prompt_yes_no("Run `retail-setup deploy` now?", default=False)
     if deploy:
+        ensure_azure_login(deploy_env, dry_run=dry_run)
         deploy_command = [
             str(env.python),
             "-m",

--- a/tests/scripts/test_setup_bootstrap.py
+++ b/tests/scripts/test_setup_bootstrap.py
@@ -61,6 +61,13 @@ def test_install_prerequisites_dry_run_records_commands(monkeypatch):
     assert commands == [["testpm", "install", "terraform"]]
 
 
+def test_current_python_env_uses_launching_interpreter():
+    env = setup.current_python_env()
+
+    assert env.python == Path(sys.executable)
+    assert env.description == "current Python environment"
+
+
 def test_run_retail_setup_dry_run_without_deploy(monkeypatch):
     commands = []
     env = setup.PythonEnv(Path("python"), "test")

--- a/tests/scripts/test_setup_bootstrap.py
+++ b/tests/scripts/test_setup_bootstrap.py
@@ -135,33 +135,31 @@ def test_extract_tenant_id_treats_null_as_missing():
     assert setup._extract_tenant_id("subscription_id: x\n") is None
 
 
-def test_ensure_azure_login_skips_when_tenant_matches(monkeypatch):
+def test_ensure_azure_login_always_runs_az_login(monkeypatch):
     commands = []
     monkeypatch.setattr(setup, "read_deploy_auth", lambda _: ("azure_cli", "TENANT"))
-    monkeypatch.setattr(setup, "_resolve_az", lambda: "az")
-    monkeypatch.setattr(setup, "_active_az_tenant", lambda _: "tenant")
-    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
-
-    setup.ensure_azure_login("dev", dry_run=False)
-
-    assert commands == []
-
-
-def test_ensure_azure_login_runs_login_on_mismatch(monkeypatch):
-    commands = []
-    monkeypatch.setattr(setup, "read_deploy_auth", lambda _: ("azure_cli", "expected"))
     monkeypatch.setattr(setup, "_resolve_az", lambda: "C:/az.cmd")
-    monkeypatch.setattr(setup, "_active_az_tenant", lambda _: "active")
     monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
 
     setup.ensure_azure_login("dev", dry_run=False)
 
-    assert commands == [["C:/az.cmd", "login", "--tenant", "expected"]]
+    assert commands == [["C:/az.cmd", "login", "--tenant", "TENANT"]]
 
 
-def test_ensure_azure_login_noop_for_non_azure_cli(monkeypatch):
+def test_ensure_azure_login_uses_powershell_for_az_powershell(monkeypatch):
     commands = []
     monkeypatch.setattr(setup, "read_deploy_auth", lambda _: ("azure_powershell", "TENANT"))
+    monkeypatch.setattr(setup.shutil, "which", lambda command: "pwsh" if command == "pwsh" else None)
+    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+
+    setup.ensure_azure_login("dev", dry_run=False)
+
+    assert commands == [["pwsh", "-NoProfile", "-Command", "Connect-AzAccount -Tenant TENANT"]]
+
+
+def test_ensure_azure_login_noop_when_no_tenant(monkeypatch):
+    commands = []
+    monkeypatch.setattr(setup, "read_deploy_auth", lambda _: ("azure_cli", None))
     monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
 
     setup.ensure_azure_login("dev", dry_run=False)

--- a/tests/scripts/test_setup_bootstrap.py
+++ b/tests/scripts/test_setup_bootstrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -61,11 +62,20 @@ def test_install_prerequisites_dry_run_records_commands(monkeypatch):
     assert commands == [["testpm", "install", "terraform"]]
 
 
-def test_current_python_env_uses_launching_interpreter():
-    env = setup.current_python_env()
+def test_run_command_reports_nonzero_exit_without_traceback(monkeypatch, capsys):
+    def fake_run(command, **kwargs):
+        raise subprocess.CalledProcessError(7, command)
 
-    assert env.python == Path(sys.executable)
-    assert env.description == "current Python environment"
+    monkeypatch.setattr(setup.subprocess, "run", fake_run)
+
+    try:
+        setup.run_command(["terraform", "init"])
+    except SystemExit as exc:
+        assert "Command failed with exit code 7: terraform init" in str(exc)
+    else:
+        raise AssertionError("run_command should raise SystemExit")
+
+    assert "$ terraform init" in capsys.readouterr().out
 
 
 def test_run_retail_setup_dry_run_without_deploy(monkeypatch):

--- a/tests/scripts/test_setup_bootstrap.py
+++ b/tests/scripts/test_setup_bootstrap.py
@@ -123,7 +123,25 @@ def test_run_retail_setup_deploy_flag_runs_deploy(monkeypatch):
     ]
 
 
-def test_extract_tenant_id_and_auth_mode():
+def test_run_retail_setup_recreate_passes_recreate_flag(monkeypatch):
+    commands = []
+    env = setup.PythonEnv(Path("python"), "test")
+    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+    monkeypatch.setattr(setup, "ensure_azure_login", lambda *_, **__: None)
+
+    setup.run_retail_setup(
+        env,
+        deploy_env="qa",
+        dry_run=True,
+        assume_yes=True,
+        deploy_requested=True,
+        recreate=True,
+    )
+
+    deploy_cmd = commands[-1]
+    assert "--recreate" in deploy_cmd
+    assert deploy_cmd.index("--recreate") < deploy_cmd.index("--yes")
+
     text = "tenant_id: 11111111-1111-1111-1111-111111111111\nauth:\n  mode: azure_cli\n"
 
     assert setup._extract_tenant_id(text) == "11111111-1111-1111-1111-111111111111"

--- a/tests/scripts/test_setup_bootstrap.py
+++ b/tests/scripts/test_setup_bootstrap.py
@@ -102,6 +102,7 @@ def test_run_retail_setup_deploy_flag_runs_deploy(monkeypatch):
     commands = []
     env = setup.PythonEnv(Path("python"), "test")
     monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+    monkeypatch.setattr(setup, "ensure_azure_login", lambda *_, **__: None)
 
     setup.run_retail_setup(
         env,
@@ -120,3 +121,49 @@ def test_run_retail_setup_deploy_flag_runs_deploy(monkeypatch):
         "qa",
         "--yes",
     ]
+
+
+def test_extract_tenant_id_and_auth_mode():
+    text = "tenant_id: 11111111-1111-1111-1111-111111111111\nauth:\n  mode: azure_cli\n"
+
+    assert setup._extract_tenant_id(text) == "11111111-1111-1111-1111-111111111111"
+    assert setup._extract_auth_mode(text) == "azure_cli"
+
+
+def test_extract_tenant_id_treats_null_as_missing():
+    assert setup._extract_tenant_id("tenant_id: null\n") is None
+    assert setup._extract_tenant_id("subscription_id: x\n") is None
+
+
+def test_ensure_azure_login_skips_when_tenant_matches(monkeypatch):
+    commands = []
+    monkeypatch.setattr(setup, "read_deploy_auth", lambda _: ("azure_cli", "TENANT"))
+    monkeypatch.setattr(setup, "_resolve_az", lambda: "az")
+    monkeypatch.setattr(setup, "_active_az_tenant", lambda _: "tenant")
+    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+
+    setup.ensure_azure_login("dev", dry_run=False)
+
+    assert commands == []
+
+
+def test_ensure_azure_login_runs_login_on_mismatch(monkeypatch):
+    commands = []
+    monkeypatch.setattr(setup, "read_deploy_auth", lambda _: ("azure_cli", "expected"))
+    monkeypatch.setattr(setup, "_resolve_az", lambda: "C:/az.cmd")
+    monkeypatch.setattr(setup, "_active_az_tenant", lambda _: "active")
+    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+
+    setup.ensure_azure_login("dev", dry_run=False)
+
+    assert commands == [["C:/az.cmd", "login", "--tenant", "expected"]]
+
+
+def test_ensure_azure_login_noop_for_non_azure_cli(monkeypatch):
+    commands = []
+    monkeypatch.setattr(setup, "read_deploy_auth", lambda _: ("azure_powershell", "TENANT"))
+    monkeypatch.setattr(setup, "run_command", lambda command, **_: commands.append(command))
+
+    setup.ensure_azure_login("dev", dry_run=False)
+
+    assert commands == []

--- a/utility/README.md
+++ b/utility/README.md
@@ -50,7 +50,10 @@ The guided setup script:
 4. Installs Python dependencies into that environment.
 5. Runs `retail-setup configure`.
 6. Runs `retail-setup render`.
-7. Asks whether to run `retail-setup deploy`.
+7. Asks whether to run `retail-setup deploy`. Before deploying, it signs in to
+   the configured Azure tenant with `az login --tenant <tenant_id>` (skipped
+   when the active Azure CLI tenant already matches, or when
+   `auth.mode: azure_powershell`).
 
 Examples:
 

--- a/utility/README.md
+++ b/utility/README.md
@@ -46,8 +46,8 @@ The guided setup script:
 1. Detects Windows, macOS, or Linux.
 2. Offers to install missing CLI prerequisites with the OS package manager
    (`winget`/Chocolatey, Homebrew, `apt-get`, `dnf`, or `yum`).
-3. Uses conda when available and accepted; otherwise creates `.venv`.
-4. Installs Python dependencies.
+3. Uses the Python environment that launched the script.
+4. Installs Python dependencies into that environment.
 5. Runs `retail-setup configure`.
 6. Runs `retail-setup render`.
 7. Asks whether to run `retail-setup deploy`.
@@ -74,6 +74,9 @@ py -3.11 -m venv .venv
 python -m pip install --upgrade pip
 python -m pip install -e .\utility
 ```
+
+If you prefer conda, activate your conda environment before running
+`python .\scripts\setup.py` or before installing the package manually.
 
 For automated deployment:
 

--- a/utility/README.md
+++ b/utility/README.md
@@ -35,13 +35,18 @@ development tests.
 
 ## Guided setup
 
-From the repository root:
+On Windows, from the repository root:
 
 ```powershell
-python .\scripts\setup.py
+.\scripts\setup.ps1
 ```
 
-The guided setup script:
+`setup.ps1` works even with nothing installed: it uses Python 3.11+ if present,
+otherwise installs Miniforge with winget and creates a conda environment, then
+delegates to `scripts\setup.py`. On macOS and Linux, activate a Python 3.11+
+environment and run `python ./scripts/setup.py` directly.
+
+The guided setup:
 
 1. Detects Windows, macOS, or Linux.
 2. Offers to install missing CLI prerequisites with the OS package manager
@@ -50,17 +55,18 @@ The guided setup script:
 4. Installs Python dependencies into that environment.
 5. Runs `retail-setup configure`.
 6. Runs `retail-setup render`.
-7. Asks whether to run `retail-setup deploy`. Before deploying, it signs in to
-   the configured Azure tenant with `az login --tenant <tenant_id>` (skipped
-   when the active Azure CLI tenant already matches, or when
-   `auth.mode: azure_powershell`).
+7. Asks whether to run `retail-setup deploy`. Before deploying, it always signs
+   in to the configured Azure tenant — `az login --tenant <tenant_id>` for
+   `auth.mode: azure_cli`, or `Connect-AzAccount -Tenant <tenant_id>` for
+   `auth.mode: azure_powershell` — so deployment never runs under the wrong
+   account.
 
 Examples:
 
 ```powershell
-python .\scripts\setup.py --env dev
-python .\scripts\setup.py --env dev --deploy
-python .\scripts\setup.py --env dev --dry-run
+.\scripts\setup.ps1 --env dev
+.\scripts\setup.ps1 --env dev --deploy
+.\scripts\setup.ps1 --env dev --dry-run
 ```
 
 `--env` selects `deploy\config\environments\<env>.yml` and generated outputs

--- a/utility/README.md
+++ b/utility/README.md
@@ -231,6 +231,14 @@ stage/deploy supported Fabric items:
 retail-setup deploy --env dev --skip-terraform
 ```
 
+For a clean slate, `--recreate` destroys the existing workspace (and every item
+in it), waits 30 seconds, then recreates everything. This is destructive and is
+gated by a confirmation prompt:
+
+```powershell
+retail-setup deploy --env dev --recreate
+```
+
 The deploy command runs these steps in order:
 
 1. Generate Terraform and fabric-cicd config files.

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -131,6 +131,68 @@ def _available_store_types() -> list[str]:
         return []
 
 
+def _load_deploy_environment(repo_root: Path, env: str):
+    root = str(repo_root)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    from deploy.scripts.deploy_config import load_environment
+
+    return load_environment(
+        env,
+        config_path=repo_root / "deploy" / "config" / "deploy.yml",
+        environments_root=repo_root / "deploy" / "config" / "environments",
+    )
+
+
+def _active_azure_cli_tenant() -> str:
+    try:
+        result = subprocess.run(
+            ["az", "account", "show", "--query", "tenantId", "-o", "tsv"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        raise typer.Exit(code=127) from None
+    if result.returncode != 0:
+        raise typer.Exit(code=1)
+    return result.stdout.strip()
+
+
+def _validate_azure_cli_tenant(repo_root: Path, env: str) -> None:
+    try:
+        config = _load_deploy_environment(repo_root, env)
+    except ImportError:
+        return
+
+    if config.auth_mode != "azure_cli" or not config.tenant_id:
+        return
+
+    try:
+        active_tenant = _active_azure_cli_tenant()
+    except typer.Exit as exc:
+        if exc.exit_code == 127:
+            typer.echo(
+                "Azure CLI is required for auth.mode=azure_cli but `az` was not found on PATH.",
+                err=True,
+            )
+            typer.echo("Install Azure CLI or set deploy config auth.mode to azure_powershell.", err=True)
+        else:
+            typer.echo("Azure CLI is not logged in.", err=True)
+            typer.echo(f"Run: az login --tenant {config.tenant_id}", err=True)
+        raise
+
+    if active_tenant.lower() != config.tenant_id.lower():
+        typer.echo(
+            "Azure CLI tenant does not match deploy config tenant_id.",
+            err=True,
+        )
+        typer.echo(f"  Active tenant:   {active_tenant}", err=True)
+        typer.echo(f"  Expected tenant: {config.tenant_id}", err=True)
+        typer.echo(f"Run: az login --tenant {config.tenant_id}", err=True)
+        raise typer.Exit(code=1)
+
+
 @app.command()
 def configure(
     repo_root: Path = typer.Option(
@@ -545,6 +607,7 @@ def deploy(
             typer.echo("note: deploy config unavailable; plan shows default lakehouse name")
     else:
         lakehouse = _lakehouse_name(repo_root, env)
+        _validate_azure_cli_tenant(repo_root, env)
     plan = _deploy_plan(env, skip_terraform, lakehouse_name=lakehouse)
     total = len(plan)
 

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -8,6 +8,7 @@ generation values (validated via GenerationConfig, written to utility/config.yam
 from __future__ import annotations
 
 import subprocess
+import shutil
 import sys
 from dataclasses import dataclass, field
 from datetime import date
@@ -145,9 +146,12 @@ def _load_deploy_environment(repo_root: Path, env: str):
 
 
 def _active_azure_cli_tenant() -> str:
+    az = shutil.which("az") or shutil.which("az.cmd") or shutil.which("az.exe")
+    if not az:
+        raise typer.Exit(code=127)
     try:
         result = subprocess.run(
-            ["az", "account", "show", "--query", "tenantId", "-o", "tsv"],
+            [az, "account", "show", "--query", "tenantId", "-o", "tsv"],
             capture_output=True,
             text=True,
             check=False,

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -492,6 +492,7 @@ def _deploy_plan(
     env: str,
     skip_terraform: bool,
     lakehouse_name: str = "retail_lakehouse",
+    recreate: bool = False,
 ) -> list[DeployStep]:
     """Build the ordered deploy command plan (data only; nothing is executed)."""
     py = sys.executable
@@ -509,6 +510,25 @@ def _deploy_plan(
                 cmd=["terraform", "-chdir=deploy/terraform", "init"],
                 description="Terraform init",
             ),
+        ]
+        if recreate:
+            steps += [
+                DeployStep(
+                    cmd=[
+                        "terraform",
+                        "-chdir=deploy/terraform",
+                        "destroy",
+                        f"-var-file={var_file}",
+                    ],
+                    needs_confirmation=True,
+                    description="Terraform destroy (recreate - DESTROYS the workspace and all items)",
+                ),
+                DeployStep(
+                    cmd=[py, "-c", "import time; time.sleep(30)"],
+                    description="Wait 30s for Fabric to finalize workspace deletion",
+                ),
+            ]
+        steps += [
             DeployStep(
                 cmd=["terraform", "-chdir=deploy/terraform", "plan", f"-var-file={var_file}"],
                 description="Terraform plan",
@@ -605,13 +625,31 @@ def deploy(
     yes: bool = typer.Option(
         False, "--yes", help="Pre-confirm gated steps (Terraform apply)."
     ),
+    recreate: bool = typer.Option(
+        False,
+        "--recreate",
+        help="Destroy the existing workspace and recreate it (clean slate).",
+    ),
 ) -> None:
     """Run the full deployment: configs, Terraform, artifacts, Fabric items, KQL.
 
     Prerequisite: the `terraform` binary must be on PATH unless --skip-terraform
     is given. Authentication is handled by the deploy framework scripts.
+
+    With --recreate, the deployment destroys the existing workspace (and every
+    item in it) and recreates it from scratch. This is destructive; use it only
+    for a clean-slate redeploy.
     """
     repo_root = repo_root.resolve()
+    if recreate and skip_terraform:
+        typer.echo("--recreate cannot be combined with --skip-terraform.", err=True)
+        raise typer.Exit(code=1)
+    if recreate and not dry_run:
+        typer.echo("")
+        typer.echo("!" * 70)
+        typer.echo("  WARNING: --recreate will DESTROY the existing workspace and ALL items")
+        typer.echo("  in it, wait 30 seconds, then recreate everything from scratch.")
+        typer.echo("!" * 70)
     if dry_run:
         # dry runs must not require live config; fall back to the default name
         try:
@@ -622,7 +660,7 @@ def deploy(
     else:
         lakehouse = _lakehouse_name(repo_root, env)
         _validate_azure_cli_tenant(repo_root, env)
-    plan = _deploy_plan(env, skip_terraform, lakehouse_name=lakehouse)
+    plan = _deploy_plan(env, skip_terraform, lakehouse_name=lakehouse, recreate=recreate)
     total = len(plan)
 
     if dry_run:
@@ -634,7 +672,7 @@ def deploy(
     for i, step in enumerate(plan, start=1):
         _echo_step(i, total, step)
         if step.needs_confirmation and not yes:
-            if not typer.confirm("Apply this Terraform plan?"):
+            if not typer.confirm(f"Proceed with: {step.description}?"):
                 typer.echo("Aborted by user.")
                 raise typer.Exit(code=1)
         try:

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -256,6 +256,16 @@ def configure(
         else "Store type"
     )
 
+    _prompted_values = (
+        tenant_id, workspace_name, capacity_name, lakehouse_name, eventhouse_name,
+        kql_database_name, store_type, start_date, end_date, store_count, seed,
+    )
+    if any(value is None for value in _prompted_values) and sys.stdin.isatty():
+        typer.echo("")
+        typer.echo("=" * 70)
+        typer.echo("  INPUT REQUIRED — review each value and press Enter to accept [default]")
+        typer.echo("=" * 70)
+
     tenant_id = _prompt_str(
         "Entra tenant ID",
         tenant_id,

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -39,6 +39,40 @@ def test_plan_orders_steps_and_gates_apply():
     assert apply_idx < build_idx < deploy_idx
 
 
+def test_recreate_inserts_destroy_and_sleep_before_plan():
+    plan = _deploy_plan("dev", skip_terraform=False, recreate=True)
+    cmds = [" ".join(map(str, s.cmd)) for s in plan]
+    init_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and "init" in c)
+    destroy_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and "destroy" in c)
+    sleep_idx = next(i for i, c in enumerate(cmds) if "time.sleep(30)" in c)
+    plan_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and " plan " in f" {c} ")
+    assert init_idx < destroy_idx < sleep_idx < plan_idx
+    assert plan[destroy_idx].needs_confirmation
+
+
+def test_recreate_rejects_skip_terraform(monkeypatch):
+    monkeypatch.setattr("retail_setup.cli.main._validate_azure_cli_tenant", lambda *_: None)
+    result = runner.invoke(app, ["deploy", "--env", "dev", "--recreate", "--skip-terraform"])
+    assert result.exit_code == 1, result.output
+    assert "--recreate cannot be combined with --skip-terraform" in result.output
+
+
+def test_recreate_dry_run_shows_destroy_step():
+    result = runner.invoke(app, ["deploy", "--env", "dev", "--recreate", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "destroy" in result.output
+
+
+def test_recreate_warns_and_aborts_on_decline(monkeypatch):
+    monkeypatch.setattr("retail_setup.cli.main._validate_azure_cli_tenant", lambda *_: None)
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: SimpleNamespace(returncode=0))
+    # Decline the first gated step (Terraform destroy).
+    result = runner.invoke(app, ["deploy", "--env", "dev", "--recreate"], input="n\n")
+    assert result.exit_code == 1, result.output
+    assert "WARNING" in result.output
+    assert "Aborted by user" in result.output
+
+
 def test_deploy_reports_missing_terraform_without_traceback(monkeypatch):
     def fake_run(cmd, *args, **kwargs):
         if cmd and cmd[0] == "terraform":

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -64,6 +64,22 @@ def test_azure_cli_tenant_preflight_accepts_matching_tenant(monkeypatch):
     _validate_azure_cli_tenant(Path("."), "dev")
 
 
+def test_active_azure_cli_tenant_uses_resolved_az_path(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="tenant-id\n")
+
+    monkeypatch.setattr("retail_setup.cli.main.shutil.which", lambda command: "C:/az.cmd")
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    from retail_setup.cli.main import _active_azure_cli_tenant
+
+    assert _active_azure_cli_tenant() == "tenant-id"
+    assert calls[0][0] == "C:/az.cmd"
+
+
 def test_azure_cli_tenant_preflight_rejects_mismatched_tenant(monkeypatch):
     monkeypatch.setattr(
         "retail_setup.cli.main._load_deploy_environment",

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -1,8 +1,10 @@
 import subprocess
+from pathlib import Path
+from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
-from retail_setup.cli.main import app, _deploy_plan
+from retail_setup.cli.main import app, _deploy_plan, _validate_azure_cli_tenant
 
 runner = CliRunner()
 
@@ -44,8 +46,36 @@ def test_deploy_reports_missing_terraform_without_traceback(monkeypatch):
         return subprocess.CompletedProcess(cmd, 0)
 
     monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("retail_setup.cli.main._validate_azure_cli_tenant", lambda *_: None)
     result = runner.invoke(app, ["deploy", "--env", "dev", "--yes"])
     assert result.exit_code == 127, result.output
     assert "Required executable not found: terraform" in result.output
     assert "--skip-terraform" in result.output
     assert "Traceback" not in result.output
+
+
+def test_azure_cli_tenant_preflight_accepts_matching_tenant(monkeypatch):
+    monkeypatch.setattr(
+        "retail_setup.cli.main._load_deploy_environment",
+        lambda *_: SimpleNamespace(auth_mode="azure_cli", tenant_id="TENANT"),
+    )
+    monkeypatch.setattr("retail_setup.cli.main._active_azure_cli_tenant", lambda: "tenant")
+
+    _validate_azure_cli_tenant(Path("."), "dev")
+
+
+def test_azure_cli_tenant_preflight_rejects_mismatched_tenant(monkeypatch):
+    monkeypatch.setattr(
+        "retail_setup.cli.main._load_deploy_environment",
+        lambda *_: SimpleNamespace(auth_mode="azure_cli", tenant_id="expected-tenant"),
+    )
+    monkeypatch.setattr(
+        "retail_setup.cli.main._active_azure_cli_tenant",
+        lambda: "active-tenant",
+    )
+
+    result = runner.invoke(app, ["deploy", "--env", "dev", "--yes"])
+    assert result.exit_code == 1, result.output
+    assert "Azure CLI tenant does not match deploy config tenant_id" in result.output
+    assert "az login --tenant expected-tenant" in result.output
+    assert "terraform" not in result.output

--- a/website/docs/setup/01-data-generation.md
+++ b/website/docs/setup/01-data-generation.md
@@ -16,7 +16,9 @@ python .\scripts\setup.py
 
 The guided setup detects your OS, offers to install missing prerequisites, uses
 the Python environment that launched the script, installs dependencies, runs
-configure, renders notebooks, and asks whether to deploy.
+configure, renders notebooks, and asks whether to deploy. Before deploying, it
+signs in to the configured Azure tenant with `az login --tenant <tenant_id>`
+(skipped when the active Azure CLI tenant already matches).
 
 `--env` selects `deploy/config/environments/<env>.yml` and writes generated
 deployment files under `deploy/.generated/<env>/`.

--- a/website/docs/setup/01-data-generation.md
+++ b/website/docs/setup/01-data-generation.md
@@ -14,9 +14,9 @@ Set-Location retail-demo
 python .\scripts\setup.py
 ```
 
-The guided setup detects your OS, offers to install missing prerequisites,
-sets up Python with conda or venv, installs dependencies, runs configure,
-renders notebooks, and asks whether to deploy.
+The guided setup detects your OS, offers to install missing prerequisites, uses
+the Python environment that launched the script, installs dependencies, runs
+configure, renders notebooks, and asks whether to deploy.
 
 `--env` selects `deploy/config/environments/<env>.yml` and writes generated
 deployment files under `deploy/.generated/<env>/`.
@@ -29,7 +29,8 @@ python .\scripts\setup.py --env dev --dry-run
 
 ## Step 1.2: Manual install path
 
-Use this path if you prefer to run each command yourself.
+Use this path if you prefer to create or activate an environment yourself before
+running each command. For conda, activate the conda environment first.
 
 ```powershell
 py -3.11 -m venv .venv

--- a/website/docs/setup/01-data-generation.md
+++ b/website/docs/setup/01-data-generation.md
@@ -11,22 +11,27 @@ From PowerShell:
 ```powershell
 git clone https://github.com/amattas/retail-demo.git
 Set-Location retail-demo
-python .\scripts\setup.py
+.\scripts\setup.ps1
 ```
+
+`setup.ps1` works even with nothing installed: it uses Python 3.11+ if present,
+otherwise installs Miniforge with winget and creates a conda environment, then
+runs the guided setup. On macOS and Linux, activate a Python 3.11+ environment
+and run `python ./scripts/setup.py` instead.
 
 The guided setup detects your OS, offers to install missing prerequisites, uses
 the Python environment that launched the script, installs dependencies, runs
 configure, renders notebooks, and asks whether to deploy. Before deploying, it
-signs in to the configured Azure tenant with `az login --tenant <tenant_id>`
-(skipped when the active Azure CLI tenant already matches).
+always signs in to the configured Azure tenant (`az login --tenant <tenant_id>`
+for `auth.mode: azure_cli`) so deployment never runs under the wrong account.
 
 `--env` selects `deploy/config/environments/<env>.yml` and writes generated
 deployment files under `deploy/.generated/<env>/`.
 
 ```powershell
-python .\scripts\setup.py --env dev
-python .\scripts\setup.py --env dev --deploy
-python .\scripts\setup.py --env dev --dry-run
+.\scripts\setup.ps1 --env dev
+.\scripts\setup.ps1 --env dev --deploy
+.\scripts\setup.ps1 --env dev --dry-run
 ```
 
 ## Step 1.2: Manual install path

--- a/website/docs/setup/troubleshooting.md
+++ b/website/docs/setup/troubleshooting.md
@@ -41,6 +41,31 @@ the workspace and resources already exist:
 retail-setup deploy --env dev --skip-terraform
 ```
 
+## Fabric `FeatureNotAvailable` during Terraform apply
+
+**Symptom**: Terraform creates the workspace, then fails creating the Lakehouse
+or Eventhouse with:
+
+```text
+Error Code: FeatureNotAvailable
+Could not create resource: The feature is not available
+```
+
+This means the target Fabric tenant/capacity/workspace does not currently expose
+that Fabric item type through the API/provider in the selected region or
+capacity.
+
+Fix:
+
+1. Confirm the selected capacity supports Lakehouse and Real-Time Intelligence.
+2. Confirm the workspace is assigned to the expected Fabric capacity.
+3. Try creating a Lakehouse and Eventhouse manually in the Fabric portal in the
+   same workspace. If the portal blocks creation, fix the tenant/capacity/region
+   first.
+4. If the workspace was created but item creation failed, either delete the
+   partial workspace and rerun deploy, or set `workspace.existing_id` in
+   `deploy/config/environments/<env>.yml` after the workspace is usable.
+
 ## `fabric_cicd` or `azure.identity` import error
 
 Install deployment dependencies:
@@ -56,6 +81,18 @@ For `auth.mode: azure_cli`:
 ```powershell
 az login --tenant <tenant-id>
 ```
+
+Before deploying, confirm the active Azure CLI tenant matches
+`deploy/config/deploy.yml` or `deploy/config/environments/<env>.yml`:
+
+```powershell
+az account show --query "{tenantId:tenantId,user:user.name,name:name}" -o table
+```
+
+If it does not match, rerun `az login --tenant <tenant-id>`. Terraform and
+fabric-cicd use the active Azure CLI identity; the `tenant_id` value in config is
+used for validation and generated files, but it does not switch the logged-in
+Azure account for you.
 
 For `auth.mode: azure_powershell`:
 


### PR DESCRIPTION
## Summary
- Simplify `scripts/setup.py` to use the Python environment that launches the script.
- Remove the conda/venv creation flow that caused failures when users were already inside an activated environment.
- Convert setup subprocess failures into concise `SystemExit` messages instead of Python tracebacks.
- Add an Azure CLI tenant preflight in `retail-setup deploy` so Terraform/fabric-cicd do not run under the wrong tenant.
- Document Azure tenant validation and Fabric `FeatureNotAvailable` troubleshooting.

## Validation
- `python -m pytest .\tests\scripts\test_setup_bootstrap.py .\utility\tests\test_cli_deploy.py -q`
- `python -m ruff check .\scripts\setup.py .\tests\scripts\test_setup_bootstrap.py .\utility\src\retail_setup\cli\main.py .\utility\tests\test_cli_deploy.py`
- `python .\scripts\setup.py --dry-run --yes --skip-prereqs --env dev`
- `npm run build` under `website\`
- `git diff --check`