### PR TITLE
fix(deploy): assign Fabric capacity to workspace

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -3,11 +3,34 @@ data "fabric_workspace" "existing" {
   id    = var.existing_workspace_id
 }
 
+# Resolve the Fabric capacity by display name when an explicit capacity_id is
+# not provided. A workspace without an assigned Fabric capacity cannot create
+# Lakehouse/Eventhouse items (the API returns FeatureNotAvailable).
+data "fabric_capacity" "main" {
+  count        = var.existing_workspace_id == null && var.capacity_id == null && var.capacity_name != null ? 1 : 0
+  display_name = var.capacity_name
+
+  lifecycle {
+    postcondition {
+      condition     = self.state == "Active"
+      error_message = "Fabric capacity '${var.capacity_name}' is not Active. Assign an active Fabric (F) SKU capacity before deploying."
+    }
+  }
+}
+
+locals {
+  resolved_capacity_id = (
+    var.capacity_id != null
+    ? var.capacity_id
+    : try(data.fabric_capacity.main[0].id, null)
+  )
+}
+
 resource "fabric_workspace" "main" {
   count                          = var.existing_workspace_id == null ? 1 : 0
   display_name                   = var.workspace_name
   description                    = var.workspace_description
-  capacity_id                    = var.capacity_id
+  capacity_id                    = local.resolved_capacity_id
   skip_capacity_state_validation = var.skip_capacity_state_validation
 }
 


### PR DESCRIPTION
## Summary
- Resolve the Fabric capacity by `capacity_name` (via the `fabric_capacity` data source) when `capacity_id` is not explicitly set, and assign it to the workspace.
- Without an assigned capacity, Fabric rejects Lakehouse/Eventhouse creation with `FeatureNotAvailable` even though the workspace itself is created.
- Add a `postcondition` that the resolved capacity is `Active`, so an unusable/paused capacity produces a clear error instead of `FeatureNotAvailable`.

## Root cause
`fabric_workspace.main` used `capacity_id = var.capacity_id`, but `configure` only collects `capacity_name`. The generated tfvars set `capacity_name` and left `capacity_id` null, so workspaces were created with no capacity, and Lakehouse/Eventhouse/KQL creation failed.

## Validation
- `terraform fmt -check` passes.
- `terraform validate` passes in an initialized working directory.
- Confirmed the configured capacity (`amattas`, F64, Active) exists; the workspace just was not assigned to it.