### PR TITLE
fix(deploy): stop fabric-cicd from managing Terraform items

### DIFF
--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -51,8 +51,6 @@ powerbi:
 deployment:
   item_types_in_scope:
     - Lakehouse
-    - Eventhouse
-    - KQLDatabase
     - Notebook
     - SemanticModel
     - Report

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -164,12 +164,13 @@ def build_workspace(
     (output_dir / ".gitkeep").touch()
 
     staged_items: list[str] = []
-    for display_name, item_type in [
-        ("retail_lakehouse", "Lakehouse"),
-        ("retail_eventhouse", "Eventhouse"),
-        ("retail_kql", "KQLDatabase"),
-    ]:
-        staged_items.append(stage_shell_item(output_dir, display_name, item_type).name)
+    # Terraform provisions the Lakehouse, Eventhouse, and KQL Database. Only the
+    # Lakehouse is staged as a fabric-cicd shell item (it publishes cleanly and
+    # helps notebook `$items.Lakehouse` references resolve). Eventhouse and
+    # KQLDatabase are NOT staged: Fabric rejects a `.platform`-only definition
+    # update ("Definition parts cannot contain the .platform file only"), and
+    # Terraform already owns them.
+    staged_items.append(stage_shell_item(output_dir, "retail_lakehouse", "Lakehouse").name)
 
     for notebook_name in _selected_notebooks(notebook_groups):
         staged_items.append(

--- a/deploy/scripts/deploy_config.py
+++ b/deploy/scripts/deploy_config.py
@@ -358,8 +358,14 @@ def render_parameter_file(
                 ),
                 "replace_value": {config.environment: onelake_url},
                 "is_regex": "true",
+                # Scope by item type only. A `file_path` filter is matched
+                # relative to the repository directory (not the item folder),
+                # so "definition/expressions.tmdl" never matches the staged
+                # "<item>.SemanticModel/definition/expressions.tmdl" path and the
+                # OneLake URL rewrite is silently skipped. The regex only matches
+                # OneLake URLs, which appear solely in the semantic model's
+                # expressions.tmdl, so item_type scoping is sufficient and safe.
                 "item_type": "SemanticModel",
-                "file_path": "definition/expressions.tmdl",
             },
             {
                 "find_value": "DirectLake - retail_lakehouse",

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -96,8 +96,10 @@ def test_build_workspace_stages_core_assets(tmp_path: Path) -> None:
     assert "retail_model.SemanticModel" in result.staged_items
     assert "retail_model.Report" in result.staged_items
     assert "retail_lakehouse.Lakehouse" in result.staged_items
-    assert "retail_eventhouse.Eventhouse" in result.staged_items
-    assert "retail_kql.KQLDatabase" in result.staged_items
+    # Eventhouse and KQLDatabase are Terraform-owned and must NOT be staged as
+    # fabric-cicd shell items (Fabric rejects a .platform-only definition).
+    assert "retail_eventhouse.Eventhouse" not in result.staged_items
+    assert "retail_kql.KQLDatabase" not in result.staged_items
 
 
 def test_setup_group_stages_rendered_notebooks(tmp_path: Path) -> None:
@@ -158,7 +160,7 @@ def test_build_workspace_threads_custom_lakehouse_name_to_setup_notebooks(
         {"metadata": {"type": "Report"}},
     )
 
-    result = build_artifacts.build_workspace(
+    build_artifacts.build_workspace(
         repo_root=repo,
         output_dir=out_dir,
         notebook_groups=["setup"],

--- a/tests/deploy/test_deploy_config.py
+++ b/tests/deploy/test_deploy_config.py
@@ -20,8 +20,6 @@ def test_load_environment_merges_defaults_and_environment() -> None:
     assert config.notebooks.include == ["core"]
     assert config.deployment.item_types_in_scope == [
         "Lakehouse",
-        "Eventhouse",
-        "KQLDatabase",
         "Notebook",
         "SemanticModel",
         "Report",


### PR DESCRIPTION
## Summary
Cleanly separate ownership: Terraform owns workspace + Lakehouse + Eventhouse + KQL Database; fabric-cicd owns Notebooks + SemanticModel + Report.

- Remove `Eventhouse` and `KQLDatabase` from `item_types_in_scope` and from `build_artifacts` shell staging. fabric-cicd was staging `.platform`-only shells and calling `updateDefinition` on the Terraform-created Eventhouse, which Fabric rejects: "Definition parts cannot contain the .platform file only."
- Fix the semantic model OneLake URL rewrite: drop the `file_path: definition/expressions.tmdl` filter so fabric-cicd matches the rewrite by `item_type: SemanticModel`. The `file_path` filter is matched relative to the repo directory (not the item folder), so it never matched the staged `*.SemanticModel/definition/expressions.tmdl` and the rewrite was silently skipped (semantic model would point at a stale lakehouse).

## Why this is safe
- `unpublish_skip: true` means fabric-cicd will not delete the Terraform-owned Eventhouse/KQL Database it no longer manages.
- The Lakehouse remains a staged shell (publishes cleanly and helps notebook `$items.Lakehouse` references resolve).
- The OneLake regex only matches OneLake URLs, which appear solely in the semantic model's `expressions.tmdl`, so `item_type` scoping is sufficient.

## Validation
- `pytest tests/deploy -q` — 14 passed.
- `ruff check` clean.
- Reproduced the original failure from a live deploy (Eventhouse publish error at item 8/10); confirmed the staged Eventhouse/KQL shells were the cause.