### PR TITLE
feat(deploy): deploy KQL querysets and organize items into workspace folders

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -91,8 +91,12 @@ After the Eventhouse and KQL database exist:
 - `unpublish_skip` defaults to `true` to avoid deleting items unexpectedly.
 - Eventstream deployment is disabled by default because Fabric source-control
   item definitions for Eventstream are not yet part of this framework.
-- Pipeline, dashboard, and queryset assets remain source inputs until their
-  Fabric source-control item formats are validated.
+- Curated KQL queries in `fabric\querysets\*.kql` deploy as a single
+  `retail_querysets.KQLQueryset` item (one tab per `.kql` file) bound to the
+  Eventhouse KQL database. `clusterUri` is resolved by fabric-cicd at publish
+  time and `databaseItemId` is rewritten from the Terraform KQL database id.
+- Pipeline and dashboard assets remain source inputs until their Fabric
+  source-control item formats are validated.
 - Secrets must come from Azure login, GitHub Actions secrets, environment
   variables, Key Vault, or ignored local files. Do not commit secrets to YAML,
   Terraform files, notebooks, or generated artifacts.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -88,6 +88,10 @@ After the Eventhouse and KQL database exist:
 
 ## Configuration notes
 
+- Published items are organized into Fabric workspace folders: demo/pipeline
+  notebooks under **Notebooks**, one-time setup notebooks under **Setup**, and
+  the semantic model and report under **Power BI**. The Lakehouse and queryset
+  stay at the workspace root.
 - `unpublish_skip` defaults to `true` to avoid deleting items unexpectedly.
 - Eventstream deployment is disabled by default because Fabric source-control
   item definitions for Eventstream are not yet part of this framework.
@@ -108,5 +112,5 @@ After the Eventhouse and KQL database exist:
 | `setup notebooks not rendered` | Run `retail-setup render --env <env>` before building/deploying the `setup` notebook group. |
 | `terraform` command not found | Install Terraform or use `--skip-terraform` when resources already exist. |
 | `fabric_cicd` import error | Install `fabric-cicd` in the active Python environment. |
-| Authentication failure | Run `az login --tenant <tenant-id>` for `azure_cli`, or `Connect-AzAccount -Tenant <tenant-id>` for `azure_powershell`. |
+| Authentication failure | Run `az account show --query "{tenantId:tenantId,user:user.name,name:name}" -o table` and confirm it matches deploy config. Run `az login --tenant <tenant-id>` for `azure_cli`, or `Connect-AzAccount -Tenant <tenant-id>` for `azure_powershell`. |
 | KQL tables missing | Run the generated `database.kql` script manually in the target KQL database. |

--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -54,6 +54,7 @@ deployment:
     - Notebook
     - SemanticModel
     - Report
+    - KQLQueryset
   publish_skip: false
   unpublish_skip: true
   orphan_exclude_regex: "^DO_NOT_DELETE_.*"

--- a/deploy/fabric-cicd/config.yml
+++ b/deploy/fabric-cicd/config.yml
@@ -4,11 +4,10 @@ core:
   repository_directory: ../workspace
   item_types_in_scope:
   - Lakehouse
-  - Eventhouse
-  - KQLDatabase
   - Notebook
   - SemanticModel
   - Report
+  - KQLQueryset
   parameter: parameter.yml
 publish:
   skip:

--- a/deploy/fabric-cicd/parameter.yml
+++ b/deploy/fabric-cicd/parameter.yml
@@ -4,7 +4,6 @@ find_replace:
     dev: https://onelake.dfs.fabric.microsoft.com/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002
   is_regex: 'true'
   item_type: SemanticModel
-  file_path: definition/expressions.tmdl
 - find_value: DirectLake - retail_lakehouse
   replace_value:
     dev: DirectLake - retail_lakehouse

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -15,6 +15,16 @@ PLATFORM_SCHEMA = (
     "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/"
     "platformProperties/2.0.0/schema.json"
 )
+
+# Workspace folder names used to organize published items. fabric-cicd maps the
+# staged directory structure to Fabric workspace folders, so staging an item
+# under `<output>/Notebooks/<item>` places it in a "Notebooks" workspace folder.
+# Demo/pipeline notebooks go under "Notebooks"; one-time setup notebooks (and
+# other setup artifacts) go under "Setup". The Lakehouse shell and KQLQueryset
+# stay at the workspace root.
+NOTEBOOKS_FOLDER = "Notebooks"
+SETUP_FOLDER = "Setup"
+POWERBI_FOLDER = "Power BI"
 NOTEBOOK_GROUPS = {
     "core": [
         "01-create-bronze-shortcuts.ipynb",
@@ -245,24 +255,32 @@ def build_workspace(
     # Terraform already owns them.
     staged_items.append(stage_shell_item(output_dir, "retail_lakehouse", "Lakehouse").name)
 
+    # Demo/pipeline notebooks publish into a "Notebooks" workspace folder.
+    notebooks_dir = output_dir / NOTEBOOKS_FOLDER
     for notebook_name in _selected_notebooks(notebook_groups):
         staged_items.append(
             stage_notebook(
                 repo_root / "fabric" / "lakehouse" / notebook_name,
-                output_dir,
+                notebooks_dir,
                 lakehouse_name=lakehouse_name,
             ).name
         )
 
+    # One-time setup notebooks publish into a separate "Setup" workspace folder.
     if "setup" in notebook_groups:
         staged_items.extend(
             item.name
-            for item in stage_setup_notebooks(repo_root, output_dir, lakehouse_name=lakehouse_name)
+            for item in stage_setup_notebooks(
+                repo_root, output_dir / SETUP_FOLDER, lakehouse_name=lakehouse_name
+            )
         )
 
+    # Power BI items publish into a "Power BI" workspace folder.
     staged_items.extend(
         item.name
-        for item in stage_powerbi_items(repo_root / "fabric" / "powerbi", output_dir)
+        for item in stage_powerbi_items(
+            repo_root / "fabric" / "powerbi", output_dir / POWERBI_FOLDER
+        )
     )
     # Curated KQL queries (fabric/querysets/*.kql) ship as a single
     # .KQLQueryset item bound to the Eventhouse KQL database. Skipped silently

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -149,11 +149,84 @@ def stage_setup_notebooks(
     return staged
 
 
+def stage_querysets(
+    repo_root: Path,
+    output_dir: Path,
+    kql_database_name: str = "retail_kql",
+    display_name: str = "retail_querysets",
+) -> list[Path]:
+    """Stage `fabric/querysets/*.kql` as one Fabric `.KQLQueryset` item.
+
+    Every `.kql` file becomes a tab in a single queryset bound to the Eventhouse
+    KQL database. The data source `clusterUri` is left empty so fabric-cicd fills
+    it from the deployed KQL database (matched by `databaseItemName`), while
+    `databaseItemId` carries the `FABRIC_KQL_DATABASE_RESOURCE_ID` placeholder
+    that `parameter.yml` replaces with the Terraform-provisioned KQL database id.
+
+    Returns an empty list when no queryset sources exist so the deploy degrades
+    gracefully.
+    """
+
+    source_dir = repo_root / "fabric" / "querysets"
+    if not source_dir.is_dir():
+        return []
+    kql_files = sorted(source_dir.glob("*.kql"), key=lambda path: path.name)
+    if not kql_files:
+        return []
+
+    item_dir = output_dir / f"{display_name}.KQLQueryset"
+    item_dir.mkdir(parents=True, exist_ok=True)
+    _write_platform(item_dir, "KQLQueryset", display_name)
+
+    data_source_id = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"retail-demo:KQLQueryset:{display_name}:datasource",
+        )
+    )
+    tabs = [
+        {
+            "id": str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"retail-demo:KQLQueryset:{display_name}:tab:{kql_file.stem}",
+                )
+            ),
+            "content": kql_file.read_text(encoding="utf-8"),
+            "title": kql_file.stem,
+            "dataSourceId": data_source_id,
+        }
+        for kql_file in kql_files
+    ]
+
+    queryset = {
+        "queryset": {
+            "version": "1.0.0",
+            "dataSources": [
+                {
+                    "id": data_source_id,
+                    "clusterUri": "",
+                    "type": "Fabric",
+                    "databaseItemId": "FABRIC_KQL_DATABASE_RESOURCE_ID",
+                    "databaseItemName": kql_database_name,
+                }
+            ],
+            "tabs": tabs,
+        }
+    }
+    (item_dir / "RealTimeQueryset.json").write_text(
+        json.dumps(queryset, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return [item_dir]
+
+
 def build_workspace(
     repo_root: Path = REPO_ROOT,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
     notebook_groups: list[str] | None = None,
     lakehouse_name: str = "retail_lakehouse",
+    kql_database_name: str = "retail_kql",
 ) -> BuildResult:
     """Build a fabric-cicd workspace folder from repository source assets."""
 
@@ -190,6 +263,15 @@ def build_workspace(
     staged_items.extend(
         item.name
         for item in stage_powerbi_items(repo_root / "fabric" / "powerbi", output_dir)
+    )
+    # Curated KQL queries (fabric/querysets/*.kql) ship as a single
+    # .KQLQueryset item bound to the Eventhouse KQL database. Skipped silently
+    # when no queryset sources exist.
+    staged_items.extend(
+        item.name
+        for item in stage_querysets(
+            repo_root, output_dir, kql_database_name=kql_database_name
+        )
     )
     return BuildResult(output_dir=output_dir, staged_items=sorted(staged_items))
 
@@ -252,10 +334,15 @@ def main() -> int:
         choices=sorted(NOTEBOOK_GROUPS),
     )
     parser.add_argument("--lakehouse-name", default="retail_lakehouse")
+    parser.add_argument("--kql-database-name", default="retail_kql")
     args = parser.parse_args()
 
     result = build_workspace(
-        args.repo_root, args.output_dir, args.notebook_groups, args.lakehouse_name
+        args.repo_root,
+        args.output_dir,
+        args.notebook_groups,
+        args.lakehouse_name,
+        args.kql_database_name,
     )
     print(f"Staged {len(result.staged_items)} items in {result.output_dir}")
     for item in result.staged_items:

--- a/fabric/querysets/README.md
+++ b/fabric/querysets/README.md
@@ -9,3 +9,19 @@ Collections:
 - Logistics: truck dwell, on-time arrivals, lane performance
 - Marketing: impressions → visits → purchases attribution
 
+## Deployment
+
+`retail-setup deploy` (via `deploy.scripts.build_artifacts`) bundles every
+`*.kql` file in this folder into one Fabric `retail_querysets.KQLQueryset`
+item, with one tab per file (the tab title is the file name without its
+extension). The queryset's data source is bound to the Eventhouse KQL database:
+
+- `clusterUri` is left empty so fabric-cicd fills it from the deployed KQL
+  database, matched by `databaseItemName` (default `retail_kql`).
+- `databaseItemId` carries the `FABRIC_KQL_DATABASE_RESOURCE_ID` placeholder,
+  which `parameter.yml` rewrites with the Terraform-provisioned KQL database id.
+
+Add a new query by dropping a `.kql` file here and redeploying — no other
+configuration is required. Use a different KQL database name with
+`build_artifacts --kql-database-name <name>`.
+

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -101,6 +101,14 @@ def test_build_workspace_stages_core_assets(tmp_path: Path) -> None:
     assert "retail_eventhouse.Eventhouse" not in result.staged_items
     assert "retail_kql.KQLDatabase" not in result.staged_items
 
+    # Notebooks publish under a "Notebooks" workspace folder; Power BI items
+    # under a "Power BI" folder; the Lakehouse shell stays at the root.
+    assert (output / "Notebooks" / "01-create-bronze-shortcuts.Notebook").is_dir()
+    assert (output / "Power BI" / "retail_model.SemanticModel").is_dir()
+    assert (output / "Power BI" / "retail_model.Report").is_dir()
+    assert (output / "retail_lakehouse.Lakehouse").is_dir()
+    assert not (output / "01-create-bronze-shortcuts.Notebook").exists()
+
 
 def test_stage_querysets_builds_kqlqueryset_with_tab_per_file(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
@@ -257,7 +265,9 @@ def test_build_workspace_threads_custom_lakehouse_name_to_setup_notebooks(
 
     # Every staged setup notebook must carry the custom lakehouse name in its metadata
     for name in build_artifacts.SETUP_NOTEBOOKS:
-        notebook_path = out_dir / f"{name}.Notebook" / "notebook-content.ipynb"
+        notebook_path = (
+            out_dir / "Setup" / f"{name}.Notebook" / "notebook-content.ipynb"
+        )
         assert notebook_path.exists(), f"Missing staged notebook: {notebook_path}"
         notebook = json.loads(notebook_path.read_text(encoding="utf-8"))
         lh_meta = notebook["metadata"]["dependencies"]["lakehouse"]

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -102,6 +102,94 @@ def test_build_workspace_stages_core_assets(tmp_path: Path) -> None:
     assert "retail_kql.KQLDatabase" not in result.staged_items
 
 
+def test_stage_querysets_builds_kqlqueryset_with_tab_per_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    querysets = repo / "fabric" / "querysets"
+    querysets.mkdir(parents=True)
+    (querysets / "q_tender_mix.kql").write_text(
+        "payment_processed | summarize sum(amount) by payment_method",
+        encoding="utf-8",
+    )
+    (querysets / "q_receipts.kql").write_text(
+        "mv_store_sales_minute | take 100", encoding="utf-8"
+    )
+
+    output = tmp_path / "workspace"
+    output.mkdir()
+    staged = build_artifacts.stage_querysets(
+        repo, output, kql_database_name="retail_kql"
+    )
+
+    assert staged == [output / "retail_querysets.KQLQueryset"]
+    item = staged[0]
+
+    platform = json.loads((item / ".platform").read_text(encoding="utf-8"))
+    assert platform["metadata"]["type"] == "KQLQueryset"
+    assert platform["metadata"]["displayName"] == "retail_querysets"
+
+    definition = json.loads((item / "RealTimeQueryset.json").read_text(encoding="utf-8"))
+    queryset = definition["queryset"]
+    data_source = queryset["dataSources"][0]
+    # clusterUri is left empty for fabric-cicd to resolve from the live KQL DB.
+    assert data_source["clusterUri"] == ""
+    assert data_source["databaseItemName"] == "retail_kql"
+    # databaseItemId carries the placeholder that parameter.yml rewrites.
+    assert data_source["databaseItemId"] == "FABRIC_KQL_DATABASE_RESOURCE_ID"
+
+    # One tab per source file, sorted by file name, each bound to the data source.
+    assert [tab["title"] for tab in queryset["tabs"]] == ["q_receipts", "q_tender_mix"]
+    assert all(tab["dataSourceId"] == data_source["id"] for tab in queryset["tabs"])
+    assert queryset["tabs"][0]["content"] == "mv_store_sales_minute | take 100"
+
+
+def test_stage_querysets_returns_empty_when_no_sources(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    output = tmp_path / "workspace"
+    output.mkdir()
+
+    # No fabric/querysets directory at all.
+    assert build_artifacts.stage_querysets(repo, output) == []
+
+    # Directory present but empty.
+    (repo / "fabric" / "querysets").mkdir(parents=True)
+    assert build_artifacts.stage_querysets(repo, output) == []
+    assert not (output / "retail_querysets.KQLQueryset").exists()
+
+
+def test_build_workspace_stages_querysets_when_present(tmp_path: Path) -> None:
+    source_root = tmp_path / "repo"
+    for notebook_name in build_artifacts.NOTEBOOK_GROUPS["core"]:
+        _write_json(
+            source_root / "fabric" / "lakehouse" / notebook_name,
+            {"metadata": {}, "cells": [], "nbformat": 4, "nbformat_minor": 5},
+        )
+    _write_json(
+        source_root / "fabric" / "powerbi" / "retail_model.SemanticModel" / ".platform",
+        {"metadata": {"type": "SemanticModel"}},
+    )
+    _write_json(
+        source_root / "fabric" / "powerbi" / "retail_model.Report" / ".platform",
+        {"metadata": {"type": "Report"}},
+    )
+    (source_root / "fabric" / "querysets").mkdir(parents=True)
+    (source_root / "fabric" / "querysets" / "q_tender_mix.kql").write_text(
+        "payment_processed | count", encoding="utf-8"
+    )
+
+    output = tmp_path / "workspace"
+    result = build_artifacts.build_workspace(
+        source_root, output, ["core"], kql_database_name="custom_kql"
+    )
+
+    assert "retail_querysets.KQLQueryset" in result.staged_items
+    definition = json.loads(
+        (output / "retail_querysets.KQLQueryset" / "RealTimeQueryset.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert definition["queryset"]["dataSources"][0]["databaseItemName"] == "custom_kql"
+
+
 def test_setup_group_stages_rendered_notebooks(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     out_dir = tmp_path / "workspace"

--- a/tests/deploy/test_deploy_config.py
+++ b/tests/deploy/test_deploy_config.py
@@ -23,6 +23,7 @@ def test_load_environment_merges_defaults_and_environment() -> None:
         "Notebook",
         "SemanticModel",
         "Report",
+        "KQLQueryset",
     ]
 
 


### PR DESCRIPTION
## Summary

Two related improvements to how `retail-setup deploy` stages and publishes Fabric items (both stacked on #275):

1. **Deploy curated KQL queries as a Fabric KQLQueryset.** The "query the database" scripts in `fabric/querysets/*.kql` now ship as a real `retail_querysets.KQLQueryset` item (one tab per file), complementing the "configure the database" scripts in `fabric/kql_database/*.kql` (applied via `apply_kql`).
2. **Organize published items into named workspace folders.**

## Workspace folders

fabric-cicd derives Fabric workspace folders from the staged directory layout, so items are now staged under subdirectories:

| Folder | Items |
| --- | --- |
| **Notebooks** | demo/pipeline notebooks (`core`, `ml`, `ontology`, `utility`, `reset`) |
| **Setup** | one-time setup notebooks (`setup-01..04`) |
| **Power BI** | semantic model + report |
| _(root)_ | Lakehouse shell, `retail_querysets.KQLQueryset` |

Item-name references (`.Lakehouse.*`) and `parameter.yml` rewrites are path-independent, so folderizing does not affect binding.

## KQLQueryset binding (authoritative)

Confirmed against fabric-cicd's own `SampleKQLQueryset.KQLQueryset` fixture and `_kqlqueryset.py`:

- `dataSources[].clusterUri = ""` → fabric-cicd fills it at publish time by looking up the KQL database by `databaseItemName` (`retail_kql`) — no `parameter.yml` rule needed for the cluster URI.
- `dataSources[].databaseItemId = "FABRIC_KQL_DATABASE_RESOURCE_ID"` → rewritten to the real Terraform KQL database id by the **existing** `parameter.yml` `find_replace` rule (scoped to `KQLQueryset`).

`build_artifacts` gains a `--kql-database-name` flag (default `retail_kql`) for custom database names.

## What changed

- **`deploy/scripts/build_artifacts.py`** — `stage_querysets()` + `NOTEBOOKS_FOLDER` / `SETUP_FOLDER` / `POWERBI_FOLDER` staging; `--kql-database-name` flag.
- **`deploy/config/deploy.yml`** — adds `KQLQueryset` to `deployment.item_types_in_scope` (regenerated `config.yml`/`parameter.yml` follow).
- **Docs** — `fabric/querysets/README.md` Deployment section; `deploy/README.md` notes on querysets + workspace folders.
- **Tests** — queryset staging/binding, empty-source no-op, and folder-placement assertions.

## Stacking

Stacked on **#275** (`fix/deploy-fabric-item-scope`), which removes the Eventhouse/KQLDatabase `.platform`-only shells that otherwise fail publish. This PR's diff includes #275's regenerated `config.yml`/`parameter.yml`. Merge #275 first.

## Validation

- `pytest tests/deploy` → 17 passed; `ruff` clean.
- Real build of all groups → `Notebooks/` (5 core), `Setup/` (4 setup), `Power BI/` (model + report), root Lakehouse + `retail_querysets.KQLQueryset` (11 tabs, empty `clusterUri`, placeholder `databaseItemId`, `databaseItemName=retail_kql`).

> Note: the KQLQueryset definition format cannot be validated against live Fabric from CI; it is modeled exactly on the fabric-cicd sample fixture.