### PR TITLE
feat(taskflow): export & deploy Fabric Task Flows (reverse-engineered API)

### DIFF
--- a/deploy/scripts/taskflow.py
+++ b/deploy/scripts/taskflow.py
@@ -1,0 +1,253 @@
+"""Export and deploy Fabric workspace Task Flows.
+
+Task Flows are not exposed by the public Fabric REST API. They live on the
+Power BI **metadata cluster** and are read/written with these undocumented
+endpoints (discovered by capturing the Fabric UI):
+
+    cluster = PUT https://api.powerbi.com/spglobalservice/GetOrInsertClusterUrisByTenantLocation
+              -> {"FixedClusterUri": "https://wabi-<region>.analysis.windows.net/"}
+
+    read    = GET  {cluster}/metadata/workspaces/{workspaceId}/taskflow202602
+              -> [{"etag", "resourceId", "taskFlow": {tasks, edges, id, name, description}}]
+
+    save    = PUT  {cluster}/metadata/workspaces/{workspaceId}/taskflow202512/{resourceId}
+              body = {"tasks": [...], "edges": [...]}
+
+A task references workspace artifacts by ``artifactUniqueId = "<artifactType>:<guid>"``.
+Because those GUIDs are workspace-specific, ``export_taskflow`` resolves each GUID
+to the artifact's display name (a portable form), and ``deploy_taskflow`` resolves
+the names back to the **target** workspace's GUIDs before saving.
+
+Auth uses the Azure CLI login: the metadata cluster needs a Power BI token and
+item listing needs a Fabric token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import requests
+    from azure.identity import AzureCliCredential
+
+PBI_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
+FABRIC_SCOPE = "https://api.fabric.microsoft.com/.default"
+FABRIC_API = "https://api.fabric.microsoft.com/v1"
+CLUSTER_DISCOVERY = (
+    "https://api.powerbi.com/spglobalservice/GetOrInsertClusterUrisByTenantLocation"
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TASKFLOW_PATH = REPO_ROOT / "fabric" / "taskflow" / "taskflow.json"
+
+# Task-flow artifactType -> Fabric REST item type (for name resolution).
+ARTIFACT_TO_ITEM_TYPE = {
+    "SynapseNotebook": "Notebook",
+    "Pipeline": "DataPipeline",
+    "Lakehouse": "Lakehouse",
+    "SqlAnalyticsEndpoint": "SQLEndpoint",
+    "KustoEventHouse": "Eventhouse",
+    "KustoDatabase": "KQLDatabase",
+    "LLMPlugin": "DataAgent",
+    "Ontology": "Ontology",
+    "GraphIndex": "GraphModel",
+    "MLExperiment": "MLExperiment",
+    "KQLQueryset": "KQLQueryset",
+    "Report": "Report",
+    "dataset": "SemanticModel",
+}
+
+
+def _token(scope: str, credential: AzureCliCredential | None = None) -> str:
+    from azure.identity import AzureCliCredential
+
+    credential = credential or AzureCliCredential()
+    return credential.get_token(scope).token
+
+
+def _session(token: str) -> requests.Session:
+    import requests
+
+    session = requests.Session()
+    session.headers["Authorization"] = f"Bearer {token}"
+    return session
+
+
+def resolve_cluster(pbi_session: requests.Session) -> str:
+    """Resolve the tenant's metadata cluster URI (no trailing slash)."""
+
+    response = pbi_session.put(CLUSTER_DISCOVERY, headers={"Content-Length": "0"})
+    response.raise_for_status()
+    return str(response.json()["FixedClusterUri"]).rstrip("/")
+
+
+def find_workspace_id(fabric_session: requests.Session, workspace_name: str) -> str:
+    """Resolve a workspace display name to its id (case-insensitive)."""
+
+    response = fabric_session.get(f"{FABRIC_API}/workspaces")
+    response.raise_for_status()
+    target = workspace_name.casefold()
+    for workspace in response.json().get("value", []):
+        if str(workspace.get("displayName", "")).casefold() == target:
+            return str(workspace["id"])
+    raise ValueError(f"Workspace not found: {workspace_name!r}")
+
+
+def list_workspace_items(
+    fabric_session: requests.Session, workspace_id: str
+) -> list[dict[str, Any]]:
+    """List all items in a workspace."""
+
+    response = fabric_session.get(f"{FABRIC_API}/workspaces/{workspace_id}/items")
+    response.raise_for_status()
+    return response.json().get("value", [])
+
+
+def get_taskflow(
+    pbi_session: requests.Session, cluster: str, workspace_id: str
+) -> dict[str, Any]:
+    """Read the raw task flow record (``{etag, resourceId, taskFlow}``)."""
+
+    url = f"{cluster}/metadata/workspaces/{workspace_id}/taskflow202602"
+    response = pbi_session.get(url)
+    response.raise_for_status()
+    records = response.json()
+    if not records:
+        raise ValueError(f"No task flow found in workspace {workspace_id}")
+    return records[0]
+
+
+def put_taskflow(
+    pbi_session: requests.Session,
+    cluster: str,
+    workspace_id: str,
+    resource_id: str,
+    task_flow: dict[str, Any],
+    etag: str | None = None,
+) -> int:
+    """Write a task flow (``{tasks, edges}``) back to the workspace."""
+
+    url = f"{cluster}/metadata/workspaces/{workspace_id}/taskflow202512/{resource_id}"
+    headers = {"Content-Type": "application/json"}
+    if etag:
+        headers["If-Match"] = etag
+    body = {"tasks": task_flow.get("tasks", []), "edges": task_flow.get("edges", [])}
+    response = pbi_session.put(url, json=body, headers=headers)
+    response.raise_for_status()
+    return response.status_code
+
+
+def _guid_name_map(items: list[dict[str, Any]]) -> dict[str, str]:
+    return {str(i["id"]): str(i.get("displayName", "")) for i in items}
+
+
+def to_portable(task_flow: dict[str, Any], guid_to_name: dict[str, str]) -> dict[str, Any]:
+    """Replace each item's GUID with its display name so the flow is workspace-agnostic."""
+
+    portable = json.loads(json.dumps(task_flow))  # deep copy
+    for task in portable.get("tasks", []):
+        for item in task.get("items", []):
+            artifact_type, _, guid = str(item.get("artifactUniqueId", "")).partition(":")
+            name = guid_to_name.get(item.get("artifactObjectId") or guid)
+            item["artifactName"] = name  # None when unresolved (e.g. legacy dataset id)
+            item["artifactType"] = item.get("artifactType", artifact_type)
+    return portable
+
+
+def to_workspace(
+    portable: dict[str, Any], name_type_to_guid: dict[tuple[str, str], str]
+) -> tuple[dict[str, Any], list[str]]:
+    """Resolve portable item names to target GUIDs. Returns (task_flow, unresolved)."""
+
+    resolved = json.loads(json.dumps(portable))
+    unresolved: list[str] = []
+    for task in resolved.get("tasks", []):
+        for item in task.get("items", []):
+            artifact_type = str(item.get("artifactType", ""))
+            name = item.get("artifactName")
+            item_type = ARTIFACT_TO_ITEM_TYPE.get(artifact_type, artifact_type)
+            guid = name_type_to_guid.get((item_type, name)) if name else None
+            if guid:
+                item["artifactUniqueId"] = f"{artifact_type}:{guid}"
+                item["artifactObjectId"] = guid
+            else:
+                unresolved.append(f"{artifact_type}:{name}")
+            item.pop("artifactName", None)
+    return resolved, unresolved
+
+
+def export_taskflow(
+    workspace: str,
+    output_path: Path = DEFAULT_TASKFLOW_PATH,
+    credential: AzureCliCredential | None = None,
+) -> Path:
+    """Export a workspace task flow to a portable JSON file (artifacts by name)."""
+
+    pbi = _session(_token(PBI_SCOPE, credential))
+    fabric = _session(_token(FABRIC_SCOPE, credential))
+    workspace_id = workspace if _looks_like_guid(workspace) else find_workspace_id(
+        fabric, workspace
+    )
+    cluster = resolve_cluster(pbi)
+    record = get_taskflow(pbi, cluster, workspace_id)
+    guid_to_name = _guid_name_map(list_workspace_items(fabric, workspace_id))
+    portable = to_portable(record["taskFlow"], guid_to_name)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(portable, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return output_path
+
+
+def deploy_taskflow(
+    workspace: str,
+    input_path: Path = DEFAULT_TASKFLOW_PATH,
+    credential: AzureCliCredential | None = None,
+) -> list[str]:
+    """Deploy a portable task flow to a workspace. Returns unresolved references."""
+
+    portable = json.loads(input_path.read_text(encoding="utf-8"))
+    pbi = _session(_token(PBI_SCOPE, credential))
+    fabric = _session(_token(FABRIC_SCOPE, credential))
+    workspace_id = workspace if _looks_like_guid(workspace) else find_workspace_id(
+        fabric, workspace
+    )
+    items = list_workspace_items(fabric, workspace_id)
+    name_type_to_guid = {
+        (str(i["type"]), str(i.get("displayName", ""))): str(i["id"]) for i in items
+    }
+    task_flow, unresolved = to_workspace(portable, name_type_to_guid)
+    cluster = resolve_cluster(pbi)
+    record = get_taskflow(pbi, cluster, workspace_id)
+    put_taskflow(pbi, cluster, workspace_id, record["resourceId"], task_flow, record["etag"])
+    return unresolved
+
+
+def _looks_like_guid(value: str) -> bool:
+    return len(value) == 36 and value.count("-") == 4
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export or deploy a Fabric Task Flow")
+    parser.add_argument("action", choices=["export", "deploy"])
+    parser.add_argument("--workspace", required=True, help="Workspace name or id.")
+    parser.add_argument("--path", type=Path, default=DEFAULT_TASKFLOW_PATH)
+    args = parser.parse_args()
+
+    if args.action == "export":
+        out = export_taskflow(args.workspace, args.path)
+        print(f"Exported task flow to {out}")
+    else:
+        unresolved = deploy_taskflow(args.workspace, args.path)
+        print("Deployed task flow.")
+        if unresolved:
+            print("Unresolved references (left unbound):")
+            for ref in unresolved:
+                print(f"  {ref}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fabric/taskflow/README.md
+++ b/fabric/taskflow/README.md
@@ -1,0 +1,80 @@
+# Task Flow
+
+The Fabric workspace **Task Flow** for the retail demo — the visual graph that
+wires the workspace items (notebooks, pipelines, lakehouse, eventhouse, semantic
+model, data agents, ontology, ML experiments) into a left-to-right data flow.
+
+`taskflow.json` is a **portable** export: each task item references its artifact
+by **display name** (resolved from GUIDs at export), so the same flow can be
+deployed to any workspace.
+
+## Why this is special
+
+Task flows are **not** exposed by the public Fabric REST API and are **not**
+workspace items (so `getDefinition` does not apply). They live on the Power BI
+**metadata cluster**. These endpoints were discovered by capturing the Fabric UI
+network traffic:
+
+| Operation | Call |
+| --- | --- |
+| Resolve cluster | `PUT https://api.powerbi.com/spglobalservice/GetOrInsertClusterUrisByTenantLocation` → `{"FixedClusterUri": "https://wabi-<region>.analysis.windows.net/"}` |
+| Read | `GET {cluster}/metadata/workspaces/{workspaceId}/taskflow202602` → `[{etag, resourceId, taskFlow}]` |
+| Save | `PUT {cluster}/metadata/workspaces/{workspaceId}/taskflow202512/{resourceId}` — body `{tasks, edges}` |
+
+### Data model
+
+```jsonc
+{
+  "id": "...", "name": "...", "description": "...",
+  "tasks": [
+    {
+      "id": "<guid>",
+      "type": "get data",        // get/store/prepare/distribute data, general, analyze and train data
+      "name": "Load Historical Data",
+      "description": "...",
+      "loc": "-220 -80",          // canvas "x y"
+      "items": [
+        { "artifactUniqueId": "<artifactType>:<guid>", "artifactType": "...", "artifactObjectId": "<guid>|null" }
+      ]
+    }
+  ],
+  "edges": [
+    { "id": "-1", "source": "<taskId>", "target": "<taskId>", "fromPort": "right", "toPort": "left" }
+  ]
+}
+```
+
+`artifactType` → Fabric item type: `SynapseNotebook`→Notebook, `Pipeline`→DataPipeline,
+`LLMPlugin`→DataAgent, `dataset`→SemanticModel, `KustoEventHouse`→Eventhouse,
+`KustoDatabase`→KQLDatabase, `Lakehouse`→Lakehouse, `Ontology`→Ontology,
+`MLExperiment`→MLExperiment, `SqlAnalyticsEndpoint`→SQLEndpoint.
+
+## Usage
+
+Both commands reuse your Azure CLI login (Power BI token for the metadata
+cluster, Fabric token for item name/GUID resolution):
+
+```powershell
+# Export the live task flow to a portable file
+python -m deploy.scripts.taskflow export --workspace "Retail Demo" --path fabric/taskflow/taskflow.json
+
+# Deploy it to a target workspace (resolves names -> target GUIDs, then PUTs)
+python -m deploy.scripts.taskflow deploy --workspace "retail-demo-dev" --path fabric/taskflow/taskflow.json
+```
+
+`deploy` reads the target's existing task flow to reuse its `resourceId`/`etag`,
+remaps every item name to the target workspace's GUID, and writes the flow.
+Unresolved references are reported and left unbound.
+
+## Caveats
+
+- **Live write.** `deploy` writes directly to the metadata cluster (there is no
+  fabric-cicd publisher for task flows). It is **not** wired into
+  `retail-setup deploy`; run it as an explicit post-deploy step once the
+  referenced items exist in the target workspace.
+- **Undocumented API.** The `taskflow202602` (read) / `taskflow202512` (write)
+  paths are internal and may change.
+- **Stale / legacy references.** Items whose GUID is no longer in the source
+  workspace export with `artifactName: null` (e.g. notebooks recreated after the
+  flow was authored). Semantic models use a legacy `dataset` id (`"3:NNNN"`)
+  rather than a GUID and also export unresolved. These are skipped on deploy.

--- a/fabric/taskflow/taskflow.json
+++ b/fabric/taskflow/taskflow.json
@@ -1,0 +1,469 @@
+{
+  "tasks": [
+    {
+      "id": "d7ce0e1e-fc0d-4749-a3a8-aec7c850017d",
+      "type": "get data",
+      "name": "Load Historical Data",
+      "description": "Ingest batch and real-time data into a single location within your Fabric workspace.",
+      "items": [
+        {
+          "artifactUniqueId": "SynapseNotebook:8a58519f-4156-40ba-a466-7d31d5e26fcd",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": "8a58519f-4156-40ba-a466-7d31d5e26fcd",
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:90009e22-24ab-4750-b2f6-b72cf6db2741",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "02-historical-data-load"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:adb9c982-0630-4585-9b9e-1c5f0a149bd0",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "01-create-bronze-shortcuts"
+        }
+      ],
+      "loc": "-220 -80"
+    },
+    {
+      "id": "32712835-c4fe-4073-aed8-195eceb57619",
+      "type": "store data",
+      "name": "Lakehouse",
+      "description": "",
+      "items": [
+        {
+          "artifactUniqueId": "Lakehouse:fc9ed7b6-6723-4116-8bf1-278135865270",
+          "artifactType": "Lakehouse",
+          "artifactObjectId": "fc9ed7b6-6723-4116-8bf1-278135865270",
+          "artifactName": "retail_lakehouse"
+        },
+        {
+          "artifactUniqueId": "SqlAnalyticsEndpoint:63f6eba8-57a6-42ec-a29d-3ee823d40969",
+          "artifactType": "SqlAnalyticsEndpoint",
+          "artifactObjectId": "63f6eba8-57a6-42ec-a29d-3ee823d40969",
+          "artifactName": "retail_lakehouse"
+        }
+      ],
+      "loc": "460 20"
+    },
+    {
+      "id": "17a0dbf9-0c1d-4be1-bcda-d7664e21336a",
+      "type": "get data",
+      "name": "Get Real-Time Data",
+      "description": "",
+      "items": [
+        {
+          "artifactUniqueId": "KustoEventHouse:c35327d5-3ac8-4922-8d69-493391c05984",
+          "artifactType": "KustoEventHouse",
+          "artifactObjectId": "c35327d5-3ac8-4922-8d69-493391c05984",
+          "artifactName": "retail_eventhouse"
+        },
+        {
+          "artifactUniqueId": "KustoDatabase:bc856a99-066c-4865-993a-7d188fbca851",
+          "artifactType": "KustoDatabase",
+          "artifactObjectId": "bc856a99-066c-4865-993a-7d188fbca851",
+          "artifactName": "retail_eventhouse"
+        }
+      ],
+      "loc": "-220 120"
+    },
+    {
+      "id": "56fc83da-28ce-4f0e-ab0a-531981bca41f",
+      "type": "prepare data",
+      "name": "Transform Historical Data",
+      "description": "",
+      "items": [
+        {
+          "artifactUniqueId": "Pipeline:abdd84f4-4893-46c0-ab7f-66aa5f65c5d0",
+          "artifactType": "Pipeline",
+          "artifactObjectId": "abdd84f4-4893-46c0-ab7f-66aa5f65c5d0",
+          "artifactName": "historical-data-load"
+        }
+      ],
+      "loc": "120 -80"
+    },
+    {
+      "id": "01f01a29-ec9a-4e20-b865-d1f7954fcfe7",
+      "type": "prepare data",
+      "name": "Transform Real-Time Data",
+      "description": "Clean, transform, extract, and load your data for analysis and modeling tasks.",
+      "items": [
+        {
+          "artifactUniqueId": "SynapseNotebook:18e17653-c8fb-456e-a4fa-44743c948866",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": "18e17653-c8fb-456e-a4fa-44743c948866",
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:543e9201-1cbe-4da2-b8f8-0a634fa8bcdc",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": "543e9201-1cbe-4da2-b8f8-0a634fa8bcdc",
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "Pipeline:3c6f0a0d-07e5-4c68-8f4b-83d269033fa8",
+          "artifactType": "Pipeline",
+          "artifactObjectId": "3c6f0a0d-07e5-4c68-8f4b-83d269033fa8",
+          "artifactName": "streaming-data-load"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:8b187f3d-b32f-4d15-ae0a-f20c518e29ec",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "04-streaming-to-gold"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:42c685c9-6bea-45f5-872b-7cc1353961e3",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "03-streaming-to-silver"
+        }
+      ],
+      "loc": "120 120"
+    },
+    {
+      "id": "15781dbc-2ab3-4cce-9622-2aa894cb145a",
+      "type": "general",
+      "name": "General",
+      "items": [
+        {
+          "artifactUniqueId": "SynapseNotebook:c3d99c89-ceb3-482d-b0e7-62625929f45e",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": "c3d99c89-ceb3-482d-b0e7-62625929f45e",
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "Pipeline:1ec9af37-769b-49e8-adb8-0ee36d961b7d",
+          "artifactType": "Pipeline",
+          "artifactObjectId": "1ec9af37-769b-49e8-adb8-0ee36d961b7d",
+          "artifactName": "daily-maintenance"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:16aa0e09-f7c3-436b-8bb2-4250fabc65d0",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "05-maintain-delta-tables"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:4c58cdde-5ead-4292-999f-2f33696fff5d",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "99-reset-lakehouse"
+        }
+      ],
+      "loc": "460 -280"
+    },
+    {
+      "id": "74c13947-61f2-4d20-ac15-2b19262e101b",
+      "type": "store data",
+      "name": "Semantic Model",
+      "description": "",
+      "items": [
+        {
+          "artifactUniqueId": "3:4416500",
+          "artifactType": "dataset",
+          "artifactObjectId": null,
+          "artifactName": null
+        }
+      ],
+      "loc": "800 120"
+    },
+    {
+      "id": "2b579fce-56a9-4b47-8602-22a334c8f273",
+      "type": "distribute data",
+      "name": "Data Agents",
+      "description": "Propose hypotheses, train models, and explore your data to make decisions and predictions.",
+      "items": [
+        {
+          "artifactUniqueId": "LLMPlugin:b791fcbd-1b88-4126-9f46-d95eac202634",
+          "artifactType": "LLMPlugin",
+          "artifactObjectId": "b791fcbd-1b88-4126-9f46-d95eac202634",
+          "artifactName": "retail-semantic-model-agent"
+        },
+        {
+          "artifactUniqueId": "LLMPlugin:c1d73913-84df-4aa3-a3cb-bf16ca343553",
+          "artifactType": "LLMPlugin",
+          "artifactObjectId": null,
+          "artifactName": "retail-ontology-agent"
+        }
+      ],
+      "loc": "1140 40"
+    },
+    {
+      "id": "333311ac-9b2e-4cfc-898c-cb63347b6988",
+      "type": "analyze and train data",
+      "name": "Analyze and train Models",
+      "description": "Propose hypotheses, train models, and explore your data to make decisions and predictions.",
+      "items": [
+        {
+          "artifactUniqueId": "MLExperiment:a4ad20b8-552e-4b80-9c98-e1ce47fa278c",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "demand_forecast"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:cffb7610-e761-485e-8f75-7f2c8a7730d2",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:07998890-6802-419e-84c6-66d1f7d741d2",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:22cf947e-4e21-4f59-b653-fc2b316d4b27",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "08-ml-customer-segmentation"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:13c32a9a-70f8-4638-97a2-54f4ddf49d05",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "06-ml-demand-forecast"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:e1aaa8df-b835-4f32-8240-f75d0d1889db",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "07-ml-market-basket"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:875f69ea-f370-4702-b5f0-efc73e0a2ae0",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "09-ml-churn-prediction"
+        },
+        {
+          "artifactUniqueId": "MLExperiment:7ee8db66-05bb-4bb3-aca8-bbc355b80443",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "churn_prediction"
+        },
+        {
+          "artifactUniqueId": "MLExperiment:fc745b56-e5eb-4f39-9956-47072085f7aa",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "customer_segmentation"
+        },
+        {
+          "artifactUniqueId": "MLExperiment:33805d04-7b88-4d31-ab18-3c690778a4de",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "market_basket"
+        },
+        {
+          "artifactUniqueId": "MLExperiment:c68213a1-407e-4580-8a91-8b17f3014e9a",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "promotion_effectiveness"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:20a387e3-668a-4ff0-a072-b33ab29a0b79",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "10-ml-promotion-effectiveness"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:09fc05bb-ef5f-45d3-85bf-de3b096c425b",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "11-ml-journey-analysis"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:e5f45d40-53c2-4a12-a9b5-c303f8c7347d",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "12-ml-stockout-prediction"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:72ac6599-7069-4679-8670-c0d74cb3ec6d",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "13-ml-delivery-prediction"
+        },
+        {
+          "artifactUniqueId": "MLExperiment:34688f82-93d4-4e31-9108-e829ef29a451",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "delivery_prediction"
+        },
+        {
+          "artifactUniqueId": "MLExperiment:fe322005-2266-4cf1-bac3-37f2c15b0e10",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "journey_analysis"
+        },
+        {
+          "artifactUniqueId": "SynapseNotebook:fdef9c48-5c00-4edc-a9ca-fcf26f8b5be4",
+          "artifactType": "SynapseNotebook",
+          "artifactObjectId": null,
+          "artifactName": "14-ml-dynamic-pricing"
+        },
+        {
+          "artifactUniqueId": "MLExperiment:864058c9-4a96-4476-9f9b-534a2e72ae30",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "stockout_prediction"
+        },
+        {
+          "artifactUniqueId": "MLExperiment:ca01314e-0157-4758-adea-9aed779c3aa8",
+          "artifactType": "MLExperiment",
+          "artifactObjectId": null,
+          "artifactName": "dynamic_pricing"
+        },
+        {
+          "artifactUniqueId": "Pipeline:28d204d9-0bb5-4756-b52e-0da700fe8bc8",
+          "artifactType": "Pipeline",
+          "artifactObjectId": "28d204d9-0bb5-4756-b52e-0da700fe8bc8",
+          "artifactName": "machine-learning"
+        }
+      ],
+      "loc": "460 320"
+    },
+    {
+      "id": "42bdbbc8-a08d-4b7d-9f8e-4b33f40e2e60",
+      "type": "distribute data",
+      "name": "Serve Ontologies",
+      "description": "Package your items for distribution as customized, easy-to-use apps.",
+      "items": [
+        {
+          "artifactUniqueId": "Ontology:573b9da8-5ba5-4b8c-9dae-7f8bde3a2fbd",
+          "artifactType": "Ontology",
+          "artifactObjectId": null,
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "GraphIndex:2a5ecefc-1e17-47b7-8ead-26d4be95c41e",
+          "artifactType": "GraphIndex",
+          "artifactObjectId": null,
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "Lakehouse:1003054e-bb57-4c1b-8a2b-eae6e4fe67c7",
+          "artifactType": "Lakehouse",
+          "artifactObjectId": null,
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "SqlAnalyticsEndpoint:a2ccc340-587d-4b58-8506-b5a6ef9852b1",
+          "artifactType": "SqlAnalyticsEndpoint",
+          "artifactObjectId": null,
+          "artifactName": null
+        },
+        {
+          "artifactUniqueId": "Ontology:ab4766aa-2ebf-4b76-86b6-7efe733d918d",
+          "artifactType": "Ontology",
+          "artifactObjectId": null,
+          "artifactName": "Retail Ontology"
+        },
+        {
+          "artifactUniqueId": "GraphIndex:778d7f93-af99-41f2-8442-6330dc789bcf",
+          "artifactType": "GraphIndex",
+          "artifactObjectId": null,
+          "artifactName": "RetailOntology_AutoGen_graph_ab4766aa2ebf4b7686b67efe733d918d"
+        },
+        {
+          "artifactUniqueId": "Lakehouse:d292daaf-0c5c-455a-b401-cad1143075a7",
+          "artifactType": "Lakehouse",
+          "artifactObjectId": null,
+          "artifactName": "RetailOntology_AutoGen_lh_ab4766aa2ebf4b7686b67efe733d918d"
+        },
+        {
+          "artifactUniqueId": "SqlAnalyticsEndpoint:5e48187f-572a-4325-82d0-64c7aa0d41c9",
+          "artifactType": "SqlAnalyticsEndpoint",
+          "artifactObjectId": null,
+          "artifactName": "RetailOntology_AutoGen_lh_ab4766aa2ebf4b7686b67efe733d918d"
+        }
+      ],
+      "loc": "800 -60"
+    }
+  ],
+  "edges": [
+    {
+      "id": "-1",
+      "source": "d7ce0e1e-fc0d-4749-a3a8-aec7c850017d",
+      "target": "56fc83da-28ce-4f0e-ab0a-531981bca41f",
+      "fromPort": "right",
+      "toPort": "left"
+    },
+    {
+      "id": "-2",
+      "source": "56fc83da-28ce-4f0e-ab0a-531981bca41f",
+      "target": "32712835-c4fe-4073-aed8-195eceb57619",
+      "fromPort": "right",
+      "toPort": "left"
+    },
+    {
+      "id": "-3",
+      "source": "17a0dbf9-0c1d-4be1-bcda-d7664e21336a",
+      "target": "01f01a29-ec9a-4e20-b865-d1f7954fcfe7",
+      "fromPort": "right",
+      "toPort": "left"
+    },
+    {
+      "id": "-4",
+      "source": "01f01a29-ec9a-4e20-b865-d1f7954fcfe7",
+      "target": "32712835-c4fe-4073-aed8-195eceb57619",
+      "fromPort": "right",
+      "toPort": "left"
+    },
+    {
+      "id": "-5",
+      "source": "15781dbc-2ab3-4cce-9622-2aa894cb145a",
+      "target": "32712835-c4fe-4073-aed8-195eceb57619",
+      "fromPort": "bottom",
+      "toPort": "top"
+    },
+    {
+      "id": "-6",
+      "source": "32712835-c4fe-4073-aed8-195eceb57619",
+      "target": "74c13947-61f2-4d20-ac15-2b19262e101b",
+      "fromPort": "right",
+      "toPort": "left"
+    },
+    {
+      "id": "-8",
+      "source": "32712835-c4fe-4073-aed8-195eceb57619",
+      "target": "333311ac-9b2e-4cfc-898c-cb63347b6988",
+      "fromPort": "bottom",
+      "toPort": "top"
+    },
+    {
+      "id": "-9",
+      "source": "333311ac-9b2e-4cfc-898c-cb63347b6988",
+      "target": "32712835-c4fe-4073-aed8-195eceb57619",
+      "fromPort": "top",
+      "toPort": "bottom"
+    },
+    {
+      "id": "-10",
+      "source": "32712835-c4fe-4073-aed8-195eceb57619",
+      "target": "42bdbbc8-a08d-4b7d-9f8e-4b33f40e2e60",
+      "fromPort": "right",
+      "toPort": "left"
+    },
+    {
+      "id": "-11",
+      "source": "74c13947-61f2-4d20-ac15-2b19262e101b",
+      "target": "2b579fce-56a9-4b47-8602-22a334c8f273",
+      "fromPort": "right",
+      "toPort": "left"
+    },
+    {
+      "id": "-12",
+      "source": "42bdbbc8-a08d-4b7d-9f8e-4b33f40e2e60",
+      "target": "2b579fce-56a9-4b47-8602-22a334c8f273",
+      "fromPort": "right",
+      "toPort": "left"
+    }
+  ],
+  "id": "adf6a8f1-8129-4a69-a7f7-80c21c32edf6",
+  "name": "Retail Demo",
+  "description": ""
+}

--- a/tests/deploy/test_taskflow.py
+++ b/tests/deploy/test_taskflow.py
@@ -1,0 +1,78 @@
+"""Tests for the Fabric Task Flow portable export/deploy remapping."""
+
+from __future__ import annotations
+
+from deploy.scripts import taskflow
+
+
+def test_to_portable_resolves_guids_to_names() -> None:
+    task_flow = {
+        "tasks": [
+            {
+                "id": "t1",
+                "name": "Load",
+                "type": "get data",
+                "items": [
+                    {
+                        "artifactUniqueId": "SynapseNotebook:nb-guid",
+                        "artifactType": "SynapseNotebook",
+                        "artifactObjectId": "nb-guid",
+                    },
+                    {
+                        "artifactUniqueId": "Pipeline:pl-guid",
+                        "artifactType": "Pipeline",
+                        "artifactObjectId": None,
+                    },
+                ],
+            }
+        ],
+        "edges": [],
+    }
+    guid_to_name = {"nb-guid": "02-historical-data-load", "pl-guid": "historical-data-load"}
+
+    portable = taskflow.to_portable(task_flow, guid_to_name)
+
+    items = portable["tasks"][0]["items"]
+    assert items[0]["artifactName"] == "02-historical-data-load"
+    # Falls back to the GUID parsed from artifactUniqueId when artifactObjectId is null.
+    assert items[1]["artifactName"] == "historical-data-load"
+    # Original task flow is not mutated.
+    assert "artifactName" not in task_flow["tasks"][0]["items"][0]
+
+
+def test_to_workspace_resolves_names_to_target_guids_and_reports_unresolved() -> None:
+    portable = {
+        "tasks": [
+            {
+                "id": "t1",
+                "items": [
+                    {"artifactType": "SynapseNotebook", "artifactName": "02-historical-data-load"},
+                    {"artifactType": "Pipeline", "artifactName": "missing-pipeline"},
+                ],
+            }
+        ],
+        "edges": [],
+    }
+    name_type_to_guid = {("Notebook", "02-historical-data-load"): "new-nb-guid"}
+
+    resolved, unresolved = taskflow.to_workspace(portable, name_type_to_guid)
+
+    item0 = resolved["tasks"][0]["items"][0]
+    assert item0["artifactUniqueId"] == "SynapseNotebook:new-nb-guid"
+    assert item0["artifactObjectId"] == "new-nb-guid"
+    assert "artifactName" not in item0  # name stripped after resolution
+    assert unresolved == ["Pipeline:missing-pipeline"]
+
+
+def test_artifact_type_mapping_covers_key_fabric_types() -> None:
+    m = taskflow.ARTIFACT_TO_ITEM_TYPE
+    assert m["SynapseNotebook"] == "Notebook"
+    assert m["Pipeline"] == "DataPipeline"
+    assert m["LLMPlugin"] == "DataAgent"
+    assert m["dataset"] == "SemanticModel"
+    assert m["KustoEventHouse"] == "Eventhouse"
+
+
+def test_looks_like_guid() -> None:
+    assert taskflow._looks_like_guid("5219ac70-71d4-4dfc-af32-5b8a6c29a471")
+    assert not taskflow._looks_like_guid("Retail Demo")


### PR DESCRIPTION
## Summary

Reverse-engineers the **undocumented Fabric Task Flow API** (by capturing the UI) and adds tooling to **export** and **deploy** the workspace task flow — the visual graph wiring notebooks, pipelines, lakehouse, eventhouse, semantic model, data agents, ontology, and ML experiments.

## The API (discovered)

Task flows are **not** in the public REST API and are **not** workspace items. They live on the Power BI metadata cluster:

| Op | Call |
| --- | --- |
| cluster | `PUT api.powerbi.com/spglobalservice/GetOrInsertClusterUrisByTenantLocation` → `FixedClusterUri` |
| read | `GET {cluster}/metadata/workspaces/{ws}/taskflow202602` → `[{etag, resourceId, taskFlow}]` |
| save | `PUT {cluster}/metadata/workspaces/{ws}/taskflow202512/{resourceId}` body `{tasks, edges}` |

`taskFlow` = `{tasks:[{id,type,name,description,loc:"x y",items:[{artifactUniqueId:"<Type>:<guid>",artifactType,artifactObjectId}]}], edges:[{id,source,target,fromPort,toPort}]}`. Both read and write work headlessly with a Power BI token.

## Tooling — `deploy/scripts/taskflow.py`

- **export** — pulls the flow and resolves each item GUID → display name (portable form), saved to `fabric/taskflow/taskflow.json`.
- **deploy** — resolves names → the **target** workspace's GUIDs (`artifactType` → Fabric item type), reuses the target's `resourceId`/`etag`, and PUTs.

`powershell
python -m deploy.scripts.taskflow export --workspace "Retail Demo"
python -m deploy.scripts.taskflow deploy --workspace "retail-demo-dev"
`

## Caveats (documented in the README)

- **Live write** — no fabric-cicd publisher exists for task flows, so `deploy` writes the metadata cluster directly and is **not** auto-wired into `retail-setup deploy` (run it as an explicit post-deploy step).
- **Undocumented** endpoints may change.
- **Stale/legacy refs** — items whose GUID is gone from the source export as `artifactName: null`; semantic models use a legacy `dataset` id. These are skipped on deploy.

## Validation

- Live **export** of the Retail Demo task flow succeeded (10 tasks, 11 edges; 38/49 items resolved to names, 11 stale/legacy correctly flagged).
- Direct API pull + the captured PUT confirm both endpoints.
- `pytest tests/deploy/test_taskflow.py` → 4 passed; `ruff` clean.