### PR TITLE
feat(deploy): rename Reporting folder & bootstrap MLflow experiments into an ML folder

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -90,8 +90,9 @@ After the Eventhouse and KQL database exist:
 
 - Published items are organized into Fabric workspace folders: demo/pipeline
   notebooks under **Notebooks**, one-time setup notebooks under **Setup**, the
-  semantic model and report under **Power BI**, and Data Pipelines under
-  **Pipelines**. The Lakehouse and queryset stay at the workspace root.
+  semantic model and report under **Reporting**, Data Pipelines under
+  **Pipelines**, and bootstrapped MLflow experiments under **ML** (with the `ml`
+  notebook group). The Lakehouse and queryset stay at the workspace root.
 - `unpublish_skip` defaults to `true` to avoid deleting items unexpectedly.
 - Eventstream deployment is disabled by default because Fabric source-control
   item definitions for Eventstream are not yet part of this framework.

--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -56,6 +56,7 @@ deployment:
     - Report
     - KQLQueryset
     - DataPipeline
+    - MLExperiment
   publish_skip: false
   unpublish_skip: true
   orphan_exclude_regex: "^DO_NOT_DELETE_.*"

--- a/deploy/fabric-cicd/config.yml
+++ b/deploy/fabric-cicd/config.yml
@@ -9,6 +9,7 @@ core:
   - Report
   - KQLQueryset
   - DataPipeline
+  - MLExperiment
   parameter: parameter.yml
 publish:
   skip:

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -20,12 +20,30 @@ PLATFORM_SCHEMA = (
 # staged directory structure to Fabric workspace folders, so staging an item
 # under `<output>/Notebooks/<item>` places it in a "Notebooks" workspace folder.
 # Demo/pipeline notebooks go under "Notebooks"; one-time setup notebooks (and
-# other setup artifacts) go under "Setup". The Lakehouse shell and KQLQueryset
-# stay at the workspace root.
+# other setup artifacts) go under "Setup"; the semantic model and report go under
+# "Reporting"; MLflow experiments go under "ML". The Lakehouse shell and
+# KQLQueryset stay at the workspace root.
 NOTEBOOKS_FOLDER = "Notebooks"
 SETUP_FOLDER = "Setup"
-POWERBI_FOLDER = "Power BI"
+POWERBI_FOLDER = "Reporting"
 PIPELINES_FOLDER = "Pipelines"
+ML_FOLDER = "ML"
+
+# MLflow experiments the ML notebooks (group "ml") create on first run. Bootstrap
+# them as MLExperiment shell items so they exist (and are organized under the "ML"
+# folder) before the notebooks run. Names match each notebook's default
+# MLFLOW_EXPERIMENT value.
+ML_EXPERIMENTS = [
+    "demand_forecast",
+    "market_basket",
+    "customer_segmentation",
+    "churn_prediction",
+    "promotion_effectiveness",
+    "journey_analysis",
+    "stockout_prediction",
+    "delivery_prediction",
+    "dynamic_pricing",
+]
 NOTEBOOK_GROUPS = {
     "core": [
         "01-create-bronze-shortcuts.ipynb",
@@ -287,6 +305,18 @@ def _deployed_notebook_names(notebook_groups: list[str]) -> set[str]:
     return names
 
 
+def stage_ml_experiments(output_dir: Path) -> list[Path]:
+    """Stage MLflow experiments as MLExperiment shell items.
+
+    fabric-cicd publishes MLExperiment shell-only (no definition), so each name
+    becomes a `<name>.MLExperiment` shell. Pre-creating them lets the ML
+    notebooks reuse the experiments rather than creating them on first run, and
+    groups them under the "ML" workspace folder.
+    """
+
+    return [stage_shell_item(output_dir, name, "MLExperiment") for name in ML_EXPERIMENTS]
+
+
 def build_workspace(
     repo_root: Path = REPO_ROOT,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
@@ -358,6 +388,11 @@ def build_workspace(
             _deployed_notebook_names(notebook_groups),
         )
     )
+    # MLflow experiments bootstrap alongside the ML notebooks, under "ML".
+    if "ml" in notebook_groups:
+        staged_items.extend(
+            item.name for item in stage_ml_experiments(output_dir / ML_FOLDER)
+        )
     return BuildResult(output_dir=output_dir, staged_items=sorted(staged_items))
 
 

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -102,10 +102,10 @@ def test_build_workspace_stages_core_assets(tmp_path: Path) -> None:
     assert "retail_kql.KQLDatabase" not in result.staged_items
 
     # Notebooks publish under a "Notebooks" workspace folder; Power BI items
-    # under a "Power BI" folder; the Lakehouse shell stays at the root.
+    # under a "Reporting" folder; the Lakehouse shell stays at the root.
     assert (output / "Notebooks" / "01-create-bronze-shortcuts.Notebook").is_dir()
-    assert (output / "Power BI" / "retail_model.SemanticModel").is_dir()
-    assert (output / "Power BI" / "retail_model.Report").is_dir()
+    assert (output / "Reporting" / "retail_model.SemanticModel").is_dir()
+    assert (output / "Reporting" / "retail_model.Report").is_dir()
     assert (output / "retail_lakehouse.Lakehouse").is_dir()
     assert not (output / "01-create-bronze-shortcuts.Notebook").exists()
 
@@ -162,6 +162,42 @@ def test_stage_querysets_returns_empty_when_no_sources(tmp_path: Path) -> None:
     (repo / "fabric" / "querysets").mkdir(parents=True)
     assert build_artifacts.stage_querysets(repo, output) == []
     assert not (output / "retail_querysets.KQLQueryset").exists()
+
+
+def test_stage_ml_experiments_creates_shell_items(tmp_path: Path) -> None:
+    staged = build_artifacts.stage_ml_experiments(tmp_path)
+
+    assert len(staged) == len(build_artifacts.ML_EXPERIMENTS)
+    item = tmp_path / "demand_forecast.MLExperiment"
+    assert item.is_dir()
+    platform = json.loads((item / ".platform").read_text(encoding="utf-8"))
+    assert platform["metadata"]["type"] == "MLExperiment"
+    assert platform["metadata"]["displayName"] == "demand_forecast"
+
+
+def test_build_workspace_stages_ml_experiments_only_with_ml_group(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    for notebook_name in build_artifacts.NOTEBOOK_GROUPS["core"] + build_artifacts.NOTEBOOK_GROUPS["ml"]:
+        _write_json(
+            repo / "fabric" / "lakehouse" / notebook_name,
+            {"metadata": {}, "cells": [], "nbformat": 4, "nbformat_minor": 5},
+        )
+    _write_json(
+        repo / "fabric" / "powerbi" / "retail_model.SemanticModel" / ".platform",
+        {"metadata": {"type": "SemanticModel"}},
+    )
+    _write_json(
+        repo / "fabric" / "powerbi" / "retail_model.Report" / ".platform",
+        {"metadata": {"type": "Report"}},
+    )
+
+    without_ml = build_artifacts.build_workspace(repo, tmp_path / "ws1", ["core"])
+    assert not (tmp_path / "ws1" / "ML").exists()
+    assert "demand_forecast.MLExperiment" not in without_ml.staged_items
+
+    with_ml = build_artifacts.build_workspace(repo, tmp_path / "ws2", ["core", "ml"])
+    assert (tmp_path / "ws2" / "ML" / "demand_forecast.MLExperiment").is_dir()
+    assert "demand_forecast.MLExperiment" in with_ml.staged_items
 
 
 def test_build_workspace_stages_querysets_when_present(tmp_path: Path) -> None:

--- a/tests/deploy/test_deploy_config.py
+++ b/tests/deploy/test_deploy_config.py
@@ -25,6 +25,7 @@ def test_load_environment_merges_defaults_and_environment() -> None:
         "Report",
         "KQLQueryset",
         "DataPipeline",
+        "MLExperiment",
     ]
 
 


### PR DESCRIPTION
## Summary

Two workspace-folder changes:

1. **Rename the `Power BI` folder → `Reporting`** (the semantic model + report now publish under **Reporting**).
2. **Bootstrap MLflow experiments** under a new **ML** folder.

## ML experiment bootstrap

The 9 ML notebooks (group `ml`) each call `mlflow.set_experiment(<name>)`, creating the experiment on first run. This pre-creates them as **MLExperiment shell items** so they exist (and are organized under **ML**) before the notebooks run — `mlflow.set_experiment` then reuses the existing experiment.

| | |
|---|---|
| Experiments | `demand_forecast`, `market_basket`, `customer_segmentation`, `churn_prediction`, `promotion_effectiveness`, `journey_analysis`, `stockout_prediction`, `delivery_prediction`, `dynamic_pricing` |
| Staged when | the `ml` notebook group is deployed (matches the notebooks) |
| Mechanism | `stage_shell_item(..., "MLExperiment")` — fabric-cicd publishes `MLExperiment` shell-only (it's in `SHELL_ONLY_PUBLISH`), like the Lakehouse |

Adds `MLExperiment` to `item_types_in_scope`.

## Validation

- Build `core setup` → folders: Notebooks, Setup, **Reporting**, Pipelines (no ML).
- Build `core setup ml` → adds **ML/** with 9 `*.MLExperiment` shells.
- `pytest tests/deploy` → 28 passed; `ruff` clean.

Independent of #280 (task flows); both branch from `main`.