### PR TITLE
feat(deploy): ship the ml notebook group by default

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -63,7 +63,7 @@ terraform -chdir=deploy\terraform apply -var-file=environments\dev.tfvars
 terraform -chdir=deploy\terraform output -json > deploy\.generated\dev\terraform-output.json
 python -m deploy.scripts.generate_configs --environment dev --terraform-output deploy\.generated\dev\terraform-output.json
 retail-setup render --env dev
-python -m deploy.scripts.build_artifacts --notebook-groups core setup --lakehouse-name retail_lakehouse
+python -m deploy.scripts.build_artifacts --notebook-groups core setup ml --lakehouse-name retail_lakehouse
 python -m deploy.scripts.deploy_items --environment dev
 python -m deploy.scripts.apply_kql --output deploy\.generated\dev\database.kql
 python -m deploy.scripts.validate_deployment --environment dev

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -565,6 +565,7 @@ def _deploy_plan(
                 "--notebook-groups",
                 "core",
                 "setup",
+                "ml",
                 "--lakehouse-name",
                 lakehouse_name,
             ],

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -17,7 +17,7 @@ def test_dry_run_prints_full_plan_and_executes_nothing(monkeypatch):
     assert calls == []
     out = result.output
     assert "generate_configs" in out and "terraform" in out
-    assert "build_artifacts" in out and "core setup" in out.replace("'", "")
+    assert "build_artifacts" in out and "core setup ml" in out.replace("'", "")
     assert "deploy_items" in out and "apply_kql" in out and "validate_deployment" in out
 
 


### PR DESCRIPTION
## Summary

Ship the `ml` notebook group by default. `retail-setup deploy` now stages `core setup ml` (was `core setup`), so a default deploy includes:

- the 9 **ML notebooks** (06–14),
- their 9 bootstrapped **MLflow experiments** (the `ML` folder, from #281),
- the **machine-learning pipeline** (its notebooks are now in scope, so `stage_pipelines` includes it).

## Change

One-line change to the deploy plan's hardcoded notebook groups in `utility/src/retail_setup/cli/main.py`, plus the dry-run test assertion and the `deploy/README.md` example.

## Validation

- `retail-setup deploy --dry-run` → `build_artifacts --notebook-groups core setup ml`.
- `pytest utility/tests/test_cli_deploy.py` → 11 passed.

> Depends on #281 (the ML folder + experiment bootstrap) for the experiments to publish. Touches a different `deploy/README.md` line than #281, so they merge cleanly.