### PR TITLE
feat(deploy): setup pipeline (KQL + setup notebooks) with post-deploy run prompt

### DIFF
--- a/deploy/fabric-cicd/parameter.yml
+++ b/deploy/fabric-cicd/parameter.yml
@@ -52,6 +52,26 @@ find_replace:
   replace_value:
     dev: $items.Notebook.14-ml-dynamic-pricing.$id
   item_type: DataPipeline
+- find_value: ada58402-29c1-5543-9bdf-4d7bac88b449
+  replace_value:
+    dev: $items.Notebook.00-apply-kql.$id
+  item_type: DataPipeline
+- find_value: f670ec39-fd56-5b27-b8b1-17cb523cb15c
+  replace_value:
+    dev: $items.Notebook.setup-01-seed-dictionaries.$id
+  item_type: DataPipeline
+- find_value: ecaa838e-f4f0-582d-a901-77d21cdbed25
+  replace_value:
+    dev: $items.Notebook.setup-02-generate-dimensions.$id
+  item_type: DataPipeline
+- find_value: a34eceb5-c8c3-5ad6-8798-a5c0d08edd16
+  replace_value:
+    dev: $items.Notebook.setup-03-generate-facts.$id
+  item_type: DataPipeline
+- find_value: 76ba8c81-cdcf-5f8b-99aa-22eb85079516
+  replace_value:
+    dev: $items.Notebook.setup-04-build-gold.$id
+  item_type: DataPipeline
 - find_value: 42c685c9-6bea-45f5-872b-7cc1353961e3
   replace_value:
     dev: $items.Notebook.03-streaming-to-silver.$id

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -160,6 +160,112 @@ def stage_setup_notebooks(
     return staged
 
 
+KQL_APPLY_NOTEBOOK = "00-apply-kql"
+
+
+def stage_kql_apply_notebook(
+    repo_root: Path,
+    output_dir: Path,
+    kql_database_name: str = "retail_kql",
+) -> Path:
+    """Generate and stage a notebook that applies the Eventhouse KQL setup scripts.
+
+    The notebook resolves the workspace's KQL database at runtime and runs the
+    combined ``.execute database script`` (built from ``fabric/kql_database/*.kql``)
+    with Kqlmagic. It is chained first in the setup pipeline so the Eventhouse
+    schema exists before the data-generation notebooks run.
+
+    Note: notebook execution can't be validated outside Fabric — verify the first
+    run and adjust the Kqlmagic auth if a headless pipeline run can't sign in.
+    """
+
+    from deploy.scripts import apply_kql
+
+    scripts = apply_kql.collect_kql_scripts(repo_root / "fabric" / "kql_database")
+    kql_script = apply_kql.build_database_script(scripts)
+    notebook = _kql_apply_notebook_content(kql_script, kql_database_name)
+
+    item_dir = output_dir / f"{KQL_APPLY_NOTEBOOK}.Notebook"
+    item_dir.mkdir(parents=True, exist_ok=True)
+    _write_platform(item_dir, "Notebook", KQL_APPLY_NOTEBOOK)
+    (item_dir / "notebook-content.ipynb").write_text(
+        json.dumps(notebook, indent=1, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return item_dir
+
+
+def _kql_apply_notebook_content(kql_script: str, kql_database_name: str) -> dict:
+    """Build the ipynb JSON for the KQL-apply notebook (Kqlmagic + embedded KQL)."""
+
+    resolve = (
+        "import requests, notebookutils\n"
+        "ws_id = notebookutils.runtime.context['currentWorkspaceId']\n"
+        "tok = notebookutils.credentials.getToken('pbi')\n"
+        "resp = requests.get(\n"
+        "    f'https://api.fabric.microsoft.com/v1/workspaces/{ws_id}/kqlDatabases',\n"
+        "    headers={'Authorization': f'Bearer {tok}'},\n"
+        ")\n"
+        "resp.raise_for_status()\n"
+        "dbs = resp.json()['value']\n"
+        f"db = next((d for d in dbs if d['displayName'] == {kql_database_name!r}), dbs[0])\n"
+        "query_uri = db['properties']['queryServiceUri']\n"
+        "db_name = db['displayName']\n"
+        "print(f'KQL database: {db_name} @ {query_uri}')"
+    )
+    connect = (
+        "%reload_ext Kqlmagic\n"
+        "from IPython import get_ipython\n"
+        "kusto_token = notebookutils.credentials.getToken(query_uri)\n"
+        "conn = (\n"
+        "    f\"azureDataExplorer://aadtoken='{kusto_token}';\"\n"
+        "    f\"cluster='{query_uri}';database='{db_name}'\"\n"
+        ")\n"
+        "get_ipython().run_line_magic('kql', conn)"
+    )
+    run = (
+        "import json\n"
+        "from IPython import get_ipython\n"
+        f"KQL_SCRIPT = json.loads(r'''{json.dumps(kql_script)}''')\n"
+        "get_ipython().run_cell_magic('kql', '', KQL_SCRIPT)\n"
+        "print('KQL setup scripts applied.')"
+    )
+    return {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": (
+                    "# Apply KQL setup scripts\n\n"
+                    "Applies the Eventhouse KQL setup (tables, ingestion mappings, "
+                    "functions, materialized views) with Kqlmagic. Generated from "
+                    "`fabric/kql_database/*.kql` by `build_artifacts` — do not edit by hand."
+                ),
+            },
+            _code_cell("%pip install --quiet Kqlmagic"),
+            _code_cell(resolve),
+            _code_cell(connect),
+            _code_cell(run),
+        ],
+        "metadata": {
+            "language_info": {"name": "python"},
+            "kernelspec": {"name": "synapse_pyspark", "display_name": "Synapse PySpark"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _code_cell(source: str) -> dict:
+    return {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": source,
+    }
+
+
 def stage_querysets(
     repo_root: Path,
     output_dir: Path,
@@ -284,6 +390,7 @@ def _deployed_notebook_names(notebook_groups: list[str]) -> set[str]:
     names = {Path(name).stem for name in _selected_notebooks(notebook_groups)}
     if "setup" in notebook_groups:
         names.update(SETUP_NOTEBOOKS)
+        names.add(KQL_APPLY_NOTEBOOK)
     return names
 
 
@@ -322,13 +429,21 @@ def build_workspace(
             ).name
         )
 
-    # One-time setup notebooks publish into a separate "Setup" workspace folder.
+    # One-time setup notebooks publish into a separate "Setup" workspace folder,
+    # along with a generated 00-apply-kql notebook that applies the Eventhouse
+    # KQL setup scripts.
     if "setup" in notebook_groups:
+        setup_dir = output_dir / SETUP_FOLDER
         staged_items.extend(
             item.name
             for item in stage_setup_notebooks(
-                repo_root, output_dir / SETUP_FOLDER, lakehouse_name=lakehouse_name
+                repo_root, setup_dir, lakehouse_name=lakehouse_name
             )
+        )
+        staged_items.append(
+            stage_kql_apply_notebook(
+                repo_root, setup_dir, kql_database_name=kql_database_name
+            ).name
         )
 
     # Power BI items publish into a "Power BI" workspace folder.

--- a/deploy/scripts/run_pipeline.py
+++ b/deploy/scripts/run_pipeline.py
@@ -1,0 +1,87 @@
+"""Run a named Fabric Data Pipeline on demand via the Job Scheduler API.
+
+Resolves the workspace from the captured Terraform outputs, finds the pipeline
+item by display name, and starts an on-demand run:
+
+    POST {FABRIC_API}/workspaces/{ws}/items/{pipelineId}/jobs/instances?jobType=Pipeline
+
+Auth reuses the Azure CLI login (see ``export_items.build_session``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from deploy.scripts.export_items import build_session, list_items
+
+if TYPE_CHECKING:
+    import requests
+
+FABRIC_API = "https://api.fabric.microsoft.com/v1"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def workspace_id_from_outputs(environment: str, repo_root: Path = REPO_ROOT) -> str:
+    """Read the workspace id from the captured Terraform outputs for an environment."""
+
+    path = repo_root / "deploy" / ".generated" / environment / "terraform-output.json"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Terraform outputs not found: {path}. Run `retail-setup deploy` first."
+        )
+    outputs = json.loads(path.read_text(encoding="utf-8"))
+    value = outputs.get("workspace_id")
+    workspace = value.get("value") if isinstance(value, dict) else value
+    if not workspace:
+        raise ValueError(f"workspace_id missing from {path}")
+    return str(workspace)
+
+
+def find_pipeline_id(
+    session: requests.Session, workspace_id: str, pipeline_name: str
+) -> str:
+    """Resolve a DataPipeline display name to its item id."""
+
+    for item in list_items(session, workspace_id, "DataPipeline"):
+        if str(item.get("displayName", "")) == pipeline_name:
+            return str(item["id"])
+    raise ValueError(
+        f"Pipeline {pipeline_name!r} not found in workspace {workspace_id}. "
+        "Deploy it first (it is staged with the `setup` notebook group)."
+    )
+
+
+def run_pipeline(
+    session: requests.Session, workspace_id: str, pipeline_id: str
+) -> str | None:
+    """Start an on-demand pipeline run; returns the job-instance URL if provided."""
+
+    url = f"{FABRIC_API}/workspaces/{workspace_id}/items/{pipeline_id}/jobs/instances"
+    response = session.post(url, params={"jobType": "Pipeline"})
+    response.raise_for_status()
+    return response.headers.get("Location")
+
+
+def main() -> int:
+    """Start an on-demand run of a named Fabric pipeline."""
+
+    parser = argparse.ArgumentParser(description="Run a Fabric Data Pipeline on demand")
+    parser.add_argument("--environment", default="dev")
+    parser.add_argument("--pipeline", required=True, help="Pipeline display name.")
+    args = parser.parse_args()
+
+    workspace_id = workspace_id_from_outputs(args.environment)
+    session = build_session()
+    pipeline_id = find_pipeline_id(session, workspace_id, args.pipeline)
+    location = run_pipeline(session, workspace_id, pipeline_id)
+    print(f"Started pipeline run for {args.pipeline!r} ({pipeline_id}).")
+    if location:
+        print(f"  Track the run at: {location}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fabric/pipelines/README.md
+++ b/fabric/pipelines/README.md
@@ -9,10 +9,20 @@ workspace and use the Git-integration format that fabric-cicd publishes.
 
 | Pipeline | Orchestrates | Schedule |
 | --- | --- | --- |
+| `setup-pipeline` | `00-apply-kql` → `setup-01`…`setup-04` (KQL setup, then dimensions/facts/gold) | On demand |
 | `historical-data-load` | `02-historical-data-load` | On demand |
 | `streaming-data-load` | `03-streaming-to-silver`, `04-streaming-to-gold` | Cron |
 | `daily-maintenance` | `05-maintain-delta-tables` | Daily 00:00 |
 | `machine-learning` | `06`–`14` ML notebooks | On demand |
+
+`setup-pipeline` is authored in this repo (not exported). Its first step,
+`00-apply-kql`, is a notebook **generated** by `build_artifacts` from
+`fabric/kql_database/*.kql` that applies the Eventhouse KQL setup with Kqlmagic;
+the remaining steps run the rendered setup notebooks in order. After
+`retail-setup deploy` completes, it offers to run `setup-pipeline` on demand
+(via `deploy.scripts.run_pipeline`). The `00-apply-kql` notebook can only be
+validated by running it in Fabric — verify its first run and adjust the Kqlmagic
+auth if a headless pipeline run can't authenticate.
 
 ## Re-exporting from Fabric
 

--- a/fabric/pipelines/setup-pipeline.DataPipeline/.platform
+++ b/fabric/pipelines/setup-pipeline.DataPipeline/.platform
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "DataPipeline",
+    "displayName": "setup-pipeline",
+    "description": "Runs the setup notebooks in order (seed dictionaries, generate dimensions, generate facts, build gold)."
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json
+++ b/fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json
@@ -1,0 +1,106 @@
+{
+  "properties": {
+    "activities": [
+      {
+        "name": "00-apply-kql",
+        "type": "TridentNotebook",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "ada58402-29c1-5543-9bdf-4d7bac88b449",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "setup-01-seed-dictionaries",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "00-apply-kql",
+            "dependencyConditions": ["Succeeded"]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "f670ec39-fd56-5b27-b8b1-17cb523cb15c",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "setup-02-generate-dimensions",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-01-seed-dictionaries",
+            "dependencyConditions": ["Succeeded"]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "ecaa838e-f4f0-582d-a901-77d21cdbed25",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "setup-03-generate-facts",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-02-generate-dimensions",
+            "dependencyConditions": ["Succeeded"]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "a34eceb5-c8c3-5ad6-8798-a5c0d08edd16",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "setup-04-build-gold",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-03-generate-facts",
+            "dependencyConditions": ["Succeeded"]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "76ba8c81-cdcf-5f8b-99aa-22eb85079516",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      }
+    ]
+  }
+}

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -164,6 +164,34 @@ def test_stage_querysets_returns_empty_when_no_sources(tmp_path: Path) -> None:
     assert not (output / "retail_querysets.KQLQueryset").exists()
 
 
+def test_stage_kql_apply_notebook_embeds_kqlmagic_and_scripts(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    kql_dir = repo / "fabric" / "kql_database"
+    kql_dir.mkdir(parents=True)
+    (kql_dir / "01-create-tables.kql").write_text(
+        ".create table receipts (id:string)", encoding="utf-8"
+    )
+    (kql_dir / "02-create-functions.kql").write_text(
+        ".create function foo() { receipts | count }", encoding="utf-8"
+    )
+
+    output = tmp_path / "workspace"
+    item = build_artifacts.stage_kql_apply_notebook(repo, output, kql_database_name="retail_kql")
+
+    assert item == output / "00-apply-kql.Notebook"
+    platform = json.loads((item / ".platform").read_text(encoding="utf-8"))
+    assert platform["metadata"]["type"] == "Notebook"
+    assert platform["metadata"]["displayName"] == "00-apply-kql"
+    notebook = json.loads((item / "notebook-content.ipynb").read_text(encoding="utf-8"))
+    text = "\n".join(
+        c["source"] if isinstance(c["source"], str) else "".join(c["source"])
+        for c in notebook["cells"]
+    )
+    assert "Kqlmagic" in text
+    assert "create table receipts" in text  # embedded KQL
+    assert "retail_kql" in text  # target database name
+
+
 def test_build_workspace_stages_querysets_when_present(tmp_path: Path) -> None:
     source_root = tmp_path / "repo"
     for notebook_name in build_artifacts.NOTEBOOK_GROUPS["core"]:
@@ -324,6 +352,12 @@ def test_build_workspace_threads_custom_lakehouse_name_to_setup_notebooks(
     _write_json(
         repo / "fabric" / "powerbi" / "retail_model.Report" / ".platform",
         {"metadata": {"type": "Report"}},
+    )
+
+    # KQL source for the generated 00-apply-kql notebook (setup group).
+    (repo / "fabric" / "kql_database").mkdir(parents=True)
+    (repo / "fabric" / "kql_database" / "01-create-tables.kql").write_text(
+        ".create table receipts (id:string)", encoding="utf-8"
     )
 
     build_artifacts.build_workspace(

--- a/tests/deploy/test_run_pipeline.py
+++ b/tests/deploy/test_run_pipeline.py
@@ -1,0 +1,61 @@
+"""Tests for the on-demand Fabric pipeline runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deploy.scripts import run_pipeline
+
+
+def test_workspace_id_from_outputs_reads_terraform_value(tmp_path: Path) -> None:
+    out = tmp_path / "deploy" / ".generated" / "dev" / "terraform-output.json"
+    out.parent.mkdir(parents=True)
+    out.write_text(json.dumps({"workspace_id": {"value": "ws-123"}}), encoding="utf-8")
+
+    assert run_pipeline.workspace_id_from_outputs("dev", repo_root=tmp_path) == "ws-123"
+
+
+def test_workspace_id_from_outputs_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Terraform outputs not found"):
+        run_pipeline.workspace_id_from_outputs("dev", repo_root=tmp_path)
+
+
+def test_find_pipeline_id_matches_display_name() -> None:
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "value": [
+                    {"displayName": "daily-maintenance", "id": "1"},
+                    {"displayName": "setup-pipeline", "id": "2"},
+                ]
+            }
+
+    class _FakeSession:
+        def get(self, url: str, params: dict | None = None) -> _FakeResponse:
+            return _FakeResponse()
+
+    assert (
+        run_pipeline.find_pipeline_id(_FakeSession(), "ws", "setup-pipeline") == "2"
+    )
+
+
+def test_find_pipeline_id_raises_when_missing() -> None:
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"value": [{"displayName": "other", "id": "1"}]}
+
+    class _FakeSession:
+        def get(self, url: str, params: dict | None = None) -> _FakeResponse:
+            return _FakeResponse()
+
+    with pytest.raises(ValueError, match="not found"):
+        run_pipeline.find_pipeline_id(_FakeSession(), "ws", "setup-pipeline")

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -706,6 +706,41 @@ def deploy(
 
     typer.echo(f"Deploy complete for environment '{env}'.")
 
+    if not yes:
+        if typer.confirm(
+            "Run the setup pipeline now (apply KQL setup, then generate "
+            "dimensions, facts, and gold)?",
+            default=False,
+        ):
+            _run_setup_pipeline(repo_root, env)
+        else:
+            typer.echo(
+                "Skipping. Run later with: "
+                "retail-setup deploy --env " + env + " (or trigger 'setup-pipeline' in Fabric)."
+            )
+
+
+def _run_setup_pipeline(repo_root: Path, env: str) -> None:
+    """Start an on-demand run of the deployed setup pipeline."""
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "deploy.scripts.run_pipeline",
+        "--environment",
+        env,
+        "--pipeline",
+        "setup-pipeline",
+    ]
+    typer.echo("    " + " ".join(cmd))
+    result = subprocess.run(cmd, cwd=repo_root)
+    if result.returncode != 0:
+        typer.echo(
+            "Could not start the setup pipeline automatically. Open the workspace "
+            "in Fabric and run 'setup-pipeline' manually.",
+            err=True,
+        )
+
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Summary

Adds a **setup pipeline** that wires up the KQL setup + the setup notebooks, and prompts to run it at the end of `retail-setup deploy`.

## setup-pipeline

`fabric/pipelines/setup-pipeline.DataPipeline` chains:

`00-apply-kql` → `setup-01-seed-dictionaries` → `setup-02-generate-dimensions` → `setup-03-generate-facts` → `setup-04-build-gold`

- **`00-apply-kql`** is a notebook **generated** by `build_artifacts` from `fabric/kql_database/*.kql`. It resolves the workspace's KQL database at runtime and applies the combined `.execute database script` with **Kqlmagic** (per your suggestion). A KQL *activity* was avoided because [its connection doesn't remap across workspaces](https://learn.microsoft.com/en-us/fabric/data-factory/kql-activity#known-limitations); a notebook activity remaps cleanly via the existing pipeline parameter logic.
- The pipeline is staged with the `setup` group (default deploy), and its 5 notebook references remap to `\.Notebook.<name>.\` automatically.

## Run prompt

After `retail-setup deploy` completes (interactive only), it asks **"Run the setup pipeline now?"**. If yes, `deploy.scripts.run_pipeline` starts an on-demand run via the Fabric Job Scheduler API (`POST .../items/{id}/jobs/instances?jobType=Pipeline`).

## Validation

- Build (`core setup ml`) → `Setup/00-apply-kql.Notebook` generated (Kqlmagic + embedded KQL) and `Pipelines/setup-pipeline.DataPipeline` staged with activities `00-apply-kql → setup-01…04`.
- `parameter.yml` gains the 5 `\.Notebook.*` rules for the setup pipeline.
- `pytest tests/deploy + test_cli_deploy` → 42 passed; `ruff` clean.

> **Caveat:** the `00-apply-kql` notebook can't be executed outside Fabric, so its first run should be validated there; if a headless pipeline run can't authenticate to Kusto, the Kqlmagic auth line may need adjustment. Independent of #281/#282 (different files / lines).