### PR TITLE
feat(deploy): detect existing workspace and prompt to reset (no --recreate needed)

### DIFF
--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -7,6 +7,7 @@ generation values (validated via GenerationConfig, written to utility/config.yam
 
 from __future__ import annotations
 
+import json
 import subprocess
 import shutil
 import sys
@@ -399,6 +400,54 @@ def _lakehouse_name(repo_root: Path, env: str) -> str:
     return str(name)
 
 
+def _workspace_name(repo_root: Path, env: str) -> str:
+    """Resolve the target workspace.name from deploy config (overlay wins)."""
+    base = yaml.safe_load((repo_root / "deploy" / "config" / "deploy.yml").read_text()) or {}
+    env_path = repo_root / "deploy" / "config" / "environments" / f"{env}.yml"
+    overlay = yaml.safe_load(env_path.read_text()) or {} if env_path.is_file() else {}
+    name = _get_by_path(overlay, "workspace.name")
+    if name is None:
+        name = _get_by_path(base, "workspace.name")
+    return str(name) if name is not None else f"retail-demo-{env}"
+
+
+def _workspace_exists(repo_root: Path, workspace_name: str) -> bool:
+    """Return True if a Fabric workspace with this display name already exists.
+
+    Best-effort: queries the Fabric REST API via the Azure CLI. Returns False if
+    the CLI is unavailable or the query fails, so detection never blocks a deploy.
+    """
+    az = shutil.which("az") or shutil.which("az.cmd") or shutil.which("az.exe")
+    if not az:
+        return False
+    try:
+        result = subprocess.run(
+            [
+                az, "rest",
+                "--resource", "https://api.fabric.microsoft.com",
+                "--url", "https://api.fabric.microsoft.com/v1/workspaces",
+                "-o", "json",
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return False
+    return any(
+        str(item.get("displayName", "")) == workspace_name
+        for item in data.get("value", [])
+    )
+
+
 def _resolve_dictionary_ref(repo_root: Path, ref: str | None) -> str:
     """Pin the dictionary ref: explicit --ref, else HEAD SHA, else 'main' with a warning."""
     if ref:
@@ -638,7 +687,9 @@ def deploy(
 
     With --recreate, the deployment destroys the existing workspace (and every
     item in it) and recreates it from scratch. This is destructive; use it only
-    for a clean-slate redeploy.
+    for a clean-slate redeploy. If you omit --recreate, an interactive deploy
+    detects an existing workspace and offers to reset it, so the flag is
+    optional.
     """
     repo_root = repo_root.resolve()
     if recreate and skip_terraform:
@@ -660,6 +711,21 @@ def deploy(
     else:
         lakehouse = _lakehouse_name(repo_root, env)
         _validate_azure_cli_tenant(repo_root, env)
+        # Auto-detect a prior deployment so the user doesn't need to remember
+        # --recreate. If the workspace exists, offer a clean-slate reset.
+        if not recreate and not skip_terraform and not yes:
+            ws_name = _workspace_name(repo_root, env)
+            if _workspace_exists(repo_root, ws_name):
+                typer.echo("")
+                typer.echo(f"Workspace '{ws_name}' already exists from a previous deploy.")
+                if typer.confirm(
+                    "Reset it? This DESTROYS the workspace and ALL items in it, "
+                    "then redeploys from scratch",
+                    default=False,
+                ):
+                    recreate = True
+                else:
+                    typer.echo("Keeping it — updating the existing workspace in place.")
     plan = _deploy_plan(env, skip_terraform, lakehouse_name=lakehouse, recreate=recreate)
     total = len(plan)
 

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -73,6 +73,72 @@ def test_recreate_warns_and_aborts_on_decline(monkeypatch):
     assert "Aborted by user" in result.output
 
 
+def test_deploy_offers_reset_when_workspace_exists(monkeypatch):
+    monkeypatch.setattr("retail_setup.cli.main._validate_azure_cli_tenant", lambda *_: None)
+    monkeypatch.setattr("retail_setup.cli.main._workspace_exists", lambda *_: True)
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: SimpleNamespace(returncode=0))
+    # Accept the reset prompt ("y"), then decline the destroy gate ("n") to stop.
+    result = runner.invoke(app, ["deploy", "--env", "dev"], input="y\nn\n")
+    assert "already exists" in result.output
+    assert "destroy" in result.output  # confirming reset took the recreate path
+    assert "Aborted by user" in result.output
+
+
+def test_deploy_skips_reset_prompt_when_workspace_absent(monkeypatch):
+    monkeypatch.setattr("retail_setup.cli.main._validate_azure_cli_tenant", lambda *_: None)
+    monkeypatch.setattr("retail_setup.cli.main._workspace_exists", lambda *_: False)
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: SimpleNamespace(returncode=0))
+    result = runner.invoke(app, ["deploy", "--env", "dev"], input="n\n")
+    assert "already exists" not in result.output
+
+
+def test_deploy_yes_skips_reset_prompt(monkeypatch):
+    seen = {"checked": False}
+
+    def fake_exists(*_):
+        seen["checked"] = True
+        return True
+
+    monkeypatch.setattr("retail_setup.cli.main._validate_azure_cli_tenant", lambda *_: None)
+    monkeypatch.setattr("retail_setup.cli.main._workspace_exists", fake_exists)
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: SimpleNamespace(returncode=0))
+    runner.invoke(app, ["deploy", "--env", "dev", "--yes"])
+    assert seen["checked"] is False  # --yes never prompts for reset
+
+
+def test_workspace_exists_matches_display_name(monkeypatch):
+    monkeypatch.setattr("retail_setup.cli.main.shutil.which", lambda _c: "C:/az.cmd")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: subprocess.CompletedProcess(
+            a, 0, stdout='{"value": [{"displayName": "retail-demo-dev"}]}'
+        ),
+    )
+    from retail_setup.cli.main import _workspace_exists
+
+    assert _workspace_exists(Path("."), "retail-demo-dev") is True
+    assert _workspace_exists(Path("."), "missing") is False
+
+
+def test_workspace_exists_false_when_az_unavailable(monkeypatch):
+    monkeypatch.setattr("retail_setup.cli.main.shutil.which", lambda _c: None)
+    from retail_setup.cli.main import _workspace_exists
+
+    assert _workspace_exists(Path("."), "retail-demo-dev") is False
+
+
+def test_workspace_name_prefers_environment_overlay(tmp_path):
+    cfg = tmp_path / "deploy" / "config"
+    (cfg / "environments").mkdir(parents=True)
+    (cfg / "deploy.yml").write_text("workspace:\n  name: retail-demo\n", encoding="utf-8")
+    (cfg / "environments" / "dev.yml").write_text(
+        "workspace:\n  name: retail-demo-dev\n", encoding="utf-8"
+    )
+    from retail_setup.cli.main import _workspace_name
+
+    assert _workspace_name(tmp_path, "dev") == "retail-demo-dev"
+
+
 def test_deploy_reports_missing_terraform_without_traceback(monkeypatch):
     def fake_run(cmd, *args, **kwargs):
         if cmd and cmd[0] == "terraform":


### PR DESCRIPTION
## Summary

Makes resetting a deployed environment effortless: an interactive `retail-setup deploy` now **detects an existing workspace and offers to reset it**, so you don't have to remember `--recreate`.

## Behavior

Before building the deploy plan (non-dry-run, no `--recreate`, no `--yes`):
1. Resolve the target workspace name from the merged deploy config (`_workspace_name`).
2. Query the Fabric REST API via `az rest` to check if a workspace with that name exists (`_workspace_exists` — best-effort; returns `False` if the CLI/query is unavailable so it never blocks a deploy).
3. If it exists, prompt: *"Workspace '<name>' already exists… Reset it? This DESTROYS the workspace and ALL items, then redeploys from scratch"*.
   - **Yes** → take the recreate path (terraform destroy → wait → apply), same as `--recreate`.
   - **No** → update the existing workspace in place.

`--recreate` still works (forces recreate, e.g. for CI/non-interactive). `--yes` never prompts.

## How to reset (answer to "how do I reset the environment")

- **Interactive:** just run `retail-setup deploy --env <env>` — it now offers to reset if the workspace exists.
- **Non-interactive / scripted:** `retail-setup deploy --env <env> --recreate`.
- **Terraform only:** `terraform -chdir=deploy/terraform destroy -var-file=environments/<env>.tfvars`.

## Validation

- Live check: resolves `retail-demo-dev` and `_workspace_exists` returns `True` for it, `False` for a bogus name.
- `pytest utility/tests/test_cli_deploy.py` → 17 passed (6 new: reset prompt taken/declined, `--yes` skips, name resolution, existence parsing, no-az fallback); `ruff` clean.
- Independent of #283 (different parts of `deploy()`).