### PR TITLE
fix(deploy): stop validation from flagging resolvable KQL queryset placeholder

### DIFF
--- a/deploy/scripts/validate_deployment.py
+++ b/deploy/scripts/validate_deployment.py
@@ -9,6 +9,30 @@ import yaml
 
 from deploy.scripts.deploy_config import DEPLOY_ROOT, load_environment
 
+# Placeholders that staged item definitions may legitimately contain. They are
+# resolved in-flight by fabric-cicd from parameter.yml at publish time (the
+# on-disk file keeps the placeholder), so a placeholder is only a problem when
+# parameter.yml has no resolving find_replace rule for the environment.
+KNOWN_PLACEHOLDERS = ("FABRIC_KQL_DATABASE_RESOURCE_ID",)
+
+
+def _resolved_placeholders(parameter_path: Path, environment: str) -> set[str]:
+    """find_values in parameter.yml that have a replacement for this environment."""
+
+    if not parameter_path.exists():
+        return set()
+    try:
+        params = yaml.safe_load(parameter_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return set()
+    resolved: set[str] = set()
+    for rule in params.get("find_replace", []) or []:
+        find_value = rule.get("find_value")
+        replace_value = (rule.get("replace_value") or {}).get(environment)
+        if find_value and replace_value:
+            resolved.add(str(find_value))
+    return resolved
+
 
 def validate_generated_files(deploy_root: Path, environment: str) -> list[str]:
     """Return validation errors for generated deployment files."""
@@ -16,10 +40,11 @@ def validate_generated_files(deploy_root: Path, environment: str) -> list[str]:
     errors: list[str] = []
     load_environment(environment)
 
+    parameter_path = deploy_root / "fabric-cicd" / "parameter.yml"
     required_files = [
         deploy_root / "terraform" / "environments" / f"{environment}.tfvars",
         deploy_root / "fabric-cicd" / "config.yml",
-        deploy_root / "fabric-cicd" / "parameter.yml",
+        parameter_path,
     ]
     for path in required_files:
         if not path.exists():
@@ -32,17 +57,25 @@ def validate_generated_files(deploy_root: Path, environment: str) -> list[str]:
             except yaml.YAMLError as exc:
                 errors.append(f"Invalid YAML in {yaml_path}: {exc}")
 
+    # A staged item may contain a placeholder (e.g. the queryset's KQL database
+    # id) as long as parameter.yml has a find_replace rule that resolves it for
+    # this environment — fabric-cicd performs the substitution at publish time.
+    # Only flag a placeholder that has no resolving rule, which would publish the
+    # literal placeholder string.
     workspace_dir = deploy_root / "workspace"
     if workspace_dir.exists():
-        unresolved = [
-            path
-            for path in workspace_dir.rglob("*")
-            if path.is_file()
-            and "FABRIC_KQL_DATABASE_RESOURCE_ID" in path.read_text(
-                encoding="utf-8", errors="ignore"
-            )
-        ]
-        errors.extend(f"Unresolved placeholder in {path}" for path in unresolved)
+        resolved = _resolved_placeholders(parameter_path, environment)
+        for path in workspace_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            content = path.read_text(encoding="utf-8", errors="ignore")
+            for placeholder in KNOWN_PLACEHOLDERS:
+                if placeholder in content and placeholder not in resolved:
+                    errors.append(
+                        f"Unresolved placeholder {placeholder} in {path} "
+                        f"(no find_replace rule for environment '{environment}' "
+                        f"in parameter.yml)"
+                    )
 
     return errors
 

--- a/tests/deploy/test_validate_deployment.py
+++ b/tests/deploy/test_validate_deployment.py
@@ -1,0 +1,96 @@
+"""Tests for offline deployment validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from deploy.scripts import validate_deployment
+
+
+def _write_required(deploy_root: Path, parameter: dict) -> None:
+    """Create the minimal required generated files for validation."""
+
+    (deploy_root / "terraform" / "environments").mkdir(parents=True)
+    (deploy_root / "terraform" / "environments" / "dev.tfvars").write_text(
+        "workspace_name = \"x\"\n", encoding="utf-8"
+    )
+    fabric = deploy_root / "fabric-cicd"
+    fabric.mkdir(parents=True)
+    (fabric / "config.yml").write_text("core: {}\n", encoding="utf-8")
+    (fabric / "parameter.yml").write_text(yaml.safe_dump(parameter), encoding="utf-8")
+
+
+def _stage_queryset_with_placeholder(deploy_root: Path) -> None:
+    item = deploy_root / "workspace" / "retail_querysets.KQLQueryset"
+    item.mkdir(parents=True)
+    (item / "RealTimeQueryset.json").write_text(
+        '{"queryset": {"dataSources": [{"databaseItemId": '
+        '"FABRIC_KQL_DATABASE_RESOURCE_ID"}]}}',
+        encoding="utf-8",
+    )
+
+
+def test_placeholder_passes_when_parameter_rule_resolves_it(tmp_path: Path) -> None:
+    deploy_root = tmp_path / "deploy"
+    _write_required(
+        deploy_root,
+        {
+            "find_replace": [
+                {
+                    "find_value": "FABRIC_KQL_DATABASE_RESOURCE_ID",
+                    "replace_value": {"dev": "real-kql-guid"},
+                    "item_type": ["KQLQueryset"],
+                }
+            ]
+        },
+    )
+    _stage_queryset_with_placeholder(deploy_root)
+
+    errors = validate_deployment.validate_generated_files(deploy_root, "dev")
+
+    # The placeholder is present on disk but parameter.yml resolves it -> no error.
+    assert errors == []
+
+
+def test_placeholder_fails_when_no_resolving_rule(tmp_path: Path) -> None:
+    deploy_root = tmp_path / "deploy"
+    # parameter.yml has no find_replace rule for the placeholder.
+    _write_required(deploy_root, {"find_replace": []})
+    _stage_queryset_with_placeholder(deploy_root)
+
+    errors = validate_deployment.validate_generated_files(deploy_root, "dev")
+
+    assert any("Unresolved placeholder" in e for e in errors)
+
+
+def test_placeholder_fails_when_rule_targets_other_environment(tmp_path: Path) -> None:
+    deploy_root = tmp_path / "deploy"
+    _write_required(
+        deploy_root,
+        {
+            "find_replace": [
+                {
+                    "find_value": "FABRIC_KQL_DATABASE_RESOURCE_ID",
+                    "replace_value": {"prod": "real-kql-guid"},
+                }
+            ]
+        },
+    )
+    _stage_queryset_with_placeholder(deploy_root)
+
+    errors = validate_deployment.validate_generated_files(deploy_root, "dev")
+
+    # Rule resolves "prod" but we validate "dev" -> still unresolved for dev.
+    assert any("Unresolved placeholder" in e for e in errors)
+
+
+def test_missing_required_file_reported(tmp_path: Path) -> None:
+    deploy_root = tmp_path / "deploy"
+    _write_required(deploy_root, {"find_replace": []})
+    (deploy_root / "fabric-cicd" / "config.yml").unlink()
+
+    errors = validate_deployment.validate_generated_files(deploy_root, "dev")
+
+    assert any("Missing required file" in e for e in errors)


### PR DESCRIPTION
## Problem

Your deploy published successfully (step 8 ✅) but failed at step 10:

`ERROR: Unresolved placeholder in ...retail_querysets.KQLQueryset\RealTimeQueryset.json`

## Root cause

`validate_deployment` scanned the **staged source** for the literal string `FABRIC_KQL_DATABASE_RESOURCE_ID` and failed if present. But that placeholder is **intentional**: fabric-cicd resolves it **in-memory** from `parameter.yml`'s `find_replace` rule at publish time — the on-disk staged `RealTimeQueryset.json` always keeps the placeholder. So once the KQLQueryset feature (#276) started staging that file, this check failed **every** deploy, even though publishing worked correctly.

Verified on your live state: `parameter.yml` resolves it (`dev: 381fc9b7-…`) and the staged file retains the placeholder — exactly as designed.

## Fix

A placeholder in a staged file is now an error **only when `parameter.yml` has no rule resolving it for the environment** (which would publish the literal string). The safety net for the genuinely-broken case — e.g. when Terraform didn't emit `kql_database_id` so no rule is generated — is preserved.

## Validation

- The **fixed** validator passes against your live `deploy/` state (real `parameter.yml` + staged workspace) → "Deployment framework validation passed".
- New `tests/deploy/test_validate_deployment.py`: placeholder + resolving rule → pass; no rule → fail; rule for a different env → fail; missing required file → fail.
- `pytest tests/deploy` → 41 passed; `ruff` clean.

This is the last step of your deploy — with this merged, `retail-setup deploy --env dev` completes cleanly end to end.