### PR TITLE
feat(taskflow): create on fresh workspace + wire task flow deploy into the deploy flow

### DIFF
--- a/deploy/scripts/taskflow.py
+++ b/deploy/scripts/taskflow.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -107,34 +108,74 @@ def list_workspace_items(
 
 def get_taskflow(
     pbi_session: requests.Session, cluster: str, workspace_id: str
-) -> dict[str, Any]:
-    """Read the raw task flow record (``{etag, resourceId, taskFlow}``)."""
+) -> dict[str, Any] | None:
+    """Read the raw task flow record (``{etag, resourceId, taskFlow}``) or ``None``.
+
+    A workspace that has never had a task flow returns an empty list; this
+    returns ``None`` in that case so callers can create one.
+    """
 
     url = f"{cluster}/metadata/workspaces/{workspace_id}/taskflow202602"
     response = pbi_session.get(url)
     response.raise_for_status()
     records = response.json()
-    if not records:
-        raise ValueError(f"No task flow found in workspace {workspace_id}")
-    return records[0]
+    return records[0] if records else None
 
 
 def put_taskflow(
     pbi_session: requests.Session,
     cluster: str,
     workspace_id: str,
-    resource_id: str,
+    record: dict[str, Any],
     task_flow: dict[str, Any],
-    etag: str | None = None,
 ) -> int:
-    """Write a task flow (``{tasks, edges}``) back to the workspace."""
+    """Update an existing task flow in the workspace.
 
+    The body must carry the existing task-flow identity (``id``/``name``/
+    ``description``) — the server rejects an empty ``taskflow.Id`` — plus the new
+    ``tasks`` and ``edges``.
+    """
+
+    resource_id = record["resourceId"]
+    existing = record.get("taskFlow", {})
     url = f"{cluster}/metadata/workspaces/{workspace_id}/taskflow202512/{resource_id}"
     headers = {"Content-Type": "application/json"}
-    if etag:
-        headers["If-Match"] = etag
-    body = {"tasks": task_flow.get("tasks", []), "edges": task_flow.get("edges", [])}
+    if record.get("etag"):
+        headers["If-Match"] = record["etag"]
+    body = {
+        "id": existing.get("id") or resource_id,
+        "name": existing.get("name") or "Retail Demo",
+        "description": existing.get("description", ""),
+        "tasks": task_flow.get("tasks", []),
+        "edges": task_flow.get("edges", []),
+    }
     response = pbi_session.put(url, json=body, headers=headers)
+    response.raise_for_status()
+    return response.status_code
+
+
+def create_taskflow(
+    pbi_session: requests.Session,
+    cluster: str,
+    workspace_id: str,
+    task_flow: dict[str, Any],
+    name: str = "Retail Demo",
+) -> int:
+    """Create a workspace's first task flow via POST to the collection.
+
+    The body is the full task-flow object (``id``, ``name``, ``description``,
+    ``tasks``, ``edges``); the server rejects an empty ``id``.
+    """
+
+    url = f"{cluster}/metadata/workspaces/{workspace_id}/taskflow202512"
+    body = {
+        "id": task_flow.get("id") or str(uuid.uuid4()),
+        "name": task_flow.get("name") or name,
+        "description": task_flow.get("description", ""),
+        "tasks": task_flow.get("tasks", []),
+        "edges": task_flow.get("edges", []),
+    }
+    response = pbi_session.post(url, json=body, headers={"Content-Type": "application/json"})
     response.raise_for_status()
     return response.status_code
 
@@ -159,11 +200,17 @@ def to_portable(task_flow: dict[str, Any], guid_to_name: dict[str, str]) -> dict
 def to_workspace(
     portable: dict[str, Any], name_type_to_guid: dict[tuple[str, str], str]
 ) -> tuple[dict[str, Any], list[str]]:
-    """Resolve portable item names to target GUIDs. Returns (task_flow, unresolved)."""
+    """Resolve portable item names to target GUIDs. Returns (task_flow, unresolved).
+
+    Items that can't be resolved to a target-workspace GUID are dropped from
+    their task (the server rejects references to non-existent artifacts) and
+    reported in the returned ``unresolved`` list.
+    """
 
     resolved = json.loads(json.dumps(portable))
     unresolved: list[str] = []
     for task in resolved.get("tasks", []):
+        kept_items: list[dict[str, Any]] = []
         for item in task.get("items", []):
             artifact_type = str(item.get("artifactType", ""))
             name = item.get("artifactName")
@@ -172,9 +219,11 @@ def to_workspace(
             if guid:
                 item["artifactUniqueId"] = f"{artifact_type}:{guid}"
                 item["artifactObjectId"] = guid
+                item.pop("artifactName", None)
+                kept_items.append(item)
             else:
                 unresolved.append(f"{artifact_type}:{name}")
-            item.pop("artifactName", None)
+        task["items"] = kept_items
     return resolved, unresolved
 
 
@@ -192,6 +241,8 @@ def export_taskflow(
     )
     cluster = resolve_cluster(pbi)
     record = get_taskflow(pbi, cluster, workspace_id)
+    if record is None:
+        raise ValueError(f"No task flow found in workspace {workspace}")
     guid_to_name = _guid_name_map(list_workspace_items(fabric, workspace_id))
     portable = to_portable(record["taskFlow"], guid_to_name)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -221,7 +272,11 @@ def deploy_taskflow(
     task_flow, unresolved = to_workspace(portable, name_type_to_guid)
     cluster = resolve_cluster(pbi)
     record = get_taskflow(pbi, cluster, workspace_id)
-    put_taskflow(pbi, cluster, workspace_id, record["resourceId"], task_flow, record["etag"])
+    if record is None:
+        # Fresh workspace with no task flow yet — create one.
+        create_taskflow(pbi, cluster, workspace_id, {**portable, **task_flow})
+    else:
+        put_taskflow(pbi, cluster, workspace_id, record, task_flow)
     return unresolved
 
 

--- a/fabric/taskflow/README.md
+++ b/fabric/taskflow/README.md
@@ -18,8 +18,9 @@ network traffic:
 | Operation | Call |
 | --- | --- |
 | Resolve cluster | `PUT https://api.powerbi.com/spglobalservice/GetOrInsertClusterUrisByTenantLocation` → `{"FixedClusterUri": "https://wabi-<region>.analysis.windows.net/"}` |
-| Read | `GET {cluster}/metadata/workspaces/{workspaceId}/taskflow202602` → `[{etag, resourceId, taskFlow}]` |
-| Save | `PUT {cluster}/metadata/workspaces/{workspaceId}/taskflow202512/{resourceId}` — body `{tasks, edges}` |
+| Read | `GET {cluster}/metadata/workspaces/{workspaceId}/taskflow202602` → `[{etag, resourceId, taskFlow}]` (empty `[]` when none exists) |
+| Create | `POST {cluster}/metadata/workspaces/{workspaceId}/taskflow202512` — body is the full task flow (`{id, name, description, tasks, edges}`; `id` must be a non-empty GUID) → `201` |
+| Update | `PUT {cluster}/metadata/workspaces/{workspaceId}/taskflow202512/{resourceId}` — body must include `id`/`name`/`description` plus `tasks`/`edges` |
 
 ### Data model
 
@@ -62,19 +63,24 @@ python -m deploy.scripts.taskflow export --workspace "Retail Demo" --path fabric
 python -m deploy.scripts.taskflow deploy --workspace "retail-demo-dev" --path fabric/taskflow/taskflow.json
 ```
 
-`deploy` reads the target's existing task flow to reuse its `resourceId`/`etag`,
-remaps every item name to the target workspace's GUID, and writes the flow.
-Unresolved references are reported and left unbound.
+`deploy` resolves every item name to the target workspace's GUID, then either
+**creates** the task flow (fresh workspace with none) or **updates** the existing
+one (reusing its `resourceId`/`id`/`etag`). Items that don't resolve to a
+target-workspace item are dropped and reported.
+
+`retail-setup deploy` offers to run this automatically at the end (interactive
+only) — "Wire up the workspace task flow now?".
 
 ## Caveats
 
 - **Live write.** `deploy` writes directly to the metadata cluster (there is no
-  fabric-cicd publisher for task flows). It is **not** wired into
-  `retail-setup deploy`; run it as an explicit post-deploy step once the
-  referenced items exist in the target workspace.
-- **Undocumented API.** The `taskflow202602` (read) / `taskflow202512` (write)
-  paths are internal and may change.
-- **Stale / legacy references.** Items whose GUID is no longer in the source
-  workspace export with `artifactName: null` (e.g. notebooks recreated after the
-  flow was authored). Semantic models use a legacy `dataset` id (`"3:NNNN"`)
-  rather than a GUID and also export unresolved. These are skipped on deploy.
+  fabric-cicd publisher for task flows). Run it after the referenced items have
+  been published so they resolve.
+- **Undocumented API.** The `taskflow202602` (read) / `taskflow202512`
+  (create/update) paths are internal and may change.
+- **Stale / legacy references are skipped.** Items whose GUID is no longer in the
+  source workspace export with `artifactName: null` (e.g. notebooks recreated
+  after the flow was authored); semantic models use a legacy `dataset` id
+  (`"3:NNNN"`). Items the target workspace doesn't have (e.g. data agents,
+  ontology, or the reset notebook when not deployed) are also dropped. The
+  resolvable core of the flow is still wired.

--- a/tests/deploy/test_taskflow.py
+++ b/tests/deploy/test_taskflow.py
@@ -57,11 +57,87 @@ def test_to_workspace_resolves_names_to_target_guids_and_reports_unresolved() ->
 
     resolved, unresolved = taskflow.to_workspace(portable, name_type_to_guid)
 
-    item0 = resolved["tasks"][0]["items"][0]
-    assert item0["artifactUniqueId"] == "SynapseNotebook:new-nb-guid"
-    assert item0["artifactObjectId"] == "new-nb-guid"
-    assert "artifactName" not in item0  # name stripped after resolution
+    items = resolved["tasks"][0]["items"]
+    # Unresolved items are dropped; only the resolved one remains.
+    assert len(items) == 1
+    assert items[0]["artifactUniqueId"] == "SynapseNotebook:new-nb-guid"
+    assert items[0]["artifactObjectId"] == "new-nb-guid"
+    assert "artifactName" not in items[0]  # name stripped after resolution
     assert unresolved == ["Pipeline:missing-pipeline"]
+
+
+def test_deploy_creates_taskflow_when_workspace_has_none(monkeypatch, tmp_path) -> None:
+    import json as _json
+
+    path = tmp_path / "taskflow.json"
+    path.write_text(
+        _json.dumps(
+            {
+                "id": "tf-id",
+                "name": "Retail Demo",
+                "tasks": [
+                    {
+                        "id": "t1",
+                        "items": [
+                            {"artifactType": "Pipeline", "artifactName": "setup-pipeline"}
+                        ],
+                    }
+                ],
+                "edges": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls = {"create": 0, "put": 0}
+
+    monkeypatch.setattr(taskflow, "_session", lambda *_a, **_k: object())
+    monkeypatch.setattr(taskflow, "_token", lambda *_a, **_k: "tok")
+    monkeypatch.setattr(taskflow, "find_workspace_id", lambda *_a: "ws")
+    monkeypatch.setattr(
+        taskflow,
+        "list_workspace_items",
+        lambda *_a: [{"type": "DataPipeline", "displayName": "setup-pipeline", "id": "pl"}],
+    )
+    monkeypatch.setattr(taskflow, "resolve_cluster", lambda *_a: "https://c")
+    monkeypatch.setattr(taskflow, "get_taskflow", lambda *_a: None)  # no existing flow
+
+    def fake_create(_s, _c, _w, tf, **_k):
+        calls["create"] += 1
+        assert tf["tasks"][0]["items"][0]["artifactObjectId"] == "pl"
+        return 201
+
+    monkeypatch.setattr(taskflow, "create_taskflow", fake_create)
+    monkeypatch.setattr(taskflow, "put_taskflow", lambda *a, **k: calls.update(put=calls["put"] + 1))
+
+    unresolved = taskflow.deploy_taskflow("retail-demo-dev", path)
+
+    assert calls["create"] == 1 and calls["put"] == 0
+    assert unresolved == []
+
+
+def test_deploy_updates_taskflow_when_workspace_has_one(monkeypatch, tmp_path) -> None:
+    import json as _json
+
+    path = tmp_path / "taskflow.json"
+    path.write_text(_json.dumps({"id": "x", "tasks": [], "edges": []}), encoding="utf-8")
+    calls = {"create": 0, "put": 0}
+
+    monkeypatch.setattr(taskflow, "_session", lambda *_a, **_k: object())
+    monkeypatch.setattr(taskflow, "_token", lambda *_a, **_k: "tok")
+    monkeypatch.setattr(taskflow, "find_workspace_id", lambda *_a: "ws")
+    monkeypatch.setattr(taskflow, "list_workspace_items", lambda *_a: [])
+    monkeypatch.setattr(taskflow, "resolve_cluster", lambda *_a: "https://c")
+    monkeypatch.setattr(
+        taskflow,
+        "get_taskflow",
+        lambda *_a: {"resourceId": "r", "etag": "e", "taskFlow": {"id": "i"}},
+    )
+    monkeypatch.setattr(taskflow, "create_taskflow", lambda *a, **k: calls.update(create=calls["create"] + 1))
+    monkeypatch.setattr(taskflow, "put_taskflow", lambda *a, **k: calls.update(put=calls["put"] + 1))
+
+    taskflow.deploy_taskflow("retail-demo-dev", path)
+
+    assert calls["put"] == 1 and calls["create"] == 0
 
 
 def test_artifact_type_mapping_covers_key_fabric_types() -> None:

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -774,6 +774,13 @@ def deploy(
     typer.echo(f"Deploy complete for environment '{env}'.")
 
     if not yes:
+        taskflow_path = repo_root / "fabric" / "taskflow" / "taskflow.json"
+        if taskflow_path.is_file() and typer.confirm(
+            "Wire up the workspace task flow now (the visual item graph)?",
+            default=False,
+        ):
+            _deploy_taskflow(repo_root, env)
+
         if typer.confirm(
             "Run the setup pipeline now (apply KQL setup, then generate "
             "dimensions, facts, and gold)?",
@@ -785,6 +792,28 @@ def deploy(
                 "Skipping. Run later with: "
                 "retail-setup deploy --env " + env + " (or trigger 'setup-pipeline' in Fabric)."
             )
+
+
+def _deploy_taskflow(repo_root: Path, env: str) -> None:
+    """Deploy the workspace task flow to the target workspace."""
+
+    workspace = _workspace_name(repo_root, env)
+    cmd = [
+        sys.executable,
+        "-m",
+        "deploy.scripts.taskflow",
+        "deploy",
+        "--workspace",
+        workspace,
+    ]
+    typer.echo("    " + " ".join(cmd))
+    result = subprocess.run(cmd, cwd=repo_root)
+    if result.returncode != 0:
+        typer.echo(
+            "Could not deploy the task flow automatically. Run later with: "
+            f"python -m deploy.scripts.taskflow deploy --workspace {workspace!r}.",
+            err=True,
+        )
 
 
 def _run_setup_pipeline(repo_root: Path, env: str) -> None:


### PR DESCRIPTION
## Summary

Makes the **task flow deploy actually run as part of `retail-setup deploy`**, and fixes it to work on a **fresh workspace** (the case the user hit — a newly-deployed workspace has no task flow yet).

## What was broken

The earlier task-flow tooling (#280) only handled **updating** an existing flow (`PUT taskflow202512/{resourceId}`). A freshly Terraform-deployed workspace returns `[]` from the read endpoint — no flow exists — so deploy couldn't run, and it was never wired into `retail-setup deploy`.

## Fixes (verified live against `retail-demo-dev`)

- **Discovered the create endpoint:** `POST {cluster}/metadata/workspaces/{ws}/taskflow202512` with the full `{id, name, description, tasks, edges}` object → `201`. (`id` must be a non-empty GUID.)
- `get_taskflow` now returns `None` for an empty workspace; `deploy_taskflow` **creates** when absent, **updates** when present.
- The **update PUT** now includes `id`/`name`/`description` (the server rejects an empty `taskflow.Id` — the UI payload I originally captured was truncated before those fields).
- `to_workspace` **drops** items that don't resolve to a target-workspace item (the server rejects references to non-existent artifacts) and reports them.
- **`retail-setup deploy`** now prompts *"Wire up the workspace task flow now?"* after a successful deploy (interactive only), before the setup-pipeline prompt.

## Live verification

- Empty `retail-demo-dev` → `POST` created the flow (201).
- Re-deploy → `PUT` updated it; the resolvable core (notebooks 02–05, pipelines, lakehouse, …) wired up; stale source refs and items retail-setup doesn't deploy (data agents, ontology, reset notebook) were skipped and reported.

## Tests

- `pytest tests/deploy + test_cli_deploy` → 56 passed; `ruff` clean. New: create-when-absent, update-when-present, unresolved-items-dropped.

> Note: builds on the open #285 (validator fix) and #283 (setup-pipeline prompt) conceptually but touches different files; branches cleanly from `main`.