### PR TITLE
fix(deploy): generate KQL notebook cell source as list of strings

### DIFF
--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -253,7 +253,7 @@ def _kql_apply_notebook_content(kql_script: str, kql_database_name: str) -> dict
             {
                 "cell_type": "markdown",
                 "metadata": {},
-                "source": (
+                "source": _source_lines(
                     "# Apply KQL setup scripts\n\n"
                     "Applies the Eventhouse KQL setup (tables, ingestion mappings, "
                     "functions, materialized views) with Kqlmagic. Generated from "
@@ -274,13 +274,23 @@ def _kql_apply_notebook_content(kql_script: str, kql_database_name: str) -> dict
     }
 
 
+def _source_lines(source: str) -> list[str]:
+    """Split notebook cell source into a list of lines.
+
+    Fabric's notebook service requires ``cell.source`` to be a list of strings
+    (not a single string), even though both are valid per the ipynb schema.
+    """
+
+    return source.splitlines(keepends=True) or [""]
+
+
 def _code_cell(source: str) -> dict:
     return {
         "cell_type": "code",
         "execution_count": None,
         "metadata": {},
         "outputs": [],
-        "source": source,
+        "source": _source_lines(source),
     }
 
 

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -183,10 +183,12 @@ def test_stage_kql_apply_notebook_embeds_kqlmagic_and_scripts(tmp_path: Path) ->
     assert platform["metadata"]["type"] == "Notebook"
     assert platform["metadata"]["displayName"] == "00-apply-kql"
     notebook = json.loads((item / "notebook-content.ipynb").read_text(encoding="utf-8"))
-    text = "\n".join(
-        c["source"] if isinstance(c["source"], str) else "".join(c["source"])
-        for c in notebook["cells"]
+    # Fabric requires every cell's source to be a list of strings, not a string.
+    assert all(isinstance(c["source"], list) for c in notebook["cells"])
+    assert all(
+        isinstance(line, str) for c in notebook["cells"] for line in c["source"]
     )
+    text = "".join("".join(c["source"]) for c in notebook["cells"])
     assert "Kqlmagic" in text
     assert "create table receipts" in text  # embedded KQL
     assert "retail_kql" in text  # target database name


### PR DESCRIPTION
## Problem

A re-deploy failed publishing the generated 00-apply-kql notebook at step 10:

> Failed to publish Notebook '00-apply-kql': InvalidNotebookContent ... Error converting value "# Apply KQL setup scripts..." to type 'List<String>'. Path 'cells[0].source'

## Cause

build_artifacts generated the notebook with each cell's source as a single **string**. The ipynb schema allows a string *or* a list of strings, but **Fabric's notebook service requires a list of strings**. (Hand-authored notebooks publish fine because Jupyter stores source as line lists.)

## Fix

Split every generated cell's source into lines via splitlines(keepends=True) (new _source_lines helper), applied to the markdown cell and all code cells.

## Validation

- Generated notebook now has cell.source as a list of strings for every cell (verified).
- Test updated to assert all sources are lists of strings.
- pytest tests/deploy/test_build_artifacts.py -> 16 passed; ruff clean.

Fixes the step-10 publish failure on retail-setup deploy.