### PR TITLE
docs: update Fabric deploy docs (pipelines, querysets, data agents, task flow)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -100,8 +100,12 @@ After the Eventhouse and KQL database exist:
   `retail_querysets.KQLQueryset` item (one tab per `.kql` file) bound to the
   Eventhouse KQL database. `clusterUri` is resolved by fabric-cicd at publish
   time and `databaseItemId` is rewritten from the Terraform KQL database id.
-- Pipeline and dashboard assets remain source inputs until their Fabric
-  source-control item formats are validated.
+- Data Pipelines in `fabric\pipelines\*.DataPipeline` deploy into a **Pipelines**
+  folder; each pipeline is staged only when its notebooks are part of the deploy,
+  and notebook references are remapped via generated `parameter.yml` rules.
+- Dashboard assets remain source inputs until their Fabric source-control item
+  formats are validated. Task flows are deployed separately by
+  `deploy.scripts.taskflow` (offered as a prompt at the end of deploy).
 - Secrets must come from Azure login, GitHub Actions secrets, environment
   variables, Key Vault, or ignored local files. Do not commit secrets to YAML,
   Terraform files, notebooks, or generated artifacts.

--- a/website/docs/fabric/data-agents.md
+++ b/website/docs/fabric/data-agents.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 9
+---
+
+# Data Agents
+
+Fabric **Data Agents** — conversational agents that answer questions over the
+retail demo's semantic model and ontology. Stored in `fabric/data-agents/` as
+source-control items (`<name>.DataAgent/` with `.platform` and the
+`Files/Config/...` definition parts).
+
+## Agents
+
+| Agent | Data source | Bound artifact |
+| --- | --- | --- |
+| `retail-semantic-model-agent` | Semantic model | `retail_model` |
+| `retail-ontology-agent` | Ontology | `retail_ontology` |
+
+Each agent's `Files/Config/draft/<source>/datasource.json` carries the schema the
+agent reasons over (tables/columns or ontology entities) plus the binding to its
+source artifact (`artifactId` + `workspaceId`). A published agent also has a
+`Files/Config/published/...` copy.
+
+## Re-exporting from Fabric
+
+The agents were exported from a live workspace with the generic item exporter,
+which reuses your Azure CLI login:
+
+```powershell
+python -m deploy.scripts.export_items --workspace-name "Retail Demo" --item-type DataAgent --output-dir fabric/data-agents
+```
+
+The same exporter handles other item types (for example `--item-type DataPipeline`).
+
+## Deployment status
+
+Data agents are **not yet** published by `retail-setup deploy`. Each
+`datasource.json` binds to the source workspace's artifact by `artifactId` and
+`workspaceId`, so deploying to another workspace requires remapping
+(`workspaceId` → `$workspace.$id`; `artifactId` → the target semantic model /
+ontology id), with the bound artifacts deployed first. See
+`fabric/data-agents/README.md` for the full detail.

--- a/website/docs/fabric/index.md
+++ b/website/docs/fabric/index.md
@@ -7,11 +7,18 @@ under `fabric/`.
 | --- | --- | --- |
 | [KQL Database](./kql-database.md) | `fabric/kql_database/` | Eventhouse tables, ingestion mappings, functions, and materialized views |
 | [Lakehouse](./lakehouse.md) | `fabric/lakehouse/` | Medallion notebooks, ML notebooks, and utilities |
-| [Pipelines](./pipelines.md) | `fabric/pipelines/` | Optional orchestration guidance |
-| [Querysets](./querysets.md) | `fabric/querysets/` | Curated KQL queries |
+| [Pipelines](./pipelines.md) | `fabric/pipelines/` | Data Pipelines (setup, streaming, maintenance, ML) deployed automatically |
+| [Querysets](./querysets.md) | `fabric/querysets/` | Curated KQL queries deployed as one KQLQueryset |
+| [Data Agents](./data-agents.md) | `fabric/data-agents/` | Conversational agents over the semantic model and ontology |
+| [Task Flow](./taskflow.md) | `fabric/taskflow/` | Visual item graph wiring the workspace |
 | [Rules](./rules.md) | `fabric/rules/` | Real-time alert queries |
 | [Dashboards](./dashboards.md) | `fabric/dashboards/` | Dashboard templates and notes |
 | [Semantic Model](./semantic-model.md) | `fabric/powerbi/` | Power BI PBIP semantic model and report |
+
+`retail-setup deploy` publishes items into named workspace folders: **Notebooks**
+(demo/pipeline notebooks), **Setup** (one-time setup notebooks), **Reporting**
+(semantic model + report), **Pipelines** (Data Pipelines), and **ML** (bootstrapped
+MLflow experiments). The Lakehouse and queryset stay at the workspace root.
 
 ## Data flow
 

--- a/website/docs/fabric/pipelines.md
+++ b/website/docs/fabric/pipelines.md
@@ -1,85 +1,90 @@
 # Pipelines
 
-Data Pipelines orchestrating the medallion notebooks and scheduled processing. `fabric/pipelines/` contains **four exported pipeline definitions** (ARM-template JSON plus manifest) that can be re-created in any Fabric workspace.
+Data Pipelines orchestrating the medallion notebooks, setup, and scheduled
+processing. `fabric/pipelines/` contains **Git-integration `.DataPipeline`
+items** (`.platform`, `pipeline-content.json`, and an optional `.schedules`) that
+`retail-setup deploy` publishes directly into the workspace.
 
 ## Pipeline Summary
 
 | Pipeline | Recommended Schedule | Activities |
 |----------|---------------------|------------|
+| `setup-pipeline` | On demand | `00-apply-kql` → `setup-01` → `setup-02` → `setup-03` → `setup-04` |
 | `historical-data-load` | Once (manual) | `02-historical-data-load` |
-| `streaming-data-load` | Every 5 minutes | `03-streaming-to-silver` → `04-streaming-to-gold` (sequential) |
-| `daily-maintenance` | Daily 3 AM UTC | `05-maintain-delta-tables` |
-| `machine-learning` | Daily/weekly (after maintenance) | ML notebooks `06`–`13` in parallel; `14` after `10` |
+| `streaming-data-load` | Cron (every 5 minutes) | `03-streaming-to-silver` → `04-streaming-to-gold` (sequential) |
+| `daily-maintenance` | Daily 00:00 | `05-maintain-delta-tables` |
+| `machine-learning` | Daily/weekly (after maintenance) | ML notebooks `06`–`14` |
 
-All notebook activities are exported with a 12-hour timeout and no retries. Schedules are configured as **triggers in the Fabric portal** — they are not part of the exported JSON.
+Notebook activities use a 12-hour timeout and no retries. Schedules present in
+`.schedules` (cron/daily) deploy with the pipeline; others are configured as
+triggers in the Fabric portal.
 
-## Folder Layout
+## Deployment
 
+`retail-setup deploy` stages each pipeline whose notebooks are part of the
+deploy into a **Pipelines** workspace folder, and adds `DataPipeline` to the
+fabric-cicd scope so they publish automatically. With the default
+`core setup ml` groups, all five pipelines deploy.
+
+Each activity references its notebook by the **source** workspace's
+`notebookId`/`workspaceId`. `deploy/fabric-cicd/parameter.yml` remaps them to the
+target at publish time (generated from the pipeline sources):
+
+- `workspaceId` → `$workspace.$id`
+- each `notebookId` GUID → `$items.Notebook.<activity-name>.$id`
+
+fabric-cicd publishes Notebooks before Data Pipelines, so the references resolve.
+
+After a successful deploy, `retail-setup deploy` offers to **run `setup-pipeline`
+now** (via the Fabric Job Scheduler API) to apply the KQL setup and generate the
+dimensions, facts, and Gold tables.
+
+`setup-pipeline` is authored in this repo; its first step `00-apply-kql` is a
+notebook **generated** from `fabric/kql_database/*.kql` that applies the
+Eventhouse KQL setup with Kqlmagic. The other four pipelines were exported from a
+live workspace with `deploy.scripts.export_pipelines`.
+
+## Re-exporting
+
+Refresh the exported pipelines from a live workspace (reuses your Azure CLI
+login):
+
+```powershell
+python -m deploy.scripts.export_pipelines --workspace-name "Retail Demo" --output-dir fabric/pipelines
 ```
-fabric/pipelines/
-├── historical-data-load/historical-data-load/
-│   ├── historical-data-load.json
-│   └── manifest.json
-├── streaming-data-load/streaming-data-load/
-│   ├── streaming-data-load.json
-│   └── manifest.json
-├── daily-maintenance/daily-maintenance/
-│   ├── daily-maintenance.json
-│   └── manifest.json
-└── machine-learning/machine-learning/
-    ├── machine-learning.json
-    └── manifest.json
-```
-
-The exported JSON references notebook and workspace IDs from the original workspace; update these when importing into a different workspace.
 
 ## Pipeline Details
 
+### setup-pipeline
+
+One-shot environment bootstrap: applies the Eventhouse KQL schema
+(`00-apply-kql`), then runs the rendered setup notebooks in order to seed
+dictionaries, generate dimensions and facts, and build the Gold tables.
+
 ### historical-data-load
 
-One-time load of historical batch data from `Files/` parquet shortcuts through Silver (`ag`) and Gold (`au`). Runs `02-historical-data-load.ipynb`. Execute manually after the Bronze shortcuts exist.
+One-time load of historical batch data from `Files/` parquet shortcuts through
+Silver (`ag`) and Gold (`au`). Runs `02-historical-data-load.ipynb`.
 
 ### streaming-data-load
 
-The streaming refresh loop. Runs `03-streaming-to-silver.ipynb` (watermark-based incremental load from Eventhouse `cusn` shortcuts), then `04-streaming-to-gold.ipynb` (Gold aggregation rebuild) on success. Schedule every 5 minutes.
+The streaming refresh loop: `03-streaming-to-silver.ipynb` (watermark-based
+incremental load from Eventhouse `cusn` shortcuts), then
+`04-streaming-to-gold.ipynb` (Gold aggregation rebuild). Cron schedule.
 
 ### daily-maintenance
 
-Runs `05-maintain-delta-tables.ipynb`: Delta `OPTIMIZE` (with ZORDER), and `VACUUM` (7-day default retention) across Silver and Gold tables. Schedule daily at 3 AM UTC, before the ML pipeline.
+Runs `05-maintain-delta-tables.ipynb`: Delta `OPTIMIZE` (with ZORDER) and
+`VACUUM` across Silver and Gold. Daily.
 
 ### machine-learning
 
-Runs the ML notebooks as parallel activities:
-
-- Parallel: `06-ml-demand-forecast`, `07-ml-market-basket`, `08-ml-customer-segmentation`, `09-ml-churn-prediction`, `10-ml-promotion-effectiveness`, `11-ml-journey-analysis`, `12-ml-stockout-prediction`, `13-ml-delivery-prediction`
-- Dependent: `14-ml-dynamic-pricing` runs only after `10-ml-promotion-effectiveness` succeeds, since it consumes `au.price_elasticity`. If elasticity data is unavailable, notebook 14 falls back to rule-based constrained pricing.
-
-See [Phase 9: ML Notebooks](../setup/09-ml-notebooks.md) for notebook details and outputs.
-
-## Creating Pipelines in Fabric
-
-For each pipeline:
-
-1. **Navigate to Data Factory**: in your Fabric workspace → New → Data pipeline
-2. **Add Notebook activities**: one per notebook listed above, with dependency conditions where noted
-3. **Configure policy**: timeout and retry settings per your environment
-4. **Add trigger**: Schedule trigger with the recommended recurrence
-5. **Save and activate**: toggle the trigger to "Started"
-
-Alternatively, import the exported JSON definitions and rebind the notebook/workspace IDs.
+Runs the ML notebooks `06`–`14`. `14-ml-dynamic-pricing` depends on
+`10-ml-promotion-effectiveness` (it consumes `au.price_elasticity`); if
+elasticity data is unavailable, notebook 14 falls back to rule-based constrained
+pricing. See [Phase 9: ML Notebooks](../setup/09-ml-notebooks.md).
 
 ## Monitoring
 
 - **Fabric Portal** → Data Factory → Pipelines → View runs
 - Check execution status, duration, and error logs
-- Set up alerts for pipeline failures
-
-## Schedule Rationale
-
-- `streaming-data-load` runs frequently (5 min) to keep Silver/Gold near-real-time; 03 and 04 are sequenced in one pipeline so Gold never reads a partially updated Silver layer
-- `daily-maintenance` runs at 3 AM UTC during low load
-- `machine-learning` should run after maintenance so models train against optimized tables; heavy notebooks (market basket, segmentation, churn, promotion effectiveness) can be moved to a weekly cadence if capacity is constrained
-
-## Legacy Names
-
-Earlier documentation referred to per-notebook pipelines (`pl_historical_load`, `pl_streaming_silver`, `pl_streaming_gold`, `pl_maintenance`, `pl_demand_forecast`, etc.). These were consolidated into the four pipelines above; `pl_streaming_silver`/`pl_streaming_gold` are now the two sequential activities of `streaming-data-load`, and all ML pipelines were merged into `machine-learning`.

--- a/website/docs/fabric/querysets.md
+++ b/website/docs/fabric/querysets.md
@@ -28,3 +28,13 @@ Curated KQL queries in `fabric/querysets/` for operations, investigations, and R
 - **Marketing**: campaign cost and conversion funnel attribution
 
 Several of these queries back the tiles in the [retail-ops dashboard template](./dashboards.md).
+
+## Deployment
+
+`retail-setup deploy` bundles every `.kql` file in `fabric/querysets/` into a
+single `retail_querysets.KQLQueryset` item (one tab per file) bound to the
+Eventhouse KQL database, and publishes it at the workspace root. Add a query by
+dropping a new `.kql` file in `fabric/querysets/` and redeploying — no other
+configuration is required. The data source `clusterUri` is resolved by
+fabric-cicd at publish time and `databaseItemId` is rewritten from the Terraform
+KQL database id.

--- a/website/docs/fabric/taskflow.md
+++ b/website/docs/fabric/taskflow.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 10
+---
+
+# Task Flow
+
+The Fabric workspace **Task Flow** — the visual graph that wires the workspace
+items (notebooks, pipelines, lakehouse, eventhouse, semantic model, data agents,
+ontology, ML experiments) into a left-to-right data flow. Stored portably in
+`fabric/taskflow/taskflow.json`, where each task item references its artifact by
+**display name** so the same flow can be deployed to any workspace.
+
+## Why it's special
+
+Task flows are **not** exposed by the public Fabric REST API and are **not**
+workspace items. They live on the Power BI metadata cluster and are read/written
+through undocumented endpoints (discovered by capturing the Fabric UI):
+
+| Operation | Call |
+| --- | --- |
+| Resolve cluster | `PUT api.powerbi.com/spglobalservice/GetOrInsertClusterUrisByTenantLocation` → `FixedClusterUri` |
+| Read | `GET {cluster}/metadata/workspaces/{ws}/taskflow202602` (empty `[]` when none exists) |
+| Create | `POST {cluster}/metadata/workspaces/{ws}/taskflow202512` — full `{id, name, description, tasks, edges}` |
+| Update | `PUT {cluster}/metadata/workspaces/{ws}/taskflow202512/{resourceId}` — includes `id`/`name`/`description` plus `tasks`/`edges` |
+
+## Export and deploy
+
+Both reuse your Azure CLI login:
+
+```powershell
+# Export the live task flow to a portable file (artifacts by name)
+python -m deploy.scripts.taskflow export --workspace "Retail Demo"
+
+# Deploy it to a target workspace (resolves names -> target GUIDs)
+python -m deploy.scripts.taskflow deploy --workspace "retail-demo-dev"
+```
+
+`deploy` **creates** the task flow when the target workspace has none, or
+**updates** the existing one. Items that don't resolve to a target-workspace
+item (stale source references, or items the target doesn't have such as data
+agents/ontology) are dropped and reported.
+
+`retail-setup deploy` offers to run this automatically at the end (interactive
+only): *"Wire up the workspace task flow now?"*.
+
+See `fabric/taskflow/README.md` for the full data model and caveats.

--- a/website/docs/setup/05-pipelines.md
+++ b/website/docs/setup/05-pipelines.md
@@ -1,42 +1,44 @@
-# Phase 5: Optional Pipelines
+# Phase 5: Pipelines
 
-Pipelines are optional. `retail-setup deploy` does not currently create Fabric
-pipelines automatically.
+`retail-setup deploy` publishes Data Pipelines automatically into a **Pipelines**
+workspace folder — no manual creation required. The pipelines orchestrate setup,
+streaming, maintenance, and ML.
 
-Use pipelines when you want scheduled or repeatable notebook execution after the
-initial manual setup has succeeded.
-
-## Recommended manual-first flow
-
-Run setup notebooks 01-04 manually once in a clean workspace:
-
-1. `setup-01-seed-dictionaries`
-2. `setup-02-generate-dimensions`
-3. `setup-03-generate-facts`
-4. `setup-04-build-gold`
-
-After that, create pipelines if you want repeatable setup, live processing, or
-maintenance.
-
-## Suggested pipelines
+## What deploys
 
 | Pipeline | Trigger | Notebook(s) | Purpose |
 | --- | --- | --- | --- |
-| `pl_setup` | Manual | Setup notebooks 01-04 | Rebuild historical demo data |
-| `pl_streaming_silver` | Every 5 minutes | `03-streaming-to-silver` | Append Eventhouse events to Silver |
-| `pl_streaming_gold` | Every 15 minutes | `04-streaming-to-gold` | Rebuild Gold aggregates from Silver |
-| `pl_maintenance` | Daily | `05-maintain-delta-tables` | Delta maintenance |
+| `setup-pipeline` | On demand | `00-apply-kql`, setup `01`–`04` | Apply KQL schema, then build historical demo data |
+| `historical-data-load` | Manual | `02-historical-data-load` | Load historical batch data |
+| `streaming-data-load` | Cron (5 min) | `03-streaming-to-silver`, `04-streaming-to-gold` | Near-real-time Silver/Gold refresh |
+| `daily-maintenance` | Daily | `05-maintain-delta-tables` | Delta maintenance |
+| `machine-learning` | Daily/weekly | `06`–`14` | Train ML models |
 
-## Parameters
+A pipeline is staged only when every notebook it orchestrates is part of the
+deploy, so its notebook references always resolve. The default `core setup ml`
+groups deploy all five.
 
-Use the same values configured by `retail-setup configure`:
+## Run the setup pipeline
 
-| Parameter | Typical value |
-| --- | --- |
-| `LAKEHOUSE_NAME` | `retail_lakehouse` |
-| `SILVER_DB` | `ag` |
-| `GOLD_DB` | `au` |
-| `BRONZE_SCHEMA` | `cusn` |
+After a successful deploy, `retail-setup deploy` asks:
+
+> Run the setup pipeline now (apply KQL setup, then generate dimensions, facts,
+> and gold)?
+
+Answer **yes** to kick off `setup-pipeline` immediately (via the Fabric Job
+Scheduler API). You can also run it later from the Fabric portal, or with:
+
+```powershell
+python -m deploy.scripts.run_pipeline --environment dev --pipeline setup-pipeline
+```
+
+## How references are remapped
+
+Each notebook activity references a `notebookId`/`workspaceId` from the source
+workspace. The deploy framework generates `parameter.yml` rules that rewrite them
+to the target workspace (`$workspace.$id` and `$items.Notebook.<name>.$id`). See
+[Fabric → Pipelines](../fabric/pipelines.md) for the full mechanism and the
+re-export command.
 
 ## Next step
 


### PR DESCRIPTION
## Summary

Documentation refresh so the deploy/Fabric docs match what `retail-setup deploy` actually does now.

- **Pipelines** (`website/docs/fabric/pipelines.md`, `website/docs/setup/05-pipelines.md`): Git-format `.DataPipeline` items deploy **automatically** into a Pipelines folder; documents the five pipelines (setup, historical, streaming, daily-maintenance, machine-learning), notebook reference remapping, the `setup-pipeline`, and the post-deploy `Run the setup pipeline now?` prompt.
- **Querysets** (`website/docs/fabric/querysets.md`): now documents that all `fabric/querysets/*.kql` files deploy as a single `retail_querysets.KQLQueryset` (one tab per file) bound to the Eventhouse KQL database.
- **Data Agents** (new `website/docs/fabric/data-agents.md`): the two exported agents, the generic item exporter, and current (not-yet-deployed) status.
- **Task Flow** (new `website/docs/fabric/taskflow.md`): the undocumented metadata-cluster API, export + create/update deploy, and the end-of-deploy `Wire up the workspace task flow now?` prompt.
- **Fabric index** (`website/docs/fabric/index.md`): added Data Agents + Task Flow rows; corrected Pipelines/Querysets descriptions.
- **deploy/README.md**: replaced the stale "Pipeline and dashboard assets remain source inputs" note with the current per-item-type deployment status.

## Verification

- `npm run build` (Docusaurus, `onBrokenLinks: 'throw'`) — **passes**, all internal links resolve.

## Notes

Docs-only change. Companion code PRs: #285 (validator placeholder fix), #286 (task flow deploy wiring), #287 (KQL notebook source-as-list fix).