### PR TITLE
fix(deploy): auto-wire task flow, fix CLI auth timeout, setup-pipeline folder + naming

### DIFF
--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -76,6 +76,11 @@ SETUP_NOTEBOOKS = [
     "setup-04-build-gold",
 ]
 
+# The one Data Pipeline that orchestrates the setup notebooks. It publishes into
+# the "Setup" workspace folder (alongside those notebooks) rather than the
+# general "Pipelines" folder.
+SETUP_PIPELINE = "setup-pipeline"
+
 
 @dataclass(frozen=True)
 class BuildResult:
@@ -178,7 +183,7 @@ def stage_setup_notebooks(
     return staged
 
 
-KQL_APPLY_NOTEBOOK = "00-apply-kql"
+KQL_APPLY_NOTEBOOK = "setup-00-apply-kql"
 
 
 def stage_kql_apply_notebook(
@@ -377,7 +382,10 @@ def stage_pipelines(
     ``deployed_notebooks`` (the notebooks selected for this deploy). Pipelines
     that reference notebooks outside the selected groups are skipped so their
     ``$items.Notebook.<name>.$id`` references always resolve at publish time.
-    Returns an empty list when no pipeline sources exist.
+
+    Each pipeline publishes into the "Pipelines" workspace folder, except
+    ``setup-pipeline`` which joins the setup notebooks under "Setup". Returns an
+    empty list when no pipeline sources exist.
     """
 
     source_dir = repo_root / "fabric" / "pipelines"
@@ -393,9 +401,11 @@ def stage_pipelines(
         )
         if not refs.issubset(deployed_notebooks):
             continue
-        destination = output_dir / item_dir.name
+        folder = SETUP_FOLDER if item_dir.stem == SETUP_PIPELINE else PIPELINES_FOLDER
+        destination = output_dir / folder / item_dir.name
         if destination.exists():
             shutil.rmtree(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(item_dir, destination)
         staged.append(destination)
     return staged
@@ -470,8 +480,8 @@ def build_workspace(
         )
 
     # One-time setup notebooks publish into a separate "Setup" workspace folder,
-    # along with a generated 00-apply-kql notebook that applies the Eventhouse
-    # KQL setup scripts.
+    # along with a generated setup-00-apply-kql notebook that applies the
+    # Eventhouse KQL setup scripts.
     if "setup" in notebook_groups:
         setup_dir = output_dir / SETUP_FOLDER
         staged_items.extend(
@@ -486,7 +496,7 @@ def build_workspace(
             ).name
         )
 
-    # Power BI items publish into a "Power BI" workspace folder.
+    # Power BI items publish into the "Reporting" workspace folder.
     staged_items.extend(
         item.name
         for item in stage_powerbi_items(
@@ -502,14 +512,15 @@ def build_workspace(
             repo_root, output_dir, kql_database_name=kql_database_name
         )
     )
-    # Data Pipelines publish into a "Pipelines" workspace folder, but only when
-    # every notebook they orchestrate is part of this deploy (so the pipeline's
-    # $items.Notebook.<name>.$id references resolve).
+    # Data Pipelines publish into a "Pipelines" workspace folder (except
+    # setup-pipeline, which joins the setup notebooks under "Setup"), but only
+    # when every notebook they orchestrate is part of this deploy (so the
+    # pipeline's $items.Notebook.<name>.$id references resolve).
     staged_items.extend(
         item.name
         for item in stage_pipelines(
             repo_root,
-            output_dir / PIPELINES_FOLDER,
+            output_dir,
             _deployed_notebook_names(notebook_groups),
         )
     )

--- a/deploy/scripts/taskflow.py
+++ b/deploy/scripts/taskflow.py
@@ -61,10 +61,20 @@ ARTIFACT_TO_ITEM_TYPE = {
 }
 
 
-def _token(scope: str, credential: AzureCliCredential | None = None) -> str:
+def _credential(credential: AzureCliCredential | None = None) -> AzureCliCredential:
+    """Azure CLI credential with a generous process timeout.
+
+    On Windows ``az.cmd`` is slow to start, so azure-identity's 10s default
+    frequently times out when fetching the Power BI and Fabric tokens back to
+    back. Allow more time, and reuse one credential for both token requests.
+    """
+
     from azure.identity import AzureCliCredential
 
-    credential = credential or AzureCliCredential()
+    return credential or AzureCliCredential(process_timeout=60)
+
+
+def _token(scope: str, credential: AzureCliCredential) -> str:
     return credential.get_token(scope).token
 
 
@@ -234,6 +244,7 @@ def export_taskflow(
 ) -> Path:
     """Export a workspace task flow to a portable JSON file (artifacts by name)."""
 
+    credential = _credential(credential)
     pbi = _session(_token(PBI_SCOPE, credential))
     fabric = _session(_token(FABRIC_SCOPE, credential))
     workspace_id = workspace if _looks_like_guid(workspace) else find_workspace_id(
@@ -260,6 +271,7 @@ def deploy_taskflow(
     """Deploy a portable task flow to a workspace. Returns unresolved references."""
 
     portable = json.loads(input_path.read_text(encoding="utf-8"))
+    credential = _credential(credential)
     pbi = _session(_token(PBI_SCOPE, credential))
     fabric = _session(_token(FABRIC_SCOPE, credential))
     workspace_id = workspace if _looks_like_guid(workspace) else find_workspace_id(

--- a/fabric/pipelines/README.md
+++ b/fabric/pipelines/README.md
@@ -9,20 +9,22 @@ workspace and use the Git-integration format that fabric-cicd publishes.
 
 | Pipeline | Orchestrates | Schedule |
 | --- | --- | --- |
-| `setup-pipeline` | `00-apply-kql` → `setup-01`…`setup-04` (KQL setup, then dimensions/facts/gold) | On demand |
+| `setup-pipeline` | `setup-00-apply-kql` → `setup-01`…`setup-04` (KQL setup, then dimensions/facts/gold) | On demand |
 | `historical-data-load` | `02-historical-data-load` | On demand |
 | `streaming-data-load` | `03-streaming-to-silver`, `04-streaming-to-gold` | Cron |
 | `daily-maintenance` | `05-maintain-delta-tables` | Daily 00:00 |
 | `machine-learning` | `06`–`14` ML notebooks | On demand |
 
 `setup-pipeline` is authored in this repo (not exported). Its first step,
-`00-apply-kql`, is a notebook **generated** by `build_artifacts` from
+`setup-00-apply-kql`, is a notebook **generated** by `build_artifacts` from
 `fabric/kql_database/*.kql` that applies the Eventhouse KQL setup with Kqlmagic;
-the remaining steps run the rendered setup notebooks in order. After
-`retail-setup deploy` completes, it offers to run `setup-pipeline` on demand
-(via `deploy.scripts.run_pipeline`). The `00-apply-kql` notebook can only be
-validated by running it in Fabric — verify its first run and adjust the Kqlmagic
-auth if a headless pipeline run can't authenticate.
+the remaining steps run the rendered setup notebooks in order. It publishes into
+the **Setup** workspace folder alongside those notebooks (not the general
+**Pipelines** folder). After `retail-setup deploy` completes, it offers to run
+`setup-pipeline` on demand (via `deploy.scripts.run_pipeline`). The
+`setup-00-apply-kql` notebook can only be validated by running it in Fabric —
+verify its first run and adjust the Kqlmagic auth if a headless pipeline run
+can't authenticate.
 
 ## Re-exporting from Fabric
 
@@ -48,11 +50,13 @@ fab export "Retail Demo.Workspace/daily-maintenance.DataPipeline" -o fabric/pipe
 ## Deployment
 
 `retail-setup deploy` publishes these pipelines into a **Pipelines** workspace
-folder. A pipeline is staged **only when every notebook it orchestrates is part
-of the deploy** — so with the default `core setup` groups the
-`historical-data-load`, `streaming-data-load`, and `daily-maintenance` pipelines
-publish, while `machine-learning` publishes only when the `ml` notebook group is
-included. This keeps every `$items.Notebook.<name>.$id` reference resolvable.
+folder — except `setup-pipeline`, which publishes into the **Setup** folder with
+the setup notebooks it orchestrates. A pipeline is staged **only when every
+notebook it orchestrates is part of the deploy** — so with the default
+`core setup` groups the `historical-data-load`, `streaming-data-load`, and
+`daily-maintenance` pipelines publish, while `machine-learning` publishes only
+when the `ml` notebook group is included. This keeps every
+`$items.Notebook.<name>.$id` reference resolvable.
 
 Each activity references its notebook by the **source** workspace's
 `notebookId`/`workspaceId`. `deploy/fabric-cicd/parameter.yml` remaps them to the

--- a/fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json
+++ b/fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json
@@ -2,7 +2,7 @@
   "properties": {
     "activities": [
       {
-        "name": "00-apply-kql",
+        "name": "setup-00-apply-kql",
         "type": "TridentNotebook",
         "dependsOn": [],
         "policy": {
@@ -22,7 +22,7 @@
         "type": "TridentNotebook",
         "dependsOn": [
           {
-            "activity": "00-apply-kql",
+            "activity": "setup-00-apply-kql",
             "dependencyConditions": ["Succeeded"]
           }
         ],

--- a/fabric/taskflow/README.md
+++ b/fabric/taskflow/README.md
@@ -68,14 +68,14 @@ python -m deploy.scripts.taskflow deploy --workspace "retail-demo-dev" --path fa
 one (reusing its `resourceId`/`id`/`etag`). Items that don't resolve to a
 target-workspace item are dropped and reported.
 
-`retail-setup deploy` offers to run this automatically at the end (interactive
-only) — "Wire up the workspace task flow now?".
+`retail-setup deploy` runs this **automatically** at the end (in both interactive
+and `--yes` modes), once the referenced items have been published.
 
 ## Caveats
 
 - **Live write.** `deploy` writes directly to the metadata cluster (there is no
-  fabric-cicd publisher for task flows). Run it after the referenced items have
-  been published so they resolve.
+  fabric-cicd publisher for task flows). `retail-setup deploy` runs it
+  automatically once the referenced items have been published, so they resolve.
 - **Undocumented API.** The `taskflow202602` (read) / `taskflow202512`
   (create/update) paths are internal and may change.
 - **Stale / legacy references are skipped.** Items whose GUID is no longer in the

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -178,10 +178,10 @@ def test_stage_kql_apply_notebook_embeds_kqlmagic_and_scripts(tmp_path: Path) ->
     output = tmp_path / "workspace"
     item = build_artifacts.stage_kql_apply_notebook(repo, output, kql_database_name="retail_kql")
 
-    assert item == output / "00-apply-kql.Notebook"
+    assert item == output / "setup-00-apply-kql.Notebook"
     platform = json.loads((item / ".platform").read_text(encoding="utf-8"))
     assert platform["metadata"]["type"] == "Notebook"
-    assert platform["metadata"]["displayName"] == "00-apply-kql"
+    assert platform["metadata"]["displayName"] == "setup-00-apply-kql"
     notebook = json.loads((item / "notebook-content.ipynb").read_text(encoding="utf-8"))
     # Fabric requires every cell's source to be a list of strings, not a string.
     assert all(isinstance(c["source"], list) for c in notebook["cells"])
@@ -296,8 +296,30 @@ def test_stage_pipelines_only_stages_when_notebooks_deployed(tmp_path: Path) -> 
 
     # streaming pipeline's notebooks are deployed; ML pipeline's are not.
     assert [p.name for p in staged] == ["streaming-data-load.DataPipeline"]
-    assert (output / "streaming-data-load.DataPipeline" / "pipeline-content.json").exists()
-    assert not (output / "machine-learning.DataPipeline").exists()
+    assert (
+        output / "Pipelines" / "streaming-data-load.DataPipeline" / "pipeline-content.json"
+    ).exists()
+    assert not (output / "Pipelines" / "machine-learning.DataPipeline").exists()
+
+
+def test_stage_pipelines_routes_setup_pipeline_to_setup_folder(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_pipeline(repo, "setup-pipeline", ["setup-00-apply-kql", "setup-01-seed-dictionaries"])
+    _write_pipeline(repo, "streaming-data-load", ["03-streaming-to-silver"])
+
+    output = tmp_path / "workspace"
+    output.mkdir()
+    deployed = {"setup-00-apply-kql", "setup-01-seed-dictionaries", "03-streaming-to-silver"}
+    staged = build_artifacts.stage_pipelines(repo, output, deployed)
+
+    # setup-pipeline joins the setup notebooks under "Setup"; others stay in "Pipelines".
+    assert (output / "Setup" / "setup-pipeline.DataPipeline").is_dir()
+    assert not (output / "Pipelines" / "setup-pipeline.DataPipeline").exists()
+    assert (output / "Pipelines" / "streaming-data-load.DataPipeline").is_dir()
+    assert {p.name for p in staged} == {
+        "setup-pipeline.DataPipeline",
+        "streaming-data-load.DataPipeline",
+    }
 
 
 def test_stage_pipelines_returns_empty_when_no_sources(tmp_path: Path) -> None:
@@ -392,7 +414,7 @@ def test_build_workspace_threads_custom_lakehouse_name_to_setup_notebooks(
         {"metadata": {"type": "Report"}},
     )
 
-    # KQL source for the generated 00-apply-kql notebook (setup group).
+    # KQL source for the generated setup-00-apply-kql notebook (setup group).
     (repo / "fabric" / "kql_database").mkdir(parents=True)
     (repo / "fabric" / "kql_database" / "01-create-tables.kql").write_text(
         ".create table receipts (id:string)", encoding="utf-8"

--- a/tests/deploy/test_taskflow.py
+++ b/tests/deploy/test_taskflow.py
@@ -92,6 +92,7 @@ def test_deploy_creates_taskflow_when_workspace_has_none(monkeypatch, tmp_path) 
 
     monkeypatch.setattr(taskflow, "_session", lambda *_a, **_k: object())
     monkeypatch.setattr(taskflow, "_token", lambda *_a, **_k: "tok")
+    monkeypatch.setattr(taskflow, "_credential", lambda *_a, **_k: object())
     monkeypatch.setattr(taskflow, "find_workspace_id", lambda *_a: "ws")
     monkeypatch.setattr(
         taskflow,
@@ -124,6 +125,7 @@ def test_deploy_updates_taskflow_when_workspace_has_one(monkeypatch, tmp_path) -
 
     monkeypatch.setattr(taskflow, "_session", lambda *_a, **_k: object())
     monkeypatch.setattr(taskflow, "_token", lambda *_a, **_k: "tok")
+    monkeypatch.setattr(taskflow, "_credential", lambda *_a, **_k: object())
     monkeypatch.setattr(taskflow, "find_workspace_id", lambda *_a: "ws")
     monkeypatch.setattr(taskflow, "list_workspace_items", lambda *_a: [])
     monkeypatch.setattr(taskflow, "resolve_cluster", lambda *_a: "https://c")

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -773,14 +773,14 @@ def deploy(
 
     typer.echo(f"Deploy complete for environment '{env}'.")
 
-    if not yes:
-        taskflow_path = repo_root / "fabric" / "taskflow" / "taskflow.json"
-        if taskflow_path.is_file() and typer.confirm(
-            "Wire up the workspace task flow now (the visual item graph)?",
-            default=False,
-        ):
-            _deploy_taskflow(repo_root, env)
+    # Wire up the workspace task flow automatically (the visual item graph that
+    # links the deployed items). Runs in both interactive and --yes modes.
+    taskflow_path = repo_root / "fabric" / "taskflow" / "taskflow.json"
+    if taskflow_path.is_file():
+        typer.echo("Wiring up the workspace task flow (the visual item graph)...")
+        _deploy_taskflow(repo_root, env)
 
+    if not yes:
         if typer.confirm(
             "Run the setup pipeline now (apply KQL setup, then generate "
             "dimensions, facts, and gold)?",

--- a/website/docs/fabric/pipelines.md
+++ b/website/docs/fabric/pipelines.md
@@ -9,7 +9,7 @@ items** (`.platform`, `pipeline-content.json`, and an optional `.schedules`) tha
 
 | Pipeline | Recommended Schedule | Activities |
 |----------|---------------------|------------|
-| `setup-pipeline` | On demand | `00-apply-kql` → `setup-01` → `setup-02` → `setup-03` → `setup-04` |
+| `setup-pipeline` | On demand | `setup-00-apply-kql` → `setup-01` → `setup-02` → `setup-03` → `setup-04` |
 | `historical-data-load` | Once (manual) | `02-historical-data-load` |
 | `streaming-data-load` | Cron (every 5 minutes) | `03-streaming-to-silver` → `04-streaming-to-gold` (sequential) |
 | `daily-maintenance` | Daily 00:00 | `05-maintain-delta-tables` |
@@ -23,8 +23,10 @@ triggers in the Fabric portal.
 
 `retail-setup deploy` stages each pipeline whose notebooks are part of the
 deploy into a **Pipelines** workspace folder, and adds `DataPipeline` to the
-fabric-cicd scope so they publish automatically. With the default
-`core setup ml` groups, all five pipelines deploy.
+fabric-cicd scope so they publish automatically. `setup-pipeline` is the
+exception — it publishes into the **Setup** folder alongside the setup notebooks
+it orchestrates. With the default `core setup ml` groups, all five pipelines
+deploy.
 
 Each activity references its notebook by the **source** workspace's
 `notebookId`/`workspaceId`. `deploy/fabric-cicd/parameter.yml` remaps them to the
@@ -39,8 +41,8 @@ After a successful deploy, `retail-setup deploy` offers to **run `setup-pipeline
 now** (via the Fabric Job Scheduler API) to apply the KQL setup and generate the
 dimensions, facts, and Gold tables.
 
-`setup-pipeline` is authored in this repo; its first step `00-apply-kql` is a
-notebook **generated** from `fabric/kql_database/*.kql` that applies the
+`setup-pipeline` is authored in this repo; its first step `setup-00-apply-kql` is
+a notebook **generated** from `fabric/kql_database/*.kql` that applies the
 Eventhouse KQL setup with Kqlmagic. The other four pipelines were exported from a
 live workspace with `deploy.scripts.export_pipelines`.
 
@@ -58,7 +60,7 @@ python -m deploy.scripts.export_pipelines --workspace-name "Retail Demo" --outpu
 ### setup-pipeline
 
 One-shot environment bootstrap: applies the Eventhouse KQL schema
-(`00-apply-kql`), then runs the rendered setup notebooks in order to seed
+(`setup-00-apply-kql`), then runs the rendered setup notebooks in order to seed
 dictionaries, generate dimensions and facts, and build the Gold tables.
 
 ### historical-data-load

--- a/website/docs/fabric/taskflow.md
+++ b/website/docs/fabric/taskflow.md
@@ -40,7 +40,8 @@ python -m deploy.scripts.taskflow deploy --workspace "retail-demo-dev"
 item (stale source references, or items the target doesn't have such as data
 agents/ontology) are dropped and reported.
 
-`retail-setup deploy` offers to run this automatically at the end (interactive
-only): *"Wire up the workspace task flow now?"*.
+`retail-setup deploy` runs this **automatically** at the end of every deploy (in
+both interactive and `--yes` modes), once the workspace items it links have been
+published.
 
 See `fabric/taskflow/README.md` for the full data model and caveats.

--- a/website/docs/setup/05-pipelines.md
+++ b/website/docs/setup/05-pipelines.md
@@ -8,7 +8,7 @@ streaming, maintenance, and ML.
 
 | Pipeline | Trigger | Notebook(s) | Purpose |
 | --- | --- | --- | --- |
-| `setup-pipeline` | On demand | `00-apply-kql`, setup `01`–`04` | Apply KQL schema, then build historical demo data |
+| `setup-pipeline` | On demand | `setup-00-apply-kql`, setup `01`–`04` | Apply KQL schema, then build historical demo data |
 | `historical-data-load` | Manual | `02-historical-data-load` | Load historical batch data |
 | `streaming-data-load` | Cron (5 min) | `03-streaming-to-silver`, `04-streaming-to-gold` | Near-real-time Silver/Gold refresh |
 | `daily-maintenance` | Daily | `05-maintain-delta-tables` | Delta maintenance |


### PR DESCRIPTION
## Summary

Fixes four issues surfaced during a live `retail-setup deploy` run.

1. **Task flow wiring is now automatic.** Previously it sat behind a `Wire up the workspace task flow now? [y/N]` prompt. It now runs automatically at the end of every deploy (both interactive and `--yes`).
2. **Fixed the task-flow CLI auth timeout.** On Windows `az.cmd` is slow to start, so azure-identity's 10s default `process_timeout` timed out when fetching the Power BI and Fabric tokens back to back (`AzureCliCredential.get_token failed: Failed to invoke the Azure CLI`). A single `AzureCliCredential(process_timeout=60)` is now constructed once and reused for both token requests.
3. **`setup-pipeline` moves to the Setup folder.** It now publishes alongside the setup notebooks it orchestrates (the `Setup` workspace folder) instead of the general `Pipelines` folder.
4. **Consistent setup-notebook naming.** The generated KQL apply notebook `00-apply-kql` is renamed `setup-00-apply-kql` so it matches the `setup-01`…`setup-04` siblings. The pipeline activity name, the `parameter.yml` notebook-id mapping (derived from the activity name), and all docs are updated to match.

## Changes

- `deploy/scripts/taskflow.py` — `_credential()` helper (`process_timeout=60`, reused across both tokens); `_token` takes the credential.
- `utility/src/retail_setup/cli/main.py` — task flow deploy runs automatically (prompt removed).
- `deploy/scripts/build_artifacts.py` — `setup-pipeline` routed to `Setup`; `KQL_APPLY_NOTEBOOK = setup-00-apply-kql`.
- `fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json` — activity renamed (+ dependsOn).
- Docs: `fabric/pipelines/README.md`, `fabric/taskflow/README.md`, `website/docs/fabric/pipelines.md`, `website/docs/fabric/taskflow.md`, `website/docs/setup/05-pipelines.md`.
- Tests: `tests/deploy/test_build_artifacts.py` (rename + new setup-folder routing test), `tests/deploy/test_taskflow.py` (mock `_credential`).

## Verification

- `pytest tests/deploy/` — **44 passed**.
- `ruff check` on changed files — **clean**.
- `build_workspace` — confirms `setup-pipeline` + `setup-00-apply-kql` land in `Setup`; other pipelines in `Pipelines`; KQL notebook cells are list-form `source`.
- `npm run build` (Docusaurus, `onBrokenLinks: 'throw'`) — **passes**.