### PR TITLE
fix(deploy): apply KQL via Kusto SDK with ThrowOnErrors so failures surface

### DIFF
--- a/deploy/scripts/apply_kql.py
+++ b/deploy/scripts/apply_kql.py
@@ -21,9 +21,17 @@ def collect_kql_scripts(source_dir: Path = KQL_SOURCE_DIR) -> list[Path]:
 
 
 def build_database_script(scripts: list[Path]) -> str:
-    """Build one `.execute database script` payload from ordered KQL files."""
+    """Build one `.execute database script` payload from ordered KQL files.
 
-    parts = ["// Generated from fabric\\kql_database", ".execute database script <|"]
+    ``ThrowOnErrors=true`` makes the batch fail (and raise) on the first command
+    error. Without it, ``.execute database script`` *always* reports success even
+    when individual commands fail, which silently leaves the schema unapplied.
+    """
+
+    parts = [
+        "// Generated from fabric\\kql_database",
+        ".execute database script with (ThrowOnErrors=true) <|",
+    ]
     for script in scripts:
         parts.append(f"\n// BEGIN {script.name}")
         parts.append(script.read_text(encoding="utf-8").strip())

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -195,11 +195,13 @@ def stage_kql_apply_notebook(
 
     The notebook resolves the workspace's KQL database at runtime and runs the
     combined ``.execute database script`` (built from ``fabric/kql_database/*.kql``)
-    with Kqlmagic. It is chained first in the setup pipeline so the Eventhouse
-    schema exists before the data-generation notebooks run.
+    with the Kusto Python SDK (``azure-kusto-data``), authenticating with the
+    notebook's AAD token. It is chained first in the setup pipeline so the
+    Eventhouse schema exists before the data-generation notebooks run.
 
-    Note: notebook execution can't be validated outside Fabric — verify the first
-    run and adjust the Kqlmagic auth if a headless pipeline run can't sign in.
+    The script sets ``ThrowOnErrors=true`` so a failed command raises instead of
+    reporting silent success (``.execute database script`` succeeds by default
+    even when individual commands fail).
     """
 
     from deploy.scripts import apply_kql
@@ -219,7 +221,7 @@ def stage_kql_apply_notebook(
 
 
 def _kql_apply_notebook_content(kql_script: str, kql_database_name: str) -> dict:
-    """Build the ipynb JSON for the KQL-apply notebook (Kqlmagic + embedded KQL)."""
+    """Build the ipynb JSON for the KQL-apply notebook (Kusto SDK + embedded KQL)."""
 
     resolve = (
         "import requests, notebookutils\n"
@@ -236,22 +238,22 @@ def _kql_apply_notebook_content(kql_script: str, kql_database_name: str) -> dict
         "db_name = db['displayName']\n"
         "print(f'KQL database: {db_name} @ {query_uri}')"
     )
-    connect = (
-        "%reload_ext Kqlmagic\n"
-        "from IPython import get_ipython\n"
-        "kusto_token = notebookutils.credentials.getToken(query_uri)\n"
-        "conn = (\n"
-        "    f\"azureDataExplorer://aadtoken='{kusto_token}';\"\n"
-        "    f\"cluster='{query_uri}';database='{db_name}'\"\n"
-        ")\n"
-        "get_ipython().run_line_magic('kql', conn)"
-    )
     run = (
-        "import json\n"
-        "from IPython import get_ipython\n"
+        "import json, notebookutils\n"
+        "from azure.kusto.data import KustoClient, KustoConnectionStringBuilder\n"
+        "from azure.kusto.data.helpers import dataframe_from_result_table\n"
         f"KQL_SCRIPT = json.loads(r'''{json.dumps(kql_script)}''')\n"
-        "get_ipython().run_cell_magic('kql', '', KQL_SCRIPT)\n"
-        "print('KQL setup scripts applied.')"
+        "kusto_token = notebookutils.credentials.getToken(query_uri)\n"
+        "kcsb = KustoConnectionStringBuilder.with_aad_access_token_authentication(\n"
+        "    query_uri, kusto_token\n"
+        ")\n"
+        "client = KustoClient(kcsb)\n"
+        "# ThrowOnErrors=true (set in the script) makes execute_mgmt raise on the\n"
+        "# first failed command instead of reporting silent success.\n"
+        "resp = client.execute_mgmt(db_name, KQL_SCRIPT)\n"
+        "df = dataframe_from_result_table(resp.primary_results[0])\n"
+        "print(df.to_string())\n"
+        "print(f'KQL setup scripts applied: {len(df)} command(s).')"
     )
     return {
         "cells": [
@@ -261,13 +263,13 @@ def _kql_apply_notebook_content(kql_script: str, kql_database_name: str) -> dict
                 "source": _source_lines(
                     "# Apply KQL setup scripts\n\n"
                     "Applies the Eventhouse KQL setup (tables, ingestion mappings, "
-                    "functions, materialized views) with Kqlmagic. Generated from "
-                    "`fabric/kql_database/*.kql` by `build_artifacts` — do not edit by hand."
+                    "functions, materialized views) with the Kusto Python SDK "
+                    "(`azure-kusto-data`). Generated from `fabric/kql_database/*.kql` "
+                    "by `build_artifacts` — do not edit by hand."
                 ),
             },
-            _code_cell("%pip install --quiet Kqlmagic"),
+            _code_cell("%pip install --quiet azure-kusto-data"),
             _code_cell(resolve),
-            _code_cell(connect),
             _code_cell(run),
         ],
         "metadata": {

--- a/fabric/pipelines/README.md
+++ b/fabric/pipelines/README.md
@@ -17,14 +17,14 @@ workspace and use the Git-integration format that fabric-cicd publishes.
 
 `setup-pipeline` is authored in this repo (not exported). Its first step,
 `setup-00-apply-kql`, is a notebook **generated** by `build_artifacts` from
-`fabric/kql_database/*.kql` that applies the Eventhouse KQL setup with Kqlmagic;
+`fabric/kql_database/*.kql` that applies the Eventhouse KQL setup with the Kusto
+Python SDK (`azure-kusto-data`), authenticating with the notebook's AAD token;
 the remaining steps run the rendered setup notebooks in order. It publishes into
 the **Setup** workspace folder alongside those notebooks (not the general
 **Pipelines** folder). After `retail-setup deploy` completes, it offers to run
-`setup-pipeline` on demand (via `deploy.scripts.run_pipeline`). The
-`setup-00-apply-kql` notebook can only be validated by running it in Fabric —
-verify its first run and adjust the Kqlmagic auth if a headless pipeline run
-can't authenticate.
+`setup-pipeline` on demand (via `deploy.scripts.run_pipeline`). The combined
+script runs with `ThrowOnErrors=true` so a failed command fails the notebook
+instead of reporting silent success.
 
 ## Re-exporting from Fabric
 

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -164,7 +164,7 @@ def test_stage_querysets_returns_empty_when_no_sources(tmp_path: Path) -> None:
     assert not (output / "retail_querysets.KQLQueryset").exists()
 
 
-def test_stage_kql_apply_notebook_embeds_kqlmagic_and_scripts(tmp_path: Path) -> None:
+def test_stage_kql_apply_notebook_embeds_kusto_sdk_and_scripts(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     kql_dir = repo / "fabric" / "kql_database"
     kql_dir.mkdir(parents=True)
@@ -189,7 +189,13 @@ def test_stage_kql_apply_notebook_embeds_kqlmagic_and_scripts(tmp_path: Path) ->
         isinstance(line, str) for c in notebook["cells"] for line in c["source"]
     )
     text = "".join("".join(c["source"]) for c in notebook["cells"])
-    assert "Kqlmagic" in text
+    # Uses the Kusto Python SDK for reliable headless auth (not Kqlmagic).
+    assert "azure-kusto-data" in text
+    assert "KustoClient" in text
+    assert "execute_mgmt" in text
+    assert "Kqlmagic" not in text
+    # ThrowOnErrors=true makes a failed command raise instead of silent success.
+    assert "ThrowOnErrors=true" in text
     assert "create table receipts" in text  # embedded KQL
     assert "retail_kql" in text  # target database name
 

--- a/website/docs/fabric/pipelines.md
+++ b/website/docs/fabric/pipelines.md
@@ -43,8 +43,9 @@ dimensions, facts, and Gold tables.
 
 `setup-pipeline` is authored in this repo; its first step `setup-00-apply-kql` is
 a notebook **generated** from `fabric/kql_database/*.kql` that applies the
-Eventhouse KQL setup with Kqlmagic. The other four pipelines were exported from a
-live workspace with `deploy.scripts.export_pipelines`.
+Eventhouse KQL setup with the Kusto Python SDK (`azure-kusto-data`). The other
+four pipelines were exported from a live workspace with
+`deploy.scripts.export_pipelines`.
 
 ## Re-exporting
 


### PR DESCRIPTION
## Problem

The generated `setup-00-apply-kql` notebook failed to apply the Eventhouse schema during a headless pipeline run, but reported **success** (Spark `exitCode 0`) — so the deploy looked fine while the KQL schema was never applied.

Two root causes:

1. **Kqlmagic is the wrong tool for headless runs.** It is built around interactive AAD auth and is unreliable when a pipeline executes the notebook with no user present.
2. **`.execute database script` succeeds by default even when individual commands fail.** Per the [Microsoft docs](https://learn.microsoft.com/en-us/kusto/management/execute-database-script): *"By default, the `.execute database script` command always succeeds."* So any failing command was swallowed and the notebook still reported success.

## Fix

- **Apply the script with the `azure-kusto-data` SDK** instead of Kqlmagic. The notebook authenticates with the notebook's own AAD token (`notebookutils.credentials.getToken` → `KustoConnectionStringBuilder.with_aad_access_token_authentication`) and runs the batch with `KustoClient.execute_mgmt` — the documented, headless-friendly path. Auth/connection problems now raise a clear `KustoServiceError` instead of a silent Kqlmagic failure.
- **Build the script with `ThrowOnErrors=true`** (`apply_kql.build_database_script`) so the first failed command raises and **fails the notebook/pipeline loudly** instead of reporting silent success.
- The notebook now prints the per-command result table for visibility.

## Changes

- `deploy/scripts/apply_kql.py` — `.execute database script with (ThrowOnErrors=true) <|`
- `deploy/scripts/build_artifacts.py` — notebook generator rewritten to use the Kusto SDK (drops the Kqlmagic install + connect cells; `%pip install azure-kusto-data`)
- `tests/deploy/test_build_artifacts.py` — asserts SDK markers + `ThrowOnErrors=true`, no Kqlmagic
- Docs: `fabric/pipelines/README.md`, `website/docs/fabric/pipelines.md`

## Verification

- `pytest tests/deploy/` → **44 passed**
- `ruff check` → clean
- Regenerated notebook: 4 cells, all list-form `source`, embedded Python compiles, contains `KustoClient` / `execute_mgmt` / `ThrowOnErrors=true`, no Kqlmagic
- `npm run build` (Docusaurus, `onBrokenLinks: 'throw'`) → passes

> Note: end-to-end execution still requires a live Fabric run to confirm the Eventhouse token audience resolves; the SDK will now surface any such error explicitly rather than failing silently.