### PR TITLE
docs(setup): clarify setup.ps1 installs only Miniforge; setup.py installs terraform/az

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,14 @@ Set-Location retail-demo
 .\scripts\setup.ps1
 ```
 
-`setup.ps1` is the Windows entry point — it works even with nothing installed.
+`setup.ps1` is the Windows entry point for machines with **nothing installed**.
 It uses Python 3.11+ if present, otherwise installs Miniforge with winget and
-creates a conda environment, then runs the guided setup. On macOS and Linux,
-activate a Python 3.11+ environment and run `python ./scripts/setup.py` instead.
+creates a conda environment, then runs the guided setup.
+
+**Already have Python 3.11+?** Run `python ./scripts/setup.py` directly to skip
+the Miniforge download — `setup.ps1` only installs Miniforge when no suitable
+Python is found. On macOS and Linux, run `python ./scripts/setup.py` from an
+activated Python 3.11+ environment.
 
 The guided setup detects Windows, macOS, or Linux; offers to install missing
 CLI prerequisites with the OS package manager; installs Python dependencies into

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,11 @@ forwarded.
 On macOS and Linux, activate a Python 3.11+ environment and run `setup.py`
 directly.
 
+Use `setup.ps1` only if you don't already have Python — its sole job is to
+bootstrap a Python 3.11+ environment (installing Miniforge with winget when
+none is found) before delegating to `setup.py`. If you already have Python
+3.11+, run `python scripts\setup.py` directly to skip the Miniforge download.
+
 ## setup.py
 
 Guided cross-platform setup engine for a new Fabric workspace.

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -8,6 +8,10 @@
     script installs Miniforge with winget and creates a conda environment so
     users with nothing installed can still run the guided setup.
 
+    Only Miniforge is installed here. The remaining CLI prerequisites
+    (git, terraform, az) are installed by scripts/setup.py using the OS package
+    manager (winget on Windows) unless --skip-prereqs is passed.
+
     All arguments are forwarded to scripts/setup.py, for example:
         ./scripts/setup.ps1 --env dev
         ./scripts/setup.ps1 --env dev --deploy

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -18,8 +18,11 @@
         ./scripts/setup.ps1 --env dev --dry-run
 
 .NOTES
-    On macOS and Linux, run scripts/setup.py directly with an activated
-    Python 3.11+ environment.
+    Use this script only if you don't already have Python 3.11+. Its job is to
+    bootstrap a Python environment (installing Miniforge with winget when none
+    is found) before delegating to scripts/setup.py. If you already have Python
+    3.11+ — on Windows, macOS, or Linux — run scripts/setup.py directly from an
+    activated environment to skip the Miniforge download.
 #>
 
 [CmdletBinding()]

--- a/utility/README.md
+++ b/utility/README.md
@@ -43,8 +43,9 @@ On Windows, from the repository root:
 
 `setup.ps1` works even with nothing installed: it uses Python 3.11+ if present,
 otherwise installs Miniforge with winget and creates a conda environment, then
-delegates to `scripts\setup.py`. On macOS and Linux, activate a Python 3.11+
-environment and run `python ./scripts/setup.py` directly.
+delegates to `scripts\setup.py`. If you already have Python 3.11+ (Windows,
+macOS, or Linux), run `python ./scripts/setup.py` directly to skip the Miniforge
+download.
 
 The guided setup:
 

--- a/website/docs/setup/01-data-generation.md
+++ b/website/docs/setup/01-data-generation.md
@@ -16,8 +16,9 @@ Set-Location retail-demo
 
 `setup.ps1` works even with nothing installed: it uses Python 3.11+ if present,
 otherwise installs Miniforge with winget and creates a conda environment, then
-runs the guided setup. On macOS and Linux, activate a Python 3.11+ environment
-and run `python ./scripts/setup.py` instead.
+runs the guided setup. If you already have Python 3.11+ (Windows, macOS, or
+Linux), run `python ./scripts/setup.py` directly to skip the Miniforge download
+— `setup.ps1` installs Miniforge only when no suitable Python is found.
 
 The guided setup detects your OS, offers to install missing prerequisites, uses
 the Python environment that launched the script, installs dependencies, runs


### PR DESCRIPTION
## Summary

Answers a question that came up: *does `setup.ps1` ensure Terraform is installed via winget?*

It does — but indirectly, and the script's own doc comment didn't say so. `setup.ps1` installs **only Miniforge** via winget, then delegates to `scripts/setup.py`, which installs the remaining CLI prerequisites (`git`, `terraform`, `az`) via the OS package manager (winget on Windows: `Hashicorp.Terraform` / `Microsoft.AzureCLI`) unless `--skip-prereqs` is passed.

This PR adds that clarification to the `.DESCRIPTION` block so the behavior is obvious without reading `setup.py`.

## Verification

- `setup.ps1` parses cleanly (PowerShell AST parser). Comment-only change — no functional impact.