### PR TITLE
fix(deploy): enable inline pip install for setup-00-apply-kql in pipeline runs

### DIFF
--- a/fabric/pipelines/README.md
+++ b/fabric/pipelines/README.md
@@ -26,6 +26,12 @@ the **Setup** workspace folder alongside those notebooks (not the general
 script runs with `ThrowOnErrors=true` so a failed command fails the notebook
 instead of reporting silent success.
 
+The notebook installs `azure-kusto-data` with `%pip`, which Fabric disables in
+pipeline runs by default. The `setup-00-apply-kql` activity therefore carries the
+boolean parameter `_inlineInstallationEnabled = True`
+([docs](https://learn.microsoft.com/en-us/fabric/data-engineering/library-management#inline-installation))
+so the inline install runs during the pipeline.
+
 ## Re-exporting from Fabric
 
 To refresh these definitions from a live workspace, use the export script. It

--- a/fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json
+++ b/fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json
@@ -14,7 +14,13 @@
         },
         "typeProperties": {
           "notebookId": "ada58402-29c1-5543-9bdf-4d7bac88b449",
-          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0",
+          "parameters": {
+            "_inlineInstallationEnabled": {
+              "value": "True",
+              "type": "bool"
+            }
+          }
         }
       },
       {

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -335,6 +335,29 @@ def test_stage_pipelines_returns_empty_when_no_sources(tmp_path: Path) -> None:
     assert build_artifacts.stage_pipelines(repo, output, {"02-historical-data-load"}) == []
 
 
+def test_setup_pipeline_enables_inline_install_on_apply_kql() -> None:
+    """The setup-00-apply-kql activity must enable %pip in pipeline runs.
+
+    The generated KQL-apply notebook installs azure-kusto-data with %pip, which
+    Fabric disables in pipeline runs unless the notebook activity carries the
+    boolean parameter ``_inlineInstallationEnabled = True``.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    content_path = (
+        repo_root
+        / "fabric"
+        / "pipelines"
+        / "setup-pipeline.DataPipeline"
+        / "pipeline-content.json"
+    )
+    content = json.loads(content_path.read_text(encoding="utf-8"))
+    activities = content["properties"]["activities"]
+    apply_kql = next(a for a in activities if a["name"] == "setup-00-apply-kql")
+    param = apply_kql["typeProperties"]["parameters"]["_inlineInstallationEnabled"]
+    assert param == {"value": "True", "type": "bool"}
+
+
 def test_build_workspace_stages_compatible_pipelines_in_folder(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     for notebook_name in build_artifacts.NOTEBOOK_GROUPS["core"]:

--- a/website/docs/fabric/pipelines.md
+++ b/website/docs/fabric/pipelines.md
@@ -64,6 +64,11 @@ One-shot environment bootstrap: applies the Eventhouse KQL schema
 (`setup-00-apply-kql`), then runs the rendered setup notebooks in order to seed
 dictionaries, generate dimensions and facts, and build the Gold tables.
 
+The `setup-00-apply-kql` activity sets the boolean parameter
+`_inlineInstallationEnabled = True` so its `%pip install azure-kusto-data` runs
+during the pipeline — Fabric disables inline installs in pipeline runs by
+default.
+
 ### historical-data-load
 
 One-time load of historical batch data from `Files/` parquet shortcuts through


### PR DESCRIPTION
## Problem

The `setup-pipeline` run failed on `setup-00-apply-kql` with:

> MagicUsageError: `%pip` magic command is disabled.
> https://learn.microsoft.com/en-us/fabric/data-engineering/library-management#inline-installation

The KQL-apply notebook installs `azure-kusto-data` with `%pip` (it is **not** preinstalled in the Fabric Spark runtime), but Fabric **disables inline installs in pipeline runs by default**. (This was the real reason `00` kept failing — earlier logs only showed the Spark driver shutdown, masking the notebook cell error.)

## Fix

Per the [Microsoft docs](https://learn.microsoft.com/en-us/fabric/data-engineering/library-management#inline-installation):

> To enable `%pip install` for a pipeline, add `_inlineInstallationEnabled` as a boolean parameter set to True in the notebook activity parameters.

This PR adds that parameter to the `setup-00-apply-kql` activity in `setup-pipeline.DataPipeline/pipeline-content.json`:

```json
"parameters": {
  "_inlineInstallationEnabled": { "value": "True", "type": "bool" }
}
```

The exact serialization (key `parameters`, `type: "bool"` lowercase, `value: "True"` string) was verified against Microsoft's own [fabric-toolbox](https://github.com/microsoft/fabric-toolbox/blob/main/monitoring/fabric-unified-admin-monitoring/src/Load_Optimization_Module_E2E.DataPipeline/pipeline-content.json) repo, which uses this same parameter.

## Changes

- `fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json` — adds the parameter to the apply-kql activity.
- `tests/deploy/test_build_artifacts.py` — regression test asserting the source pipeline carries `_inlineInstallationEnabled = {value: 'True', type: 'bool'}`.
- Docs: `fabric/pipelines/README.md`, `website/docs/fabric/pipelines.md`.

## Verification

- `pytest tests/deploy/` → **45 passed** (incl. new regression test)
- `ruff` → clean
- JSON validates; deploy notebook-ref collection still maps `setup-00-apply-kql`
- `npm run build` (Docusaurus) → passes

> The parameter only affects pipeline runs; interactive notebook runs already allow `%pip`. A live `setup-pipeline` run is still the final confirmation, but the `%pip`-disabled error is now resolved at the source.