### PR TITLE
fix(deploy): raise az credential process_timeout to 120s for cold token calls

### DIFF
--- a/deploy/scripts/apply_kql.py
+++ b/deploy/scripts/apply_kql.py
@@ -51,11 +51,16 @@ def build_database_script(scripts: list[Path]) -> str:
 
 
 def _credential(credential: AzureCliCredential | None = None) -> AzureCliCredential:
-    """Azure CLI credential with a generous process timeout (slow ``az.cmd`` on Windows)."""
+    """Azure CLI credential with a generous process timeout.
+
+    A *cold* ``az account get-access-token`` for the Kusto/Eventhouse audience can
+    take ~90s on Windows (warm calls are ~1s). 120s absorbs the cold-start
+    without making a genuinely-broken ``az`` hang excessively.
+    """
 
     from azure.identity import AzureCliCredential
 
-    return credential or AzureCliCredential(process_timeout=60)
+    return credential or AzureCliCredential(process_timeout=120)
 
 
 def resolve_kql_database(

--- a/deploy/scripts/taskflow.py
+++ b/deploy/scripts/taskflow.py
@@ -64,14 +64,15 @@ ARTIFACT_TO_ITEM_TYPE = {
 def _credential(credential: AzureCliCredential | None = None) -> AzureCliCredential:
     """Azure CLI credential with a generous process timeout.
 
-    On Windows ``az.cmd`` is slow to start, so azure-identity's 10s default
-    frequently times out when fetching the Power BI and Fabric tokens back to
-    back. Allow more time, and reuse one credential for both token requests.
+    On Windows ``az.cmd`` is slow to start, and a *cold* token for the Power BI /
+    Fabric audience can take ~90s (the deploy fetches both back to back; warm
+    calls are ~1s). 120s absorbs the cold-start without making a genuinely-broken
+    ``az`` hang excessively. One credential is reused for both token requests.
     """
 
     from azure.identity import AzureCliCredential
 
-    return credential or AzureCliCredential(process_timeout=60)
+    return credential or AzureCliCredential(process_timeout=120)
 
 
 def _token(scope: str, credential: AzureCliCredential) -> str:


### PR DESCRIPTION
## Summary

Both the KQL-apply step (#293) and the task-flow deploy step intermittently failed with:

> `CredentialUnavailableError: Failed to invoke the Azure CLI` / `subprocess.TimeoutExpired: ... 'get-access-token' ... timed out after 60 seconds`

**Root cause:** a *cold* `az account get-access-token` for the Kusto/Eventhouse (`https://kusto.kusto.windows.net`) and Power BI (`https://analysis.windows.net/powerbi/api`) audiences can take ~90s on Windows (measured: PBI **92.6s**, Kusto >120s), while warm calls are ~1s. That exceeds the 60s `process_timeout` on `AzureCliCredential` and aborts the deploy. It is **not** a code or audience bug — once `az` is warm, both steps succeed (verified live: KQL applied 133 commands; task flow deployed).

## Fix

Raise `AzureCliCredential(process_timeout=...)` from **60 → 120s** in both:
- `deploy/scripts/apply_kql.py`
- `deploy/scripts/taskflow.py`

120s covers the observed cold-start worst case (~92s) with margin, without making a genuinely-broken `az` hang excessively.

## Verification

- Reproduced live: cold PBI token = 92.6s (> 60s → failure); warm = ~1s.
- After warming az, both steps completed (task flow exit 0; KQL 133 commands, idempotent).
- `pytest tests/deploy/test_apply_kql.py tests/deploy/test_taskflow.py` → **11 passed, 1 skipped**; `ruff` clean.

> Tip for operators: the first `az` token of a session is the slow one; 120s absorbs it.