### PR TITLE
feat(cli): streamline deploy flow and clarify output

### DIFF
--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -40,6 +40,11 @@ _GENERATION_KEYS = ("store_type", "start_date", "end_date", "store_count", "seed
 _DEFAULT_START_DATE = date(2025, 1, 1)
 _DEFAULT_END_DATE = date(2025, 3, 31)
 
+# After a recreate destroy, Fabric needs time to release the workspace name and
+# capacity before the same name can be created again. 30s proved too short, so
+# we wait longer before terraform apply recreates everything.
+_RECREATE_WAIT_SECONDS = 90
+
 
 def _default_repo_root() -> Path:
     """Walk up from cwd to the first directory containing deploy/config."""
@@ -573,19 +578,18 @@ def _deploy_plan(
                     description="Terraform destroy (recreate - DESTROYS the workspace and all items)",
                 ),
                 DeployStep(
-                    cmd=[py, "-c", "import time; time.sleep(30)"],
-                    description="Wait 30s for Fabric to finalize workspace deletion",
+                    cmd=[py, "-c", f"import time; time.sleep({_RECREATE_WAIT_SECONDS})"],
+                    description=(
+                        f"Wait {_RECREATE_WAIT_SECONDS}s for Fabric to finalize "
+                        "workspace deletion"
+                    ),
                 ),
             ]
         steps += [
             DeployStep(
-                cmd=["terraform", "-chdir=deploy/terraform", "plan", f"-var-file={var_file}"],
-                description="Terraform plan",
-            ),
-            DeployStep(
                 cmd=["terraform", "-chdir=deploy/terraform", "apply", f"-var-file={var_file}"],
                 needs_confirmation=True,
-                description="Terraform apply (confirmation required)",
+                description="Terraform apply (previews changes, then asks to confirm)",
             ),
             DeployStep(
                 cmd=["terraform", "-chdir=deploy/terraform", "output", "-json"],
@@ -645,9 +649,27 @@ def _deploy_plan(
     return steps
 
 
+def _hr(char: str = "-") -> None:
+    typer.echo(char * 60)
+
+
+def _deploy_banner(env: str, total: int, recreate: bool, dry_run: bool) -> None:
+    _hr("=")
+    typer.echo("  Deploy to Microsoft Fabric")
+    typer.echo(f"  Environment : {env}")
+    typer.echo(f"  Steps       : {total}")
+    if recreate:
+        typer.echo("  Mode        : recreate (destroys, then rebuilds from scratch)")
+    if dry_run:
+        typer.echo("  Preview     : dry run (nothing will be executed)")
+    _hr("=")
+
+
 def _echo_step(index: int, total: int, step: DeployStep) -> None:
     gate = " [requires confirmation]" if step.needs_confirmation else ""
     redirect = f" > {step.output_file}" if step.output_file else ""
+    typer.echo("")
+    _hr("-")
     typer.echo(f"[{index}/{total}] {step.description}{gate}")
     typer.echo(f"    {' '.join(step.cmd)}{redirect}")
 
@@ -703,7 +725,10 @@ def deploy(
         typer.echo("")
         typer.echo("!" * 70)
         typer.echo("  WARNING: --recreate will DESTROY the existing workspace and ALL items")
-        typer.echo("  in it, wait 30 seconds, then recreate everything from scratch.")
+        typer.echo(
+            f"  in it, wait {_RECREATE_WAIT_SECONDS} seconds, then recreate "
+            "everything from scratch."
+        )
         typer.echo("!" * 70)
     if dry_run:
         # dry runs must not require live config; fall back to the default name
@@ -733,8 +758,9 @@ def deploy(
     plan = _deploy_plan(env, skip_terraform, lakehouse_name=lakehouse, recreate=recreate)
     total = len(plan)
 
+    _deploy_banner(env, total, recreate, dry_run)
+
     if dry_run:
-        typer.echo(f"Deploy plan for environment '{env}' (dry run; nothing executed):")
         for i, step in enumerate(plan, start=1):
             _echo_step(i, total, step)
         return
@@ -774,7 +800,10 @@ def deploy(
             )
             raise typer.Exit(code=result.returncode)
 
-    typer.echo(f"Deploy complete for environment '{env}'.")
+    typer.echo("")
+    _hr("=")
+    typer.echo(f"  Deploy complete for environment '{env}'.")
+    _hr("=")
 
     # Wire up the workspace task flow automatically (the visual item graph that
     # links the deployed items). Runs in both interactive and --yes modes.

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -4,7 +4,12 @@ from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
-from retail_setup.cli.main import app, _deploy_plan, _validate_azure_cli_tenant
+from retail_setup.cli.main import (
+    app,
+    _deploy_plan,
+    _validate_azure_cli_tenant,
+    _RECREATE_WAIT_SECONDS,
+)
 
 runner = CliRunner()
 
@@ -33,21 +38,25 @@ def test_plan_orders_steps_and_gates_apply():
     cmds = [" ".join(map(str, s.cmd)) for s in plan]
     apply_idx = next(i for i, c in enumerate(cmds) if "apply" in c and "terraform" in c)
     assert plan[apply_idx].needs_confirmation
-    assert any("plan" in c for c in cmds[:apply_idx])
+    # The redundant `terraform plan` step was removed; apply previews + confirms.
+    assert not any(" plan " in f" {c} " for c in cmds)
     build_idx = next(i for i, c in enumerate(cmds) if "build_artifacts" in c)
     deploy_idx = next(i for i, c in enumerate(cmds) if "deploy_items" in c)
     assert apply_idx < build_idx < deploy_idx
 
 
-def test_recreate_inserts_destroy_and_sleep_before_plan():
+def test_recreate_inserts_destroy_and_sleep_before_apply():
     plan = _deploy_plan("dev", skip_terraform=False, recreate=True)
     cmds = [" ".join(map(str, s.cmd)) for s in plan]
     init_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and "init" in c)
     destroy_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and "destroy" in c)
-    sleep_idx = next(i for i, c in enumerate(cmds) if "time.sleep(30)" in c)
-    plan_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and " plan " in f" {c} ")
-    assert init_idx < destroy_idx < sleep_idx < plan_idx
+    sleep_idx = next(
+        i for i, c in enumerate(cmds) if f"time.sleep({_RECREATE_WAIT_SECONDS})" in c
+    )
+    apply_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and "apply" in c)
+    assert init_idx < destroy_idx < sleep_idx < apply_idx
     assert plan[destroy_idx].needs_confirmation
+    assert not any(" plan " in f" {c} " for c in cmds)
 
 
 def test_recreate_rejects_skip_terraform(monkeypatch):


### PR DESCRIPTION
## Summary

Three improvements to the `retail-setup deploy` command, all driven by recent deploy runs:

1. **Removed the redundant `terraform plan` step.** `terraform apply` already previews the changes and prompts for confirmation, so the standalone plan step added an extra wait with no new information.
2. **Increased the post-destroy recreate wait from 30s to 90s** (new `_RECREATE_WAIT_SECONDS` constant). 30s was too short for Fabric to release the workspace name and capacity after a destroy, which blocked the immediate re-create on the `--recreate` path.
3. **Added a deploy banner and per-step dividers** to the deploy output, matching the friendlier style introduced for the setup script (PR #295). The long deploy log is now much easier to scan.

## Output preview (`deploy --recreate --dry-run`)

`
============================================================
  Deploy to Microsoft Fabric
  Environment : dev
  Steps       : 11
  Mode        : recreate (destroys, then rebuilds from scratch)
  Preview     : dry run (nothing will be executed)
============================================================

------------------------------------------------------------
[5/11] Terraform apply (previews changes, then asks to confirm) [requires confirmation]
    terraform -chdir=deploy/terraform apply -var-file=environments/dev.tfvars
`

## Tests

- Updated `test_plan_orders_steps_and_gates_apply` and renamed `test_recreate_inserts_destroy_and_sleep_before_plan` -> `...before_apply` to reflect the removed plan step and the new wait value (imported via `_RECREATE_WAIT_SECONDS`).
- `tests/test_cli_deploy.py`: 17 passed. `ruff` clean.
