### PR TITLE
chore(deploy): quiet KQL output and unify deploy step formatting

### DIFF
--- a/deploy/scripts/_output.py
+++ b/deploy/scripts/_output.py
@@ -1,0 +1,45 @@
+"""Consistent console output for deploy sub-scripts.
+
+The ``retail-setup deploy`` orchestrator prints a divider, a ``[i/total]``
+header, and the command for each step. These helpers keep every sub-script's
+own output uniform underneath that header: short status lines indented to
+align with the command echo, with nested details indented one level further.
+
+Import the module (not the names) so the short verbs never clash with local
+variables, e.g. ``for error in errors: console.error(error)``::
+
+    from deploy.scripts import _output as console
+    console.info("Wrote configs")
+    console.detail("retail_model.Report")
+"""
+
+from __future__ import annotations
+
+import sys
+
+_INDENT = "    "
+_DETAIL_INDENT = "        "
+
+
+def info(message: str) -> None:
+    """Print a primary status line beneath the current deploy step."""
+
+    print(f"{_INDENT}- {message}")
+
+
+def detail(message: str) -> None:
+    """Print an indented sub-detail, e.g. a staged item or unbound reference."""
+
+    print(f"{_DETAIL_INDENT}{message}")
+
+
+def warn(message: str) -> None:
+    """Print a warning to stderr (still shown when output is otherwise quiet)."""
+
+    print(f"{_INDENT}! {message}", file=sys.stderr)
+
+
+def error(message: str) -> None:
+    """Print an error to stderr."""
+
+    print(f"{_INDENT}ERROR: {message}", file=sys.stderr)

--- a/deploy/scripts/apply_kql.py
+++ b/deploy/scripts/apply_kql.py
@@ -14,6 +14,8 @@ import argparse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from deploy.scripts import _output as console
+
 if TYPE_CHECKING:
     from azure.identity import AzureCliCredential
 
@@ -127,6 +129,35 @@ def _result_to_frame(response: Any) -> Any:
     return dataframe_from_result_table(response.primary_results[0])
 
 
+def _summarize_result(frame: Any) -> None:
+    """Print a concise summary of a ``.execute database script`` result.
+
+    The raw Kusto result has one wide row per command (including the full
+    command text), which is hundreds of rows for the retail schema. Collapse it
+    to a completed/failed count and only print details for failed commands.
+    """
+
+    total = len(frame)
+    columns = getattr(frame, "columns", None)
+    results = frame["Result"] if columns is not None and "Result" in columns else None
+    if results is None:
+        console.info(f"KQL applied: {total} command(s).")
+        return
+
+    failures = frame[results != "Completed"]
+    completed = total - len(failures)
+    if len(failures) == 0:
+        console.info(f"KQL applied: {completed}/{total} commands completed.")
+        return
+
+    console.info(f"KQL applied: {completed}/{total} completed, {len(failures)} failed:")
+    for _, row in failures.iterrows():
+        lines = str(row.get("CommandText", "")).strip().splitlines()
+        first_line = lines[0][:100] if lines else ""
+        reason = str(row.get("Reason", "")).strip()
+        console.detail(f"[{row.get('CommandType', '')}] {first_line} -> {reason}")
+
+
 def apply_to_database(
     *,
     script: str,
@@ -142,12 +173,11 @@ def apply_to_database(
         workspace_id, kql_database_id, credential
     )
     database_name = kql_database_name or resolved_name
-    print(f"Applying KQL to database '{database_name}' @ {query_uri}")
+    console.info(f"Applying KQL to '{database_name}' @ {query_uri}")
     response = execute_database_script(query_uri, database_name, script, credential)
 
     frame = _result_to_frame(response)
-    print(frame.to_string())
-    print(f"KQL setup scripts applied: {len(frame)} command(s).")
+    _summarize_result(frame)
     return len(frame)
 
 
@@ -182,7 +212,7 @@ def main() -> int:
     script = build_database_script(collect_kql_scripts(args.source_dir))
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(script, encoding="utf-8")
-    print(f"Wrote combined KQL deployment script to {args.output}")
+    console.info(f"Wrote combined KQL script to {args.output}")
 
     if not args.execute:
         return 0

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -9,6 +9,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from deploy.scripts import _output as console
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "deploy" / "workspace"
 PLATFORM_SCHEMA = (
@@ -478,9 +480,9 @@ def main() -> int:
         args.lakehouse_name,
         args.kql_database_name,
     )
-    print(f"Staged {len(result.staged_items)} items in {result.output_dir}")
+    console.info(f"Staged {len(result.staged_items)} items in {result.output_dir}")
     for item in result.staged_items:
-        print(f"  {item}")
+        console.detail(item)
     return 0
 
 

--- a/deploy/scripts/deploy_config.py
+++ b/deploy/scripts/deploy_config.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import yaml
 
+from deploy.scripts import _output as console
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_ROOT = REPO_ROOT / "deploy"
 CONFIG_ROOT = DEPLOY_ROOT / "config"
@@ -533,9 +535,9 @@ def main() -> int:
         else None
     )
     paths = write_generated_configs(config, args.deploy_root, outputs)
-    print(f"Wrote {paths.tfvars}")
-    print(f"Wrote {paths.fabric_config}")
-    print(f"Wrote {paths.parameter}")
+    console.info(f"Wrote {paths.tfvars}")
+    console.info(f"Wrote {paths.fabric_config}")
+    console.info(f"Wrote {paths.parameter}")
     return 0
 
 

--- a/deploy/scripts/deploy_items.py
+++ b/deploy/scripts/deploy_items.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from deploy.scripts import _output as console
 from deploy.scripts.deploy_config import DEPLOY_ROOT
 
 
@@ -25,15 +26,26 @@ def build_credential(auth_mode: str):
 
 
 def deploy(config_path: Path, environment: str, auth_mode: str) -> None:
-    """Run fabric-cicd configuration deployment."""
+    """Run fabric-cicd configuration deployment with quiet, consistent output.
+
+    fabric-cicd logs verbose ``[info] HH:MM:SS - ####`` banners at INFO. Raise
+    its package logger to WARNING so only warnings and errors surface, and print
+    our own concise progress lines to match the other deploy steps.
+    """
+
+    import logging
 
     from fabric_cicd import deploy_with_config
 
+    logging.getLogger("fabric_cicd").setLevel(logging.WARNING)
+
+    console.info(f"Publishing Fabric items (environment '{environment}')...")
     deploy_with_config(
         config_file_path=str(config_path.resolve()),
         token_credential=build_credential(auth_mode),
         environment=environment,
     )
+    console.info("Published Fabric items.")
 
 
 def main() -> int:

--- a/deploy/scripts/run_pipeline.py
+++ b/deploy/scripts/run_pipeline.py
@@ -15,6 +15,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from deploy.scripts import _output as console
 from deploy.scripts.export_items import build_session, list_items
 
 if TYPE_CHECKING:
@@ -77,9 +78,9 @@ def main() -> int:
     session = build_session()
     pipeline_id = find_pipeline_id(session, workspace_id, args.pipeline)
     location = run_pipeline(session, workspace_id, pipeline_id)
-    print(f"Started pipeline run for {args.pipeline!r} ({pipeline_id}).")
+    console.info(f"Started pipeline run for {args.pipeline!r} ({pipeline_id}).")
     if location:
-        print(f"  Track the run at: {location}")
+        console.detail(f"Track the run at: {location}")
     return 0
 
 

--- a/deploy/scripts/taskflow.py
+++ b/deploy/scripts/taskflow.py
@@ -30,6 +30,8 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from deploy.scripts import _output as console
+
 if TYPE_CHECKING:
     import requests
     from azure.identity import AzureCliCredential
@@ -306,14 +308,14 @@ def main() -> int:
 
     if args.action == "export":
         out = export_taskflow(args.workspace, args.path)
-        print(f"Exported task flow to {out}")
+        console.info(f"Exported task flow to {out}")
     else:
         unresolved = deploy_taskflow(args.workspace, args.path)
-        print("Deployed task flow.")
+        console.info("Deployed task flow.")
         if unresolved:
-            print("Unresolved references (left unbound):")
+            console.warn("Unresolved references (left unbound):")
             for ref in unresolved:
-                print(f"  {ref}")
+                console.detail(ref)
     return 0
 
 

--- a/deploy/scripts/validate_deployment.py
+++ b/deploy/scripts/validate_deployment.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import yaml
 
+from deploy.scripts import _output as console
 from deploy.scripts.deploy_config import DEPLOY_ROOT, load_environment
 
 # Placeholders that staged item definitions may legitimately contain. They are
@@ -91,9 +92,9 @@ def main() -> int:
     errors = validate_generated_files(args.deploy_root, args.environment)
     if errors:
         for error in errors:
-            print(f"ERROR: {error}")
+            console.error(error)
         return 1
-    print("Deployment framework validation passed")
+    console.info("Deployment framework validation passed")
     return 0
 
 

--- a/tests/deploy/test_apply_kql.py
+++ b/tests/deploy/test_apply_kql.py
@@ -143,3 +143,63 @@ def test_apply_to_database_runs_resolved_script(monkeypatch) -> None:
     assert calls["query_uri"] == "https://cluster"
     assert calls["database_name"] == "retail_kql"
     assert "ThrowOnErrors=true" in calls["script"]
+
+
+def test_summarize_result_is_concise_on_success(capsys) -> None:
+    """A successful apply collapses to one line; no per-command text is dumped."""
+
+    pd = pytest.importorskip("pandas")
+    frame = pd.DataFrame(
+        {
+            "CommandType": ["DatabaseScriptExecute", "TableCreate", "TableCreate"],
+            "CommandText": [
+                ".execute database script",
+                ".create-merge table receipt_created (store_id:long)",
+                ".create-merge table receipt_line_added (line_number:long)",
+            ],
+            "Result": ["Completed", "Completed", "Completed"],
+            "Reason": ["", "", ""],
+        }
+    )
+
+    apply_kql._summarize_result(frame)
+
+    out = capsys.readouterr().out
+    assert "KQL applied: 3/3 commands completed." in out
+    # The verbose command text must not be printed on success.
+    assert "create-merge table receipt_created" not in out
+
+
+def test_summarize_result_lists_only_failures(capsys) -> None:
+    pd = pytest.importorskip("pandas")
+    frame = pd.DataFrame(
+        {
+            "CommandType": ["TableCreate", "FunctionCreate"],
+            "CommandText": [
+                ".create-merge table ok (x:long)",
+                ".create-or-alter function bad() { nope }",
+            ],
+            "Result": ["Completed", "Failed"],
+            "Reason": ["", "Semantic error: 'nope' is not defined"],
+        }
+    )
+
+    apply_kql._summarize_result(frame)
+
+    out = capsys.readouterr().out
+    assert "1/2 completed, 1 failed" in out
+    assert "FunctionCreate" in out and "not defined" in out
+    # The command that succeeded is not listed in the failure detail.
+    assert "create-merge table ok" not in out
+
+
+def test_summarize_result_falls_back_without_columns(capsys) -> None:
+    """A result object without a Result column still prints a count, not a dump."""
+
+    class _Frame:
+        def __len__(self) -> int:
+            return 7
+
+    apply_kql._summarize_result(_Frame())
+
+    assert "KQL applied: 7 command(s)." in capsys.readouterr().out

--- a/tests/deploy/test_output.py
+++ b/tests/deploy/test_output.py
@@ -1,0 +1,25 @@
+"""Tests for the shared deploy console output helpers."""
+
+from __future__ import annotations
+
+from deploy.scripts import _output as console
+
+
+def test_info_indents_with_dash(capsys) -> None:
+    console.info("hello")
+    assert capsys.readouterr().out == "    - hello\n"
+
+
+def test_detail_indents_further(capsys) -> None:
+    console.detail("retail_model.Report")
+    assert capsys.readouterr().out == "        retail_model.Report\n"
+
+
+def test_warn_and_error_go_to_stderr(capsys) -> None:
+    console.warn("careful")
+    console.error("broke")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "! careful" in captured.err
+    assert "ERROR: broke" in captured.err


### PR DESCRIPTION
## Summary

Two deploy UX issues, both visible in a real `retail-setup deploy` run:

1. **The KQL apply step was extremely verbose.** It printed the entire Kusto result frame -- one wide row per command, *including the full command text* -- which is ~130 rows and 100+ KB of output for the retail schema.
2. **The deploy sub-scripts each printed in their own style**, and the `Deploy Fabric items` step surfaced fabric-cicd's noisy `[info] HH:MM:SS - ####` banners, so the orchestrated log read inconsistently.

## Changes

- **Concise KQL summary** (`apply_kql.py`): the frame dump is replaced by `KQL applied: N/N commands completed.` On failure it lists only the failed commands (type, first line, reason). `apply_to_database` still returns the row count.
- **Shared output helper** (new `deploy/scripts/_output.py`): `info` / `detail` / `warn` / `error` print consistent, indented status lines that nest under the orchestrator's `[i/total]` step header (`    - message`).
- **Unified the sub-scripts**: `deploy_config`, `build_artifacts`, `validate_deployment`, `taskflow`, `run_pipeline`, and `apply_kql` all route through the helper.
- **Quieted fabric-cicd** (`deploy_items.py`): raise the `fabric_cicd` logger to `WARNING` (suppressing the INFO banners) and print our own `Publishing Fabric items...` / `Published Fabric items.` lines. Warnings and errors still surface.

## Before / after (KQL step)

Before: ~130 rows like `0  d7d0... DatabaseScriptExecute  .execute database script... Completed` (100+ KB).

After:
`
    - Applying KQL to 'retail_kql' @ https://trd-...kusto.fabric.microsoft.com
    - KQL applied: 133/133 commands completed.
`

## Tests

- New coverage in `tests/deploy/test_apply_kql.py` (success summary, failure list, frameless fallback) and `tests/deploy/test_output.py` (helper formatting).
- `tests/deploy`: **54 passed, 1 skipped**; `ruff` clean.
- Verified in the deploy env that setting the `fabric_cicd` logger to WARNING gates INFO (and its child loggers) while warnings/errors still emit.
