### PR TITLE
fix(deploy): resolve notebook lakehouse binding via logicalId + zero GUID

### DIFF
--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -18,6 +18,25 @@ PLATFORM_SCHEMA = (
     "platformProperties/2.0.0/schema.json"
 )
 
+# fabric-cicd replaces this sentinel workspace id with the target workspace id
+# at publish time (its `_replace_workspace_ids`). The `$workspace.$id` token only
+# resolves inside parameter.yml replace_values, NOT when baked into item content,
+# so a notebook's default-lakehouse workspace binding must use this sentinel.
+_CURRENT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _logical_id(item_type: str, display_name: str) -> str:
+    """Deterministic fabric-cicd logicalId for a staged item.
+
+    The same value is written to the item's ``.platform`` and referenced by
+    other items (e.g. a notebook's default lakehouse), so fabric-cicd's
+    ``_replace_logical_ids`` resolves the reference to the deployed item GUID.
+    Like ``$workspace.$id``, the ``$items.<type>.<name>.$id`` token only resolves
+    inside parameter.yml, so item content must reference the logicalId directly.
+    """
+
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"retail-demo:{item_type}:{display_name}"))
+
 # Workspace folder names used to organize published items. fabric-cicd maps the
 # staged directory structure to Fabric workspace folders, so staging an item
 # under `<output>/Notebooks/<item>` places it in a "Notebooks" workspace folder.
@@ -118,12 +137,12 @@ def stage_notebook(
     notebook = json.loads(source_path.read_text(encoding="utf-8"))
     metadata = notebook.setdefault("metadata", {})
     dependencies = metadata.setdefault("dependencies", {})
-    lakehouse_id_ref = f"$items.Lakehouse.{lakehouse_name}.$id"
+    lakehouse_logical_id = _logical_id("Lakehouse", lakehouse_name)
     dependencies["lakehouse"] = {
-        "default_lakehouse": lakehouse_id_ref,
+        "default_lakehouse": lakehouse_logical_id,
         "default_lakehouse_name": lakehouse_name,
-        "default_lakehouse_workspace_id": "$workspace.$id",
-        "known_lakehouses": [{"id": lakehouse_id_ref}],
+        "default_lakehouse_workspace_id": _CURRENT_WORKSPACE_ID,
+        "known_lakehouses": [{"id": lakehouse_logical_id}],
     }
     (item_dir / "notebook-content.ipynb").write_text(
         json.dumps(notebook, indent=1, ensure_ascii=False),
@@ -346,12 +365,13 @@ def build_workspace(
 
     staged_items: list[str] = []
     # Terraform provisions the Lakehouse, Eventhouse, and KQL Database. Only the
-    # Lakehouse is staged as a fabric-cicd shell item (it publishes cleanly and
-    # helps notebook `$items.Lakehouse` references resolve). Eventhouse and
-    # KQLDatabase are NOT staged: Fabric rejects a `.platform`-only definition
-    # update ("Definition parts cannot contain the .platform file only"), and
-    # Terraform already owns them.
-    staged_items.append(stage_shell_item(output_dir, "retail_lakehouse", "Lakehouse").name)
+    # Lakehouse is staged as a fabric-cicd shell item so its `.platform` logicalId
+    # exists in the deployment; notebook default-lakehouse bindings reference that
+    # same logicalId (see `_logical_id`) and fabric-cicd resolves it to the
+    # deployed lakehouse GUID. Eventhouse and KQLDatabase are NOT staged: Fabric
+    # rejects a `.platform`-only definition update ("Definition parts cannot
+    # contain the .platform file only"), and Terraform already owns them.
+    staged_items.append(stage_shell_item(output_dir, lakehouse_name, "Lakehouse").name)
 
     # Demo/pipeline notebooks publish into a "Notebooks" workspace folder.
     notebooks_dir = output_dir / NOTEBOOKS_FOLDER
@@ -434,9 +454,7 @@ def _write_platform(item_dir: Path, item_type: str, display_name: str) -> None:
         "metadata": {"type": item_type, "displayName": display_name},
         "config": {
             "version": "2.0",
-            "logicalId": str(
-                uuid.uuid5(uuid.NAMESPACE_URL, f"retail-demo:{item_type}:{display_name}")
-            ),
+            "logicalId": _logical_id(item_type, display_name),
         },
     }
     (item_dir / ".platform").write_text(

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -29,12 +29,36 @@ def test_stage_notebook_creates_platform_and_notebook_content(tmp_path: Path) ->
         "displayName": "01-create-bronze-shortcuts",
     }
     notebook = json.loads((staged / "notebook-content.ipynb").read_text(encoding="utf-8"))
+    lakehouse_logical_id = build_artifacts._logical_id("Lakehouse", "retail_lakehouse")
     assert notebook["metadata"]["dependencies"]["lakehouse"] == {
-        "default_lakehouse": "$items.Lakehouse.retail_lakehouse.$id",
+        "default_lakehouse": lakehouse_logical_id,
         "default_lakehouse_name": "retail_lakehouse",
-        "default_lakehouse_workspace_id": "$workspace.$id",
-        "known_lakehouses": [{"id": "$items.Lakehouse.retail_lakehouse.$id"}],
+        "default_lakehouse_workspace_id": "00000000-0000-0000-0000-000000000000",
+        "known_lakehouses": [{"id": lakehouse_logical_id}],
     }
+
+
+def test_notebook_lakehouse_binding_matches_staged_lakehouse_logical_id(tmp_path: Path) -> None:
+    """The notebook's default-lakehouse id must equal the staged Lakehouse shell's
+    .platform logicalId so fabric-cicd resolves it to the deployed lakehouse GUID
+    (the $items.Lakehouse.<name>.$id token does NOT resolve in raw item content)."""
+
+    source = tmp_path / "fabric" / "lakehouse" / "01-create-bronze-shortcuts.ipynb"
+    _write_json(source, {"metadata": {}, "cells": [], "nbformat": 4, "nbformat_minor": 5})
+    output = tmp_path / "deploy" / "workspace"
+
+    lakehouse_dir = build_artifacts.stage_shell_item(output, "retail_lakehouse", "Lakehouse")
+    notebook_dir = build_artifacts.stage_notebook(source, output)
+
+    platform = json.loads((lakehouse_dir / ".platform").read_text(encoding="utf-8"))
+    notebook = json.loads((notebook_dir / "notebook-content.ipynb").read_text(encoding="utf-8"))
+    binding = notebook["metadata"]["dependencies"]["lakehouse"]
+
+    assert binding["default_lakehouse"] == platform["config"]["logicalId"]
+    assert binding["known_lakehouses"][0]["id"] == platform["config"]["logicalId"]
+    # No unresolved fabric-cicd tokens may leak into published notebook content.
+    assert "$workspace" not in json.dumps(notebook)
+    assert "$items" not in json.dumps(notebook)
 
 
 def test_stage_powerbi_items_copies_item_directories(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`setup-01-seed-dictionaries` (and every setup/streaming notebook) failed at runtime:

> Notebook execution failed ... `Error value - LakehouseWorkspaceId is not a valid GUID: $workspace.$id`

`build_artifacts.stage_notebook` baked fabric-cicd **dynamic tokens** straight into each notebook's default-lakehouse binding:

`json
"default_lakehouse": "$items.Lakehouse.retail_lakehouse.$id",
"default_lakehouse_workspace_id": "$workspace.$id"
`

But fabric-cicd only resolves `\.\` / `\.<type>.<name>.\` when they appear as **parameter.yml `replace_value`s** (`_parameter/_utils.py`). When baked into raw item content they are shipped **literally**, so the notebook tried to attach a lakehouse in workspace `\.\` -> invalid GUID.

## Fix

Use the two replacements fabric-cicd **does** apply to item content at publish time (`fabric_workspace._publish_item` -> `_replace_logical_ids` + `_replace_workspace_ids`):

| Field | Before | After | Resolved by |
|---|---|---|---|
| `default_lakehouse_workspace_id` | `\.\` | `00000000-0000-0000-0000-000000000000` | `_replace_workspace_ids` -> target workspace id |
| `default_lakehouse` / `known_lakehouses[].id` | `\.Lakehouse.<name>.\` | staged Lakehouse `.platform` **logicalId** | `_replace_logical_ids` -> deployed lakehouse GUID |

- New `_logical_id(item_type, display_name)` helper (deterministic `uuid5`) is shared by `_write_platform` and `stage_notebook` so the notebook reference and the staged Lakehouse shell's `.platform` logicalId are guaranteed identical.
- The Lakehouse shell is now staged under the configured `lakehouse_name` (was hardcoded `retail_lakehouse`).

## Tests

- Updated the binding assertion; added `test_notebook_lakehouse_binding_matches_staged_lakehouse_logical_id` which stages both items and asserts the ids match and that **no** `\` / `\` tokens leak into published content.
- `tests/deploy/test_build_artifacts.py`: 17 passed; `ruff` clean.

Staged output lives under the git-ignored `deploy/workspace/`, so it is regenerated by the `build_artifacts` deploy step — no committed artifacts to refresh.
