### PR TITLE
feat(deploy): retry transient failures and flag long-running generation

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,6 +51,16 @@ Use `--skip-terraform` only when the workspace/resources already exist:
 retail-setup deploy --env dev --skip-terraform
 ```
 
+After the items publish, the deploy offers to run the **setup pipeline**, which
+generates the historical data in Fabric (dimensions, then facts, then gold). That
+generation runs asynchronously in Fabric and **can take a while** — often several
+minutes to an hour or more depending on the configured months of history and store
+count. You can close the CLI and track progress in the Fabric workspace.
+
+Transient failures self-heal: cold `az` token calls and flaky Fabric/Power BI REST
+calls are retried with backoff (token acquisition for the KQL apply, task flow, and
+pipeline trigger), and the pipeline trigger itself is retried a few times.
+
 ## Manual script workflow
 
 Run from the repository root:
@@ -130,3 +140,5 @@ does not.
 | `fabric_cicd` import error | Install `fabric-cicd` in the active Python environment. |
 | Authentication failure | Run `az account show --query "{tenantId:tenantId,user:user.name,name:name}" -o table` and confirm it matches deploy config. Run `az login --tenant <tenant-id>` for `azure_cli`, or `Connect-AzAccount -Tenant <tenant-id>` for `azure_powershell`. |
 | KQL tables missing | Run the generated `database.kql` script manually in the target KQL database. |
+| `az` token timeout / cold-start hang | A cold `az account get-access-token` can take ~90s; the deploy uses a 120s credential timeout and retries transient auth failures. Warming `az` first (`az account get-access-token --resource https://api.fabric.microsoft.com -o none`) avoids the delay. |
+| Setup pipeline not triggered | The CLI retries the trigger a few times, then prints a fallback. Open the workspace in Fabric and run `setup-pipeline` manually. |

--- a/deploy/scripts/_retry.py
+++ b/deploy/scripts/_retry.py
@@ -1,0 +1,55 @@
+"""Lightweight retry for transient deploy failures.
+
+A *cold* ``az account get-access-token`` call intermittently times out (surfacing
+as ``ClientAuthenticationError`` / ``CredentialUnavailableError``, or
+``KustoAuthenticationError`` for the Kusto SDK), and Fabric / Power BI REST calls
+occasionally return a transient 5xx/429 or drop the connection. ``retry_call``
+re-attempts a callable a few times with exponential backoff so a single transient
+failure doesn't abort a deploy.
+
+The ``sleep`` hook is injectable so tests run without real delays.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def retry_call(
+    func: Callable[[], T],
+    *,
+    attempts: int = 3,
+    delay: float = 5.0,
+    backoff: float = 2.0,
+    retry_on: tuple[type[BaseException], ...] = (Exception,),
+    on_retry: Callable[[int, BaseException], None] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> T:
+    """Call ``func``; retry on ``retry_on`` exceptions with exponential backoff.
+
+    Re-raises the last exception once ``attempts`` are exhausted. ``on_retry`` (if
+    given) is called with the 1-based attempt number and the exception before each
+    wait, e.g. to log a "retrying..." notice. ``sleep`` defaults to ``time.sleep``
+    (looked up at call time so tests can patch it).
+    """
+
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    sleeper = sleep if sleep is not None else time.sleep
+    wait = delay
+    for attempt in range(1, attempts + 1):
+        try:
+            return func()
+        except retry_on as exc:
+            if attempt == attempts:
+                raise
+            if on_retry is not None:
+                on_retry(attempt, exc)
+            sleeper(wait)
+            wait *= backoff
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/deploy/scripts/apply_kql.py
+++ b/deploy/scripts/apply_kql.py
@@ -174,7 +174,27 @@ def apply_to_database(
     )
     database_name = kql_database_name or resolved_name
     console.info(f"Applying KQL to '{database_name}' @ {query_uri}")
-    response = execute_database_script(query_uri, database_name, script, credential)
+
+    from deploy.scripts._retry import retry_call
+
+    # The Kusto SDK acquires the token inside execute_mgmt; a cold az token can
+    # raise KustoAuthenticationError. Retrying re-runs the (idempotent) script.
+    # The exception type is only available when the Kusto SDK is installed (it is
+    # in the deploy env); without it, retry_on=() simply means "don't retry".
+    try:
+        from azure.kusto.data.exceptions import KustoAuthenticationError
+
+        retry_on: tuple[type[BaseException], ...] = (KustoAuthenticationError,)
+    except ModuleNotFoundError:
+        retry_on = ()
+
+    response = retry_call(
+        lambda: execute_database_script(query_uri, database_name, script, credential),
+        retry_on=retry_on,
+        on_retry=lambda n, exc: console.warn(
+            f"Kusto auth attempt {n} failed ({type(exc).__name__}); retrying..."
+        ),
+    )
 
     frame = _result_to_frame(response)
     _summarize_result(frame)

--- a/deploy/scripts/export_items.py
+++ b/deploy/scripts/export_items.py
@@ -36,13 +36,24 @@ _JSON_PART_NAMES = {".platform", ".schedules"}
 
 
 def build_session(credential: AzureCliCredential | None = None) -> requests.Session:
-    """Create an authenticated requests session for the Fabric REST API."""
+    """Create an authenticated requests session for the Fabric REST API.
+
+    Uses a generous credential process timeout and retries transient cold-``az``
+    token failures (the deploy's pipeline trigger runs this right after a long
+    Terraform/publish step, when the token cache may have lapsed).
+    """
 
     import requests
+    from azure.core.exceptions import ClientAuthenticationError
     from azure.identity import AzureCliCredential
 
-    credential = credential or AzureCliCredential()
-    token = credential.get_token(FABRIC_SCOPE).token
+    from deploy.scripts._retry import retry_call
+
+    credential = credential or AzureCliCredential(process_timeout=120)
+    token = retry_call(
+        lambda: credential.get_token(FABRIC_SCOPE).token,
+        retry_on=(ClientAuthenticationError,),
+    )
     session = requests.Session()
     session.headers["Authorization"] = f"Bearer {token}"
     return session

--- a/deploy/scripts/taskflow.py
+++ b/deploy/scripts/taskflow.py
@@ -78,7 +78,24 @@ def _credential(credential: AzureCliCredential | None = None) -> AzureCliCredent
 
 
 def _token(scope: str, credential: AzureCliCredential) -> str:
-    return credential.get_token(scope).token
+    """Acquire an access token, retrying transient cold-``az`` auth failures.
+
+    A cold ``az account get-access-token`` (Power BI / Fabric audience) can time
+    out even with a generous process timeout; a retry usually succeeds once ``az``
+    has warmed up.
+    """
+
+    from azure.core.exceptions import ClientAuthenticationError
+
+    from deploy.scripts._retry import retry_call
+
+    return retry_call(
+        lambda: credential.get_token(scope).token,
+        retry_on=(ClientAuthenticationError,),
+        on_retry=lambda n, exc: console.warn(
+            f"Azure CLI token attempt {n} failed ({type(exc).__name__}); retrying..."
+        ),
+    )
 
 
 def _session(token: str) -> requests.Session:

--- a/tests/deploy/test_retry.py
+++ b/tests/deploy/test_retry.py
@@ -1,0 +1,74 @@
+"""Tests for the transient-failure retry helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from deploy.scripts._retry import retry_call
+
+
+class _Boom(Exception):
+    pass
+
+
+def test_returns_first_success_without_sleeping() -> None:
+    slept: list[float] = []
+    result = retry_call(lambda: 7, sleep=slept.append)
+    assert result == 7
+    assert slept == []
+
+
+def test_retries_then_succeeds() -> None:
+    calls = {"n": 0}
+    slept: list[float] = []
+
+    def flaky() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _Boom("transient")
+        return "ok"
+
+    notices: list[int] = []
+    result = retry_call(
+        flaky,
+        attempts=3,
+        delay=1.0,
+        backoff=2.0,
+        retry_on=(_Boom,),
+        on_retry=lambda n, _exc: notices.append(n),
+        sleep=slept.append,
+    )
+
+    assert result == "ok"
+    assert calls["n"] == 3
+    assert slept == [1.0, 2.0]  # exponential backoff
+    assert notices == [1, 2]
+
+
+def test_reraises_after_exhausting_attempts() -> None:
+    calls = {"n": 0}
+
+    def always_fail() -> None:
+        calls["n"] += 1
+        raise _Boom("nope")
+
+    with pytest.raises(_Boom):
+        retry_call(always_fail, attempts=2, retry_on=(_Boom,), sleep=lambda _w: None)
+    assert calls["n"] == 2
+
+
+def test_does_not_retry_unlisted_exceptions() -> None:
+    calls = {"n": 0}
+
+    def wrong_error() -> None:
+        calls["n"] += 1
+        raise ValueError("not retryable")
+
+    with pytest.raises(ValueError):
+        retry_call(wrong_error, retry_on=(_Boom,), sleep=lambda _w: None)
+    assert calls["n"] == 1  # no retry
+
+
+def test_rejects_zero_attempts() -> None:
+    with pytest.raises(ValueError):
+        retry_call(lambda: 1, attempts=0)

--- a/tests/deploy/test_taskflow.py
+++ b/tests/deploy/test_taskflow.py
@@ -2,7 +2,27 @@
 
 from __future__ import annotations
 
+import pytest
+
 from deploy.scripts import taskflow
+
+
+def test_token_retries_transient_auth_failure(monkeypatch) -> None:
+    """A cold-az ClientAuthenticationError is retried; a later success returns."""
+
+    azcore = pytest.importorskip("azure.core.exceptions")
+    monkeypatch.setattr("time.sleep", lambda *_a: None)
+    calls = {"n": 0}
+
+    class _Cred:
+        def get_token(self, _scope):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise azcore.ClientAuthenticationError("cold az")
+            return type("T", (), {"token": "tok"})()
+
+    assert taskflow._token("scope", _Cred()) == "tok"
+    assert calls["n"] == 2
 
 
 def test_to_portable_resolves_guids_to_names() -> None:

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -11,6 +11,7 @@ import json
 import subprocess
 import shutil
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
@@ -44,6 +45,12 @@ _DEFAULT_END_DATE = date(2025, 3, 31)
 # capacity before the same name can be created again. 30s proved too short, so
 # we wait longer before terraform apply recreates everything.
 _RECREATE_WAIT_SECONDS = 90
+
+# The setup pipeline runs asynchronously in Fabric; the CLI only needs to start
+# it. Retry the start a few times so a single transient failure (e.g. a cold az
+# token right after a long Terraform/publish step) doesn't leave it untriggered.
+_PIPELINE_TRIGGER_ATTEMPTS = 3
+_PIPELINE_TRIGGER_RETRY_WAIT = 10
 
 
 def _default_repo_root() -> Path:
@@ -849,7 +856,20 @@ def _deploy_taskflow(repo_root: Path, env: str) -> None:
 
 
 def _run_setup_pipeline(repo_root: Path, env: str) -> None:
-    """Start an on-demand run of the deployed setup pipeline."""
+    """Start an on-demand run of the deployed setup pipeline.
+
+    Prints a heads-up that generation can take a while (it runs asynchronously in
+    Fabric) and retries the trigger a few times so a transient failure doesn't
+    leave the pipeline unstarted.
+    """
+
+    typer.echo("")
+    _hr("=")
+    typer.echo("  Generating the historical data (dimensions, then facts, then gold).")
+    typer.echo("  This can take a while -- often several minutes to an hour or more,")
+    typer.echo("  depending on the months of history and store count. It runs in")
+    typer.echo("  Fabric, so you can close this and track progress in the workspace.")
+    _hr("=")
 
     cmd = [
         sys.executable,
@@ -861,13 +881,22 @@ def _run_setup_pipeline(repo_root: Path, env: str) -> None:
         "setup-pipeline",
     ]
     typer.echo("    " + " ".join(cmd))
-    result = subprocess.run(cmd, cwd=repo_root)
-    if result.returncode != 0:
-        typer.echo(
-            "Could not start the setup pipeline automatically. Open the workspace "
-            "in Fabric and run 'setup-pipeline' manually.",
-            err=True,
-        )
+    for attempt in range(1, _PIPELINE_TRIGGER_ATTEMPTS + 1):
+        result = subprocess.run(cmd, cwd=repo_root)
+        if result.returncode == 0:
+            return
+        if attempt < _PIPELINE_TRIGGER_ATTEMPTS:
+            typer.echo(
+                f"  Trigger attempt {attempt} failed (exit {result.returncode}); "
+                f"retrying in {_PIPELINE_TRIGGER_RETRY_WAIT}s...",
+                err=True,
+            )
+            time.sleep(_PIPELINE_TRIGGER_RETRY_WAIT)
+    typer.echo(
+        "Could not start the setup pipeline automatically. Open the workspace "
+        "in Fabric and run 'setup-pipeline' manually.",
+        err=True,
+    )
 
 
 if __name__ == "__main__":

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -4,11 +4,14 @@ from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
+import retail_setup.cli.main as cli
 from retail_setup.cli.main import (
     app,
     _deploy_plan,
     _validate_azure_cli_tenant,
     _RECREATE_WAIT_SECONDS,
+    _PIPELINE_TRIGGER_ATTEMPTS,
+    _run_setup_pipeline,
 )
 
 runner = CliRunner()
@@ -146,6 +149,39 @@ def test_workspace_name_prefers_environment_overlay(tmp_path):
     from retail_setup.cli.main import _workspace_name
 
     assert _workspace_name(tmp_path, "dev") == "retail-demo-dev"
+
+
+def test_run_setup_pipeline_warns_takes_a_while_and_retries(monkeypatch, capsys):
+    monkeypatch.setattr(cli.time, "sleep", lambda *_a: None)
+    attempts = {"n": 0}
+
+    def fake_run(_cmd, cwd=None):
+        attempts["n"] += 1
+        # Fail the first trigger, succeed on the retry.
+        return SimpleNamespace(returncode=1 if attempts["n"] == 1 else 0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    _run_setup_pipeline(Path("."), "dev")
+
+    out = capsys.readouterr().out
+    assert "can take a while" in out
+    assert attempts["n"] == 2  # retried once after the initial failure
+
+
+def test_run_setup_pipeline_gives_up_after_max_attempts(monkeypatch, capsys):
+    monkeypatch.setattr(cli.time, "sleep", lambda *_a: None)
+    runs = {"n": 0}
+
+    def fake_run(_cmd, cwd=None):
+        runs["n"] += 1
+        return SimpleNamespace(returncode=1)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    _run_setup_pipeline(Path("."), "dev")
+
+    captured = capsys.readouterr()
+    assert runs["n"] == _PIPELINE_TRIGGER_ATTEMPTS
+    assert "run 'setup-pipeline' manually" in captured.err
 
 
 def test_deploy_reports_missing_terraform_without_traceback(monkeypatch):


### PR DESCRIPTION
## Summary

Addresses the repeated **task flow timeouts** and adds the requested **retry logic** and a **""this can take a while""** heads-up for data generation.

### Retry for transient failures
A cold `az account get-access-token` can take ~90s and intermittently times out (`CredentialUnavailableError` / `ClientAuthenticationError`); Fabric/Power BI REST calls also fail transiently. These previously aborted the deploy.

- New `deploy/scripts/_retry.py` -> `retry_call(func, retry_on=..., on_retry=..., sleep=...)`: exponential backoff, injectable sleep for tests.
- Wrapped the token acquisitions that were failing:
  - `taskflow._token` (Power BI + Fabric tokens) — the task flow timeout you hit.
  - `export_items.build_session` (pipeline trigger) — now also uses a **120s** credential timeout.
  - `apply_kql` Kusto management call (`KustoAuthenticationError`), guarded so the Spark-only test env without the SDK still imports.

### Generation heads-up + trigger retry
`_run_setup_pipeline` now prints a clear banner that generation runs in Fabric and **can take a while** (minutes to an hour+), and retries the trigger `_PIPELINE_TRIGGER_ATTEMPTS` times before printing manual fallback instructions.

### Docs
`deploy/README.md`: documents the long-running generation step, the retry behavior, and az cold-start guidance (+ two troubleshooting rows).

## Tests
- `tests/deploy/test_retry.py`: success-no-sleep, retry-then-succeed (asserts exponential backoff + `on_retry`), exhaustion re-raise, non-retryable passthrough, zero-attempts guard.
- `tests/deploy/test_taskflow.py`: token retry-then-succeed (guarded by `importorskip(""azure.core.exceptions"")`).
- `utility/tests/test_cli_deploy.py`: `_run_setup_pipeline` prints the heads-up and retries; gives up after the max attempts with the manual fallback.
- `tests/deploy` + `test_cli_deploy`: **79 passed, 2 skipped** (env-guarded); `ruff` clean. Verified `retry_call` end-to-end against a real `azure.core` exception in the deploy env.

> Note: builds on the same branch state as #298 (notebook lakehouse GUID fix); the two touch different files and are independent.
