### PR TITLE
feat(cli): configure by months of data with a record-count estimate

### DIFF
--- a/utility/README.md
+++ b/utility/README.md
@@ -119,7 +119,15 @@ retail-setup configure
 
 Interactive prompts show the current config/default value in brackets. The
 store type prompt also lists the available dictionary profiles:
-`grocery`, `hardware`, `luxury`, and `supercenter`.
+`grocery`, `hardware`, `luxury`, and `supercenter`. After you pick the
+generation settings, `configure` prints an approximate **record-count estimate**
+(in-store receipts and lines, online orders, payments, customers) so you can
+gauge the output volume and runtime; interactively it then asks whether to use
+the settings or re-enter them.
+
+You choose **how many months** of history to generate rather than an explicit
+date range. The window **ends yesterday**, so real-time streaming continues
+seamlessly from today (`start_date`/`end_date` are derived from `months`).
 
 Non-interactive example:
 
@@ -133,8 +141,7 @@ retail-setup configure `
   --eventhouse-name retail_eventhouse `
   --kql-database-name retail_kql `
   --store-type supercenter `
-  --start-date 2025-01-01 `
-  --end-date 2025-03-31 `
+  --months 3 `
   --store-count 50 `
   --seed 42
 ```
@@ -146,7 +153,7 @@ The persisted generation settings are:
 | Setting | Meaning |
 | --- | --- |
 | `store_type` | Dictionary/profile to use: `grocery`, `hardware`, `luxury`, or `supercenter`. |
-| `start_date` / `end_date` | Inclusive historical generation date range. |
+| `months` | Months of historical data to generate. The window ends yesterday; `start_date`/`end_date` are derived from it (1–120). |
 | `store_count` | Number of stores to generate. Must be between 1 and 2000. |
 | `seed` | Deterministic random seed. |
 

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -13,7 +13,6 @@ import shutil
 import sys
 import time
 from dataclasses import dataclass, field
-from datetime import date
 from pathlib import Path
 from typing import Any, Optional
 
@@ -37,9 +36,8 @@ def _main() -> None:
 
 # generation keys the user supplies via `configure`; derived defaults
 # (dc_count, customer_count, ...) are intentionally not persisted.
-_GENERATION_KEYS = ("store_type", "start_date", "end_date", "store_count", "seed")
-_DEFAULT_START_DATE = date(2025, 1, 1)
-_DEFAULT_END_DATE = date(2025, 3, 31)
+_GENERATION_KEYS = ("store_type", "months", "store_count", "seed")
+_DEFAULT_MONTHS = 3
 
 # After a recreate destroy, Fabric needs time to release the workspace name and
 # capacity before the same name can be created again. 30s proved too short, so
@@ -145,6 +143,23 @@ def _available_store_types() -> list[str]:
         return []
 
 
+def _print_record_estimate(generation: GenerationConfig) -> None:
+    """Show an approximate record-count breakdown for the chosen settings."""
+
+    from retail_setup.generation.estimate import estimate_record_counts
+
+    counts = estimate_record_counts(generation)
+    typer.echo("")
+    _hr("-")
+    typer.echo(
+        f"  Estimated records for {generation.start_date} to {generation.end_date} "
+        f"({generation.store_count} stores):"
+    )
+    for name, value in counts.items():
+        typer.echo(f"    {name:<20} ~ {value:>15,}")
+    _hr("-")
+
+
 def _load_deploy_environment(repo_root: Path, env: str):
     root = str(repo_root)
     if root not in sys.path:
@@ -235,10 +250,11 @@ def configure(
     store_type: Optional[str] = typer.Option(
         None, "--store-type", help="Store type. Available values are shown interactively."
     ),
-    start_date: Optional[str] = typer.Option(
-        None, "--start-date", help="Start date (YYYY-MM-DD)."
+    months: Optional[int] = typer.Option(
+        None,
+        "--months",
+        help="Months of historical data to generate (the window ends yesterday).",
     ),
-    end_date: Optional[str] = typer.Option(None, "--end-date", help="End date (YYYY-MM-DD)."),
     store_count: Optional[int] = typer.Option(None, "--store-count", help="Store count."),
     seed: Optional[int] = typer.Option(None, "--seed", help="Random seed."),
 ) -> None:
@@ -271,7 +287,7 @@ def configure(
 
     _prompted_values = (
         tenant_id, workspace_name, capacity_name, lakehouse_name, eventhouse_name,
-        kql_database_name, store_type, start_date, end_date, store_count, seed,
+        kql_database_name, store_type, months, store_count, seed,
     )
     if any(value is None for value in _prompted_values) and sys.stdin.isatty():
         typer.echo("")
@@ -309,53 +325,51 @@ def configure(
         kql_database_name,
         default=_config_default(base_config, env_config, "eventhouse.kql_database_name"),
     )
-    store_type = _prompt_str(
-        store_type_prompt,
-        store_type,
-        default=existing_generation.get(
-            "store_type", GenerationConfig.model_fields["store_type"].default
-        ),
+    # Generation settings: prompt, show a record-count estimate, and (when
+    # interactive) offer to change them before committing. Validation happens
+    # before any file writes (the deploy YAMLs are written next and restored if
+    # framework validation later rejects them).
+    interactive = sys.stdin.isatty()
+    store_type_default = existing_generation.get(
+        "store_type", GenerationConfig.model_fields["store_type"].default
     )
-    start_date = _prompt_str(
-        "Start date (YYYY-MM-DD)",
-        start_date,
-        default=existing_generation.get("start_date", _DEFAULT_START_DATE.isoformat()),
-    )
-    end_date = _prompt_str(
-        "End date (YYYY-MM-DD)",
-        end_date,
-        default=existing_generation.get("end_date", _DEFAULT_END_DATE.isoformat()),
-    )
-    store_count = _prompt_int(
-        "Store count",
-        store_count,
-        default=int(
-            existing_generation.get(
-                "store_count", GenerationConfig.model_fields["store_count"].default
-            )
-        ),
-    )
-    seed = _prompt_int(
-        "Random seed",
-        seed,
-        default=int(
-            existing_generation.get("seed", GenerationConfig.model_fields["seed"].default)
-        ),
-    )
-
-    # Validate generation values before any file writes (deploy YAMLs are
-    # written next and restored if framework validation rejects them).
-    try:
-        generation = GenerationConfig(
-            store_type=store_type,
-            start_date=start_date,
-            end_date=end_date,
-            store_count=store_count,
-            seed=seed,
+    months_default = int(existing_generation.get("months", _DEFAULT_MONTHS))
+    store_count_default = int(
+        existing_generation.get(
+            "store_count", GenerationConfig.model_fields["store_count"].default
         )
-    except ValidationError as exc:
-        typer.echo(f"Invalid generation settings:\n{exc}")
-        raise typer.Exit(code=1)
+    )
+    seed_default = int(
+        existing_generation.get("seed", GenerationConfig.model_fields["seed"].default)
+    )
+    while True:
+        store_type = _prompt_str(store_type_prompt, store_type, default=store_type_default)
+        months = _prompt_int(
+            "Months of data to generate (history ends yesterday)",
+            months,
+            default=months_default,
+        )
+        store_count = _prompt_int("Store count", store_count, default=store_count_default)
+        seed = _prompt_int("Random seed", seed, default=seed_default)
+        try:
+            generation = GenerationConfig(
+                store_type=store_type,
+                months=months,
+                store_count=store_count,
+                seed=seed,
+            )
+        except ValidationError as exc:
+            typer.echo(f"Invalid generation settings:\n{exc}")
+            if interactive:
+                store_type = months = store_count = seed = None
+                continue
+            raise typer.Exit(code=1)
+
+        _print_record_estimate(generation)
+        if not interactive or typer.confirm("Use these settings?", default=True):
+            break
+        # Re-enter every generation value on the next loop iteration.
+        store_type = months = store_count = seed = None
 
     original_deploy = _update_yaml_file(
         deploy_yml,

--- a/utility/src/retail_setup/config/generation.py
+++ b/utility/src/retail_setup/config/generation.py
@@ -1,6 +1,7 @@
 """Generation settings (utility/config.yaml). Environment settings live in deploy/config/."""
 
-from datetime import date
+import calendar
+from datetime import date, timedelta
 from pathlib import Path
 
 import yaml
@@ -9,10 +10,25 @@ from pydantic import BaseModel, Field, model_validator
 from retail_setup.dictionaries.loader import available_store_types, default_dictionary_root
 
 
+def _subtract_months(anchor: date, months: int) -> date:
+    """Return the date ``months`` calendar months before ``anchor`` (day clamped)."""
+
+    month_index = anchor.month - 1 - months
+    year = anchor.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(anchor.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
 class GenerationConfig(BaseModel):
     store_type: str = "supercenter"
-    start_date: date
-    end_date: date
+    # Preferred input: number of months of history to generate. The window ends
+    # *yesterday* so real-time streaming continues seamlessly from today.
+    # ``start_date``/``end_date`` may be provided explicitly instead (back-compat);
+    # they are derived from ``months`` only when not both already supplied.
+    months: int | None = Field(default=None, ge=1, le=120)
+    start_date: date | None = None
+    end_date: date | None = None
     store_count: int = Field(default=50, gt=0, le=2000)
     seed: int = 42
     silver_db: str = "ag"
@@ -53,6 +69,18 @@ class GenerationConfig(BaseModel):
     def resolved_dictionary_root(self) -> Path:
         """Resolved dictionary root path (explicit override or package default)."""
         return Path(self.dictionary_root) if self.dictionary_root else default_dictionary_root()
+
+    @model_validator(mode="after")
+    def _derive_date_range(self) -> "GenerationConfig":
+        """Derive start/end from ``months`` (window ends yesterday) when needed."""
+
+        if self.months is not None and not (self.start_date and self.end_date):
+            end = date.today() - timedelta(days=1)
+            self.end_date = end
+            self.start_date = _subtract_months(end, self.months)
+        if self.start_date is None or self.end_date is None:
+            raise ValueError("provide `months`, or both `start_date` and `end_date`")
+        return self
 
     @model_validator(mode="after")
     def _date_order(self) -> "GenerationConfig":

--- a/utility/src/retail_setup/generation/estimate.py
+++ b/utility/src/retail_setup/generation/estimate.py
@@ -1,0 +1,62 @@
+"""Rough record-count estimates for a generation config (no Spark required).
+
+``retail-setup configure`` shows these so the operator can sanity-check the
+output volume (and the time it implies) before committing to a run. The numbers
+are deliberately approximate: receipt volume is shaped by hourly/daily/monthly
+weights and per-store multipliers, but the dominant driver is
+``store_count * days * transactions_per_store_day``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from retail_setup.config.generation import GenerationConfig
+
+# Fallback average items/basket if the store profile can't be read.
+_DEFAULT_BASKET_LAMBDA = 12.0
+# Weighted avg lines/online-order from the 60/30/10 basket buckets
+# (1-3, 2-5, 5-8 lines): 0.6*2 + 0.3*3.5 + 0.1*6.5 ~= 2.9.
+_ONLINE_LINES_PER_ORDER = 2.9
+
+
+def _basket_lambda(cfg: GenerationConfig) -> float:
+    """Average items per in-store basket for the configured store type."""
+
+    profile = cfg.resolved_dictionary_root / cfg.store_type / "profile.json"
+    try:
+        return float(json.loads(profile.read_text(encoding="utf-8"))["basket_lambda"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return _DEFAULT_BASKET_LAMBDA
+
+
+def estimate_record_counts(cfg: GenerationConfig) -> dict[str, int]:
+    """Approximate per-group record counts for a generation config.
+
+    Returns an ordered mapping of group name -> estimated row count, ending with a
+    ``"Total (approx)"`` entry. Covers the dominant tables; smaller fact tables
+    (sensors, store ops, marketing, inventory) are omitted, so the real total is
+    somewhat higher.
+    """
+
+    days = (cfg.end_date - cfg.start_date).days + 1
+    store_days = cfg.store_count * days
+    basket = _basket_lambda(cfg)
+
+    receipts = round(store_days * cfg.transactions_per_store_day)
+    returns = round(receipts * cfg.return_rate)
+    receipt_lines = round(receipts * basket)
+    online_headers = round(cfg.online_orders_per_day * days)
+    online_lines = round(online_headers * _ONLINE_LINES_PER_ORDER)
+    payments = receipts + returns + online_headers
+
+    groups = {
+        "Customers (dim)": cfg.customer_count,
+        "In-store receipts": receipts + returns,
+        "Receipt lines": receipt_lines,
+        "Online orders": online_headers,
+        "Online order lines": online_lines,
+        "Payments": payments,
+    }
+    groups["Total (approx)"] = sum(groups.values())
+    return groups

--- a/utility/tests/test_cli_configure.py
+++ b/utility/tests/test_cli_configure.py
@@ -41,8 +41,8 @@ def test_configure_writes_both_configs(tmp_path):
         "--workspace-name", "my-ws", "--capacity-name", "F64",
         "--lakehouse-name", "my_lh", "--eventhouse-name", "my_eh",
         "--kql-database-name", "my_kql",
-        "--store-type", "grocery", "--start-date", "2025-01-01",
-        "--end-date", "2025-03-31", "--store-count", "10", "--seed", "9",
+        "--store-type", "grocery", "--months", "3",
+        "--store-count", "10", "--seed", "9",
     ])
     assert result.exit_code == 0, result.output
     base = yaml.safe_load((tmp_path / "deploy/config/deploy.yml").read_text())
@@ -53,7 +53,11 @@ def test_configure_writes_both_configs(tmp_path):
     assert env["workspace"]["name"] == "my-ws"
     gen = yaml.safe_load((tmp_path / "utility/config.yaml").read_text())
     assert gen["store_type"] == "grocery"
+    assert gen["months"] == 3
     assert gen["store_count"] == 10
+    assert "start_date" not in gen and "end_date" not in gen
+    # The estimate is shown before writing.
+    assert "Estimated records" in result.output
 
 
 def test_configure_prompts_show_defaults_and_store_types(tmp_path):
@@ -61,7 +65,7 @@ def test_configure_prompts_show_defaults_and_store_types(tmp_path):
     result = runner.invoke(
         app,
         ["configure", "--repo-root", str(tmp_path), "--env", "dev"],
-        input="\n" * 11,
+        input="\n" * 12,
     )
     assert result.exit_code == 0, result.output
     assert (
@@ -69,16 +73,15 @@ def test_configure_prompts_show_defaults_and_store_types(tmp_path):
         in result.output
     )
     assert "[supercenter]" in result.output
-    assert "Start date (YYYY-MM-DD) [2025-01-01]" in result.output
-    assert "End date (YYYY-MM-DD) [2025-03-31]" in result.output
+    assert "Months of data to generate (history ends yesterday) [3]" in result.output
     assert "Store count [50]" in result.output
     assert "Random seed [42]" in result.output
+    assert "Estimated records" in result.output
 
     gen = yaml.safe_load((tmp_path / "utility/config.yaml").read_text())
     assert gen == {
         "store_type": "supercenter",
-        "start_date": "2025-01-01",
-        "end_date": "2025-03-31",
+        "months": 3,
         "store_count": 50,
         "seed": 42,
     }
@@ -91,8 +94,8 @@ def test_configure_rejects_bad_generation_values(tmp_path):
         "--tenant-id", "t", "--workspace-name", "w", "--capacity-name", "c",
         "--lakehouse-name", "lh", "--eventhouse-name", "eh",
         "--kql-database-name", "kq",
-        "--store-type", "bogus", "--start-date", "2025-01-01",
-        "--end-date", "2025-03-31", "--store-count", "10", "--seed", "9",
+        "--store-type", "bogus", "--months", "3",
+        "--store-count", "10", "--seed", "9",
     ])
     assert result.exit_code != 0
     assert "bogus" in result.output

--- a/utility/tests/test_estimate.py
+++ b/utility/tests/test_estimate.py
@@ -1,0 +1,44 @@
+"""Tests for the configure-time record-count estimate."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from retail_setup.config.generation import GenerationConfig
+from retail_setup.generation.estimate import estimate_record_counts
+
+
+def _cfg(**kw) -> GenerationConfig:
+    base = {"store_type": "supercenter", "start_date": date(2025, 1, 1),
+            "end_date": date(2025, 1, 10), "store_count": 50}
+    base.update(kw)
+    return GenerationConfig(**base)
+
+
+def test_estimate_has_total_and_scales_with_stores_and_days():
+    counts = estimate_record_counts(_cfg())
+    assert "Total (approx)" in counts
+    assert counts["Total (approx)"] == sum(
+        v for k, v in counts.items() if k != "Total (approx)"
+    )
+
+    # 10 days, 50 stores, 400 txns/store-day -> ~200k in-store receipts.
+    assert counts["In-store receipts"] == 50 * 10 * 400 + round(50 * 10 * 400 * 0.01)
+    # supercenter basket lambda is 12 -> ~12 lines per receipt.
+    assert counts["Receipt lines"] == round(50 * 10 * 400 * 12)
+
+
+def test_estimate_grows_with_more_months():
+    small = estimate_record_counts(_cfg(start_date=date(2025, 1, 1), end_date=date(2025, 1, 10)))
+    large = estimate_record_counts(_cfg(start_date=date(2025, 1, 1), end_date=date(2025, 3, 31)))
+    assert large["Total (approx)"] > small["Total (approx)"]
+
+
+def test_estimate_falls_back_on_unknown_basket(monkeypatch):
+    # An unreadable profile falls back to the default basket lambda rather than failing.
+    cfg = _cfg()
+    monkeypatch.setattr(
+        "retail_setup.generation.estimate._basket_lambda", lambda _cfg: 12.0
+    )
+    counts = estimate_record_counts(cfg)
+    assert counts["Receipt lines"] > 0

--- a/utility/tests/test_generation_config.py
+++ b/utility/tests/test_generation_config.py
@@ -21,6 +21,53 @@ def test_end_before_start_rejected():
         GenerationConfig(start_date=date(2025, 3, 1), end_date=date(2025, 1, 1))
 
 
+def test_months_derives_window_ending_yesterday():
+    from datetime import timedelta
+
+    cfg = GenerationConfig(store_type="grocery", months=3)
+    yesterday = date.today() - timedelta(days=1)
+    assert cfg.end_date == yesterday
+    assert cfg.months == 3
+    assert cfg.start_date < cfg.end_date
+    # ~3 calendar months earlier (allow the trailing partial day from inclusivity)
+    assert 89 <= (cfg.end_date - cfg.start_date).days <= 93
+
+
+def test_months_required_when_dates_absent():
+    with pytest.raises(ValidationError, match="months"):
+        GenerationConfig(store_type="grocery")
+
+
+def test_explicit_dates_take_precedence_over_months():
+    cfg = GenerationConfig(
+        store_type="grocery",
+        months=6,
+        start_date=date(2025, 1, 1),
+        end_date=date(2025, 1, 31),
+    )
+    assert cfg.start_date == date(2025, 1, 1)
+    assert cfg.end_date == date(2025, 1, 31)
+
+
+def test_subtract_months_clamps_day():
+    from retail_setup.config.generation import _subtract_months
+
+    assert _subtract_months(date(2025, 3, 31), 1) == date(2025, 2, 28)
+    assert _subtract_months(date(2025, 1, 15), 1) == date(2024, 12, 15)
+    assert _subtract_months(date(2024, 3, 31), 1) == date(2024, 2, 29)  # leap year
+
+
+def test_yaml_round_trip_months(tmp_path: Path):
+    from datetime import timedelta
+
+    p = tmp_path / "config.yaml"
+    p.write_text("store_type: grocery\nmonths: 2\nstore_count: 10\nseed: 7\n")
+    cfg = load_generation_config(p)
+    assert cfg.months == 2
+    assert cfg.store_count == 10
+    assert cfg.end_date == date.today() - timedelta(days=1)
+
+
 def test_store_type_must_exist_on_disk():
     with pytest.raises(ValidationError, match="store_type"):
         GenerationConfig(
@@ -56,7 +103,9 @@ def test_scale_overrides_respected():
 
 def test_explicit_dictionary_root(tmp_path):
     # a fake root with one valid store type
-    import json, shutil
+    import json
+    import shutil
+
     from retail_setup.dictionaries.loader import default_dictionary_root
 
     src = default_dictionary_root()

--- a/website/docs/setup/configuration.md
+++ b/website/docs/setup/configuration.md
@@ -38,9 +38,13 @@ Important values:
 | Setting | Description |
 | --- | --- |
 | `store_type` | One of `grocery`, `hardware`, `luxury`, or `supercenter`. |
-| `start_date` / `end_date` | Inclusive historical generation date range. |
+| `months` | Months of historical data to generate. The window ends yesterday so streaming continues from today; `start_date`/`end_date` are derived from it. |
 | `store_count` | Number of stores to generate. |
 | `seed` | Deterministic random seed. |
+
+When you run `retail-setup configure`, it asks **how many months** of history to
+generate (not an explicit date range) and then prints an approximate
+record-count estimate so you can gauge the output volume before committing.
 
 The engine also has derived defaults:
 


### PR DESCRIPTION
## Summary

Two configure-time UX changes you asked for.

### 1. Ask for months, not a date range (window ends yesterday)
Operators think in ""how much history,"" and a fixed end date leaves a gap before real-time streaming. `configure` now asks **how many months** of data to generate and derives the window so it **ends yesterday** — streaming then continues seamlessly from today.

- `GenerationConfig` gains `months` (1–120) and derives `start_date`/`end_date` (end = yesterday) when explicit dates aren't both supplied. **Explicit dates still work** (back-compat) and take precedence, so the generation engine and its tests are unchanged. `utility/config.yaml` now persists `months`.

### 2. Record-count estimate with a chance to change settings
After you pick the generation settings, `configure` prints an approximate breakdown so you can gauge volume/runtime, then (interactively) asks whether to use them or re-enter:

`
------------------------------------------------------------
  Estimated records for 2026-03-15 to 2026-06-15 (50 stores):
    Customers (dim)      ~          50,000
    In-store receipts    ~       1,878,600
    Receipt lines        ~      22,320,000
    Online orders        ~          37,200
    Online order lines   ~         107,880
    Payments             ~       1,915,800
    Total (approx)       ~      26,309,480
------------------------------------------------------------
Use these settings? [Y/n]
`

New `retail_setup/generation/estimate.py` (Spark-free, lazy-imported) grounds the numbers in `store_count × days × transactions_per_store_day` and the store profile's basket size.

## Tests
- `test_generation_config.py`: months derivation (ends yesterday), `months` required when no dates, explicit-dates precedence, `_subtract_months` day-clamping/leap-year, months yaml round-trip.
- `test_estimate.py`: totals, scaling with stores/days/months, basket fallback.
- `test_cli_configure.py`: configure writes `months` (not dates) and shows the estimate.
- Suite green; ruff clean. (Pre-existing `test_render_writes_rendered_notebooks` fails only due to Windows `os.symlink` privilege — unrelated.)

## Docs
`utility/README.md` and `website/docs/setup/configuration.md` updated for the months input and the estimate.

> **Stacked on #299** (shares `cli/main.py`). Base is `feat/deploy-retry-and-progress`; merge #299 first and this auto-retargets to `main`.
