### PR TITLE
fix(taskflow): drop unbindable task-flow references

### DIFF
--- a/deploy/scripts/taskflow.py
+++ b/deploy/scripts/taskflow.py
@@ -215,15 +215,26 @@ def _guid_name_map(items: list[dict[str, Any]]) -> dict[str, str]:
 
 
 def to_portable(task_flow: dict[str, Any], guid_to_name: dict[str, str]) -> dict[str, Any]:
-    """Replace each item's GUID with its display name so the flow is workspace-agnostic."""
+    """Replace each item's GUID with its display name so the flow is workspace-agnostic.
+
+    Items whose GUID can't be resolved to a name (deleted/stale references, or ids
+    not present in the workspace item listing) are dropped rather than emitted with
+    ``artifactName: null`` — a null name can never bind on deploy and only adds
+    noise to the unresolved-reference report.
+    """
 
     portable = json.loads(json.dumps(task_flow))  # deep copy
     for task in portable.get("tasks", []):
+        kept: list[dict[str, Any]] = []
         for item in task.get("items", []):
             artifact_type, _, guid = str(item.get("artifactUniqueId", "")).partition(":")
             name = guid_to_name.get(item.get("artifactObjectId") or guid)
-            item["artifactName"] = name  # None when unresolved (e.g. legacy dataset id)
+            if name is None:
+                continue
+            item["artifactName"] = name
             item["artifactType"] = item.get("artifactType", artifact_type)
+            kept.append(item)
+        task["items"] = kept
     return portable
 
 

--- a/fabric/taskflow/taskflow.json
+++ b/fabric/taskflow/taskflow.json
@@ -7,12 +7,6 @@
       "description": "Ingest batch and real-time data into a single location within your Fabric workspace.",
       "items": [
         {
-          "artifactUniqueId": "SynapseNotebook:8a58519f-4156-40ba-a466-7d31d5e26fcd",
-          "artifactType": "SynapseNotebook",
-          "artifactObjectId": "8a58519f-4156-40ba-a466-7d31d5e26fcd",
-          "artifactName": null
-        },
-        {
           "artifactUniqueId": "SynapseNotebook:90009e22-24ab-4750-b2f6-b72cf6db2741",
           "artifactType": "SynapseNotebook",
           "artifactObjectId": null,
@@ -91,18 +85,6 @@
       "description": "Clean, transform, extract, and load your data for analysis and modeling tasks.",
       "items": [
         {
-          "artifactUniqueId": "SynapseNotebook:18e17653-c8fb-456e-a4fa-44743c948866",
-          "artifactType": "SynapseNotebook",
-          "artifactObjectId": "18e17653-c8fb-456e-a4fa-44743c948866",
-          "artifactName": null
-        },
-        {
-          "artifactUniqueId": "SynapseNotebook:543e9201-1cbe-4da2-b8f8-0a634fa8bcdc",
-          "artifactType": "SynapseNotebook",
-          "artifactObjectId": "543e9201-1cbe-4da2-b8f8-0a634fa8bcdc",
-          "artifactName": null
-        },
-        {
           "artifactUniqueId": "Pipeline:3c6f0a0d-07e5-4c68-8f4b-83d269033fa8",
           "artifactType": "Pipeline",
           "artifactObjectId": "3c6f0a0d-07e5-4c68-8f4b-83d269033fa8",
@@ -128,12 +110,6 @@
       "type": "general",
       "name": "General",
       "items": [
-        {
-          "artifactUniqueId": "SynapseNotebook:c3d99c89-ceb3-482d-b0e7-62625929f45e",
-          "artifactType": "SynapseNotebook",
-          "artifactObjectId": "c3d99c89-ceb3-482d-b0e7-62625929f45e",
-          "artifactName": null
-        },
         {
           "artifactUniqueId": "Pipeline:1ec9af37-769b-49e8-adb8-0ee36d961b7d",
           "artifactType": "Pipeline",
@@ -165,7 +141,7 @@
           "artifactUniqueId": "3:4416500",
           "artifactType": "dataset",
           "artifactObjectId": null,
-          "artifactName": null
+          "artifactName": "retail_model"
         }
       ],
       "loc": "800 120"
@@ -202,18 +178,6 @@
           "artifactType": "MLExperiment",
           "artifactObjectId": null,
           "artifactName": "demand_forecast"
-        },
-        {
-          "artifactUniqueId": "SynapseNotebook:cffb7610-e761-485e-8f75-7f2c8a7730d2",
-          "artifactType": "SynapseNotebook",
-          "artifactObjectId": null,
-          "artifactName": null
-        },
-        {
-          "artifactUniqueId": "SynapseNotebook:07998890-6802-419e-84c6-66d1f7d741d2",
-          "artifactType": "SynapseNotebook",
-          "artifactObjectId": null,
-          "artifactName": null
         },
         {
           "artifactUniqueId": "SynapseNotebook:22cf947e-4e21-4f59-b653-fc2b316d4b27",
@@ -333,52 +297,10 @@
       "description": "Package your items for distribution as customized, easy-to-use apps.",
       "items": [
         {
-          "artifactUniqueId": "Ontology:573b9da8-5ba5-4b8c-9dae-7f8bde3a2fbd",
-          "artifactType": "Ontology",
-          "artifactObjectId": null,
-          "artifactName": null
-        },
-        {
-          "artifactUniqueId": "GraphIndex:2a5ecefc-1e17-47b7-8ead-26d4be95c41e",
-          "artifactType": "GraphIndex",
-          "artifactObjectId": null,
-          "artifactName": null
-        },
-        {
-          "artifactUniqueId": "Lakehouse:1003054e-bb57-4c1b-8a2b-eae6e4fe67c7",
-          "artifactType": "Lakehouse",
-          "artifactObjectId": null,
-          "artifactName": null
-        },
-        {
-          "artifactUniqueId": "SqlAnalyticsEndpoint:a2ccc340-587d-4b58-8506-b5a6ef9852b1",
-          "artifactType": "SqlAnalyticsEndpoint",
-          "artifactObjectId": null,
-          "artifactName": null
-        },
-        {
           "artifactUniqueId": "Ontology:ab4766aa-2ebf-4b76-86b6-7efe733d918d",
           "artifactType": "Ontology",
           "artifactObjectId": null,
           "artifactName": "Retail Ontology"
-        },
-        {
-          "artifactUniqueId": "GraphIndex:778d7f93-af99-41f2-8442-6330dc789bcf",
-          "artifactType": "GraphIndex",
-          "artifactObjectId": null,
-          "artifactName": "RetailOntology_AutoGen_graph_ab4766aa2ebf4b7686b67efe733d918d"
-        },
-        {
-          "artifactUniqueId": "Lakehouse:d292daaf-0c5c-455a-b401-cad1143075a7",
-          "artifactType": "Lakehouse",
-          "artifactObjectId": null,
-          "artifactName": "RetailOntology_AutoGen_lh_ab4766aa2ebf4b7686b67efe733d918d"
-        },
-        {
-          "artifactUniqueId": "SqlAnalyticsEndpoint:5e48187f-572a-4325-82d0-64c7aa0d41c9",
-          "artifactType": "SqlAnalyticsEndpoint",
-          "artifactObjectId": null,
-          "artifactName": "RetailOntology_AutoGen_lh_ab4766aa2ebf4b7686b67efe733d918d"
         }
       ],
       "loc": "800 -60"

--- a/tests/deploy/test_taskflow.py
+++ b/tests/deploy/test_taskflow.py
@@ -60,6 +60,53 @@ def test_to_portable_resolves_guids_to_names() -> None:
     assert "artifactName" not in task_flow["tasks"][0]["items"][0]
 
 
+def test_to_portable_drops_unnameable_items() -> None:
+    task_flow = {
+        "tasks": [
+            {
+                "id": "t1",
+                "items": [
+                    {
+                        "artifactUniqueId": "SynapseNotebook:nb1",
+                        "artifactType": "SynapseNotebook",
+                        "artifactObjectId": "nb1",
+                    },
+                    {
+                        "artifactUniqueId": "SynapseNotebook:gone",
+                        "artifactType": "SynapseNotebook",
+                        "artifactObjectId": "gone",
+                    },
+                ],
+            }
+        ],
+        "edges": [],
+    }
+
+    portable = taskflow.to_portable(task_flow, {"nb1": "01-create-bronze-shortcuts"})
+
+    items = portable["tasks"][0]["items"]
+    assert len(items) == 1  # the unnameable (deleted) item is dropped
+    assert items[0]["artifactName"] == "01-create-bronze-shortcuts"
+
+
+def test_committed_taskflow_has_only_bindable_items() -> None:
+    """The committed portable task flow must not carry null-name or workspace-
+    specific auto-generated references; both can never bind on deploy."""
+
+    import json as _json
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    data = _json.loads(
+        (repo_root / "fabric" / "taskflow" / "taskflow.json").read_text(encoding="utf-8")
+    )
+    for task in data["tasks"]:
+        for item in task["items"]:
+            name = item.get("artifactName")
+            assert name, f"null artifactName in task {task.get('name')!r}"
+            assert "_AutoGen_" not in str(name), f"unportable auto-gen reference: {name}"
+
+
 def test_to_workspace_resolves_names_to_target_guids_and_reports_unresolved() -> None:
     portable = {
         "tasks": [


### PR DESCRIPTION
## Summary

The deployed task flow reported a wall of **unresolved references** because the committed `fabric/taskflow/taskflow.json` carried items that can never bind in a fresh workspace.

Root causes (the export had captured them from a messy source workspace):
- **11 items with `artifactName: null`** — stale/deleted references that lost their name on export (fabric-cicd / the metadata API couldn't resolve the GUID to a name).
- **Workspace-specific ontology artifacts** `RetailOntology_AutoGen_*` whose hashed names differ per workspace, so they can never match by name.

## Changes

- **Cleaned the committed task flow** (abric/taskflow/taskflow.json):
  - **Recovered the semantic model**: `dataset:None` -> `dataset:retail_model`. Its Power BI dataset id doesn't resolve to a name on export, but it binds by name at deploy time — so the *Semantic Model* task now works instead of being a dead `None` ref.
  - Dropped the 10 remaining `null`-name items and the 3 `_AutoGen_` ontology artifacts. No task is left empty (10 tasks / 11 edges preserved).
- **Hardened `to_portable`**: it now **drops** items it can't name instead of emitting `artifactName: null`, so future exports stay clean.

## Result
Unresolved references at deploy drop from ~18 to the few **optional** components that `retail-setup deploy` doesn't create — `99-reset-lakehouse`, the two `LLMPlugin` data agents, and `Retail Ontology` — which bind once those are deployed.

## Tests
- `test_to_portable_drops_unnameable_items` — unnameable item is dropped.
- `test_committed_taskflow_has_only_bindable_items` — guards the committed file against null-name / auto-gen references (regression guard).
- `tests/deploy/test_taskflow.py`: 8 passed, 1 skipped (env-guarded); ruff clean.

> **Stacked on #300 -> #299** (shares `taskflow.py`/`test_taskflow.py` with #299, and would break if merged before #299 since `_token` needs `_retry.py`). Merge order: #299, #300, then this (auto-retargets to `main`).
