### PR TITLE
feat(deploy): deploy and link data agents, ontology, and reset notebook

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -124,9 +124,23 @@ does not.
 - Data Pipelines in `fabric\pipelines\*.DataPipeline` deploy into a **Pipelines**
   folder; each pipeline is staged only when its notebooks are part of the deploy,
   and notebook references are remapped via generated `parameter.yml` rules.
+- Data Agents in `fabric\data-agents\*.DataAgent` deploy into a **Data Agents**
+  folder (item type `DataAgent`, which must be in `item_types_in_scope`). Their
+  datasource configs reference the source workspace and the semantic model by
+  GUID; generated `parameter.yml` rules remap those to the target workspace and
+  the deployed `SemanticModel`. The ontology agent also references the ontology,
+  which is created at **runtime** by the `30-create-ontology` notebook — that GUID
+  cannot be resolved at deploy time, so the ontology agent binds to its ontology
+  only after that notebook runs (re-run it / rebind in the workspace).
+- The `retail-setup deploy` plan stages the `core`, `setup`, `ml`, `ontology`, and
+  `reset` notebook groups, so `30-create-ontology` and `99-reset-lakehouse` are
+  deployed alongside the core pipeline and ML notebooks.
 - Dashboard assets remain source inputs until their Fabric source-control item
   formats are validated. Task flows are deployed separately by
-  `deploy.scripts.taskflow` (offered as a prompt at the end of deploy).
+  `deploy.scripts.taskflow` (offered as a prompt at the end of deploy). The task
+  flow links items by display name, so a node binds once its item exists in the
+  workspace. The ontology node (`RetailOntology_AutoGen`) and ontology agent link
+  after the ontology notebook has run and the task flow is re-deployed.
 - Secrets must come from Azure login, GitHub Actions secrets, environment
   variables, Key Vault, or ignored local files. Do not commit secrets to YAML,
   Terraform files, notebooks, or generated artifacts.

--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -57,6 +57,7 @@ deployment:
     - KQLQueryset
     - DataPipeline
     - MLExperiment
+    - DataAgent
   publish_skip: false
   unpublish_skip: true
   orphan_exclude_regex: "^DO_NOT_DELETE_.*"

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -18,6 +18,25 @@ PLATFORM_SCHEMA = (
     "platformProperties/2.0.0/schema.json"
 )
 
+# fabric-cicd replaces this sentinel workspace id with the target workspace id
+# at publish time (its `_replace_workspace_ids`). The `$workspace.$id` token only
+# resolves inside parameter.yml replace_values, NOT when baked into item content,
+# so a notebook's default-lakehouse workspace binding must use this sentinel.
+_CURRENT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _logical_id(item_type: str, display_name: str) -> str:
+    """Deterministic fabric-cicd logicalId for a staged item.
+
+    The same value is written to the item's ``.platform`` and referenced by
+    other items (e.g. a notebook's default lakehouse), so fabric-cicd's
+    ``_replace_logical_ids`` resolves the reference to the deployed item GUID.
+    Like ``$workspace.$id``, the ``$items.<type>.<name>.$id`` token only resolves
+    inside parameter.yml, so item content must reference the logicalId directly.
+    """
+
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"retail-demo:{item_type}:{display_name}"))
+
 # Workspace folder names used to organize published items. fabric-cicd maps the
 # staged directory structure to Fabric workspace folders, so staging an item
 # under `<output>/Notebooks/<item>` places it in a "Notebooks" workspace folder.
@@ -118,12 +137,12 @@ def stage_notebook(
     notebook = json.loads(source_path.read_text(encoding="utf-8"))
     metadata = notebook.setdefault("metadata", {})
     dependencies = metadata.setdefault("dependencies", {})
-    lakehouse_id_ref = f"$items.Lakehouse.{lakehouse_name}.$id"
+    lakehouse_logical_id = _logical_id("Lakehouse", lakehouse_name)
     dependencies["lakehouse"] = {
-        "default_lakehouse": lakehouse_id_ref,
+        "default_lakehouse": lakehouse_logical_id,
         "default_lakehouse_name": lakehouse_name,
-        "default_lakehouse_workspace_id": "$workspace.$id",
-        "known_lakehouses": [{"id": lakehouse_id_ref}],
+        "default_lakehouse_workspace_id": _CURRENT_WORKSPACE_ID,
+        "known_lakehouses": [{"id": lakehouse_logical_id}],
     }
     (item_dir / "notebook-content.ipynb").write_text(
         json.dumps(notebook, indent=1, ensure_ascii=False),
@@ -346,12 +365,13 @@ def build_workspace(
 
     staged_items: list[str] = []
     # Terraform provisions the Lakehouse, Eventhouse, and KQL Database. Only the
-    # Lakehouse is staged as a fabric-cicd shell item (it publishes cleanly and
-    # helps notebook `$items.Lakehouse` references resolve). Eventhouse and
-    # KQLDatabase are NOT staged: Fabric rejects a `.platform`-only definition
-    # update ("Definition parts cannot contain the .platform file only"), and
-    # Terraform already owns them.
-    staged_items.append(stage_shell_item(output_dir, "retail_lakehouse", "Lakehouse").name)
+    # Lakehouse is staged as a fabric-cicd shell item so its `.platform` logicalId
+    # exists in the deployment; notebook default-lakehouse bindings reference that
+    # same logicalId (see `_logical_id`) and fabric-cicd resolves it to the
+    # deployed lakehouse GUID. Eventhouse and KQLDatabase are NOT staged: Fabric
+    # rejects a `.platform`-only definition update ("Definition parts cannot
+    # contain the .platform file only"), and Terraform already owns them.
+    staged_items.append(stage_shell_item(output_dir, lakehouse_name, "Lakehouse").name)
 
     # Demo/pipeline notebooks publish into a "Notebooks" workspace folder.
     notebooks_dir = output_dir / NOTEBOOKS_FOLDER
@@ -434,9 +454,7 @@ def _write_platform(item_dir: Path, item_type: str, display_name: str) -> None:
         "metadata": {"type": item_type, "displayName": display_name},
         "config": {
             "version": "2.0",
-            "logicalId": str(
-                uuid.uuid5(uuid.NAMESPACE_URL, f"retail-demo:{item_type}:{display_name}")
-            ),
+            "logicalId": _logical_id(item_type, display_name),
         },
     }
     (item_dir / ".platform").write_text(

--- a/deploy/scripts/build_artifacts.py
+++ b/deploy/scripts/build_artifacts.py
@@ -49,6 +49,7 @@ SETUP_FOLDER = "Setup"
 POWERBI_FOLDER = "Reporting"
 PIPELINES_FOLDER = "Pipelines"
 ML_FOLDER = "ML"
+DATA_AGENTS_FOLDER = "Data Agents"
 
 # MLflow experiments the ML notebooks (group "ml") create on first run. Bootstrap
 # them as MLExperiment shell items so they exist (and are organized under the "ML"
@@ -348,6 +349,35 @@ def stage_ml_experiments(output_dir: Path) -> list[Path]:
     return [stage_shell_item(output_dir, name, "MLExperiment") for name in ML_EXPERIMENTS]
 
 
+def stage_data_agents(repo_root: Path, output_dir: Path) -> list[Path]:
+    """Stage ``fabric/data-agents/*.DataAgent`` item folders into the workspace output.
+
+    Each Data Agent is a complete fabric-cicd item folder (``.platform`` plus a
+    ``Files/Config`` definition). They publish into a "Data Agents" workspace
+    folder. The agents reference the semantic model / ontology and source
+    workspace by GUID in their datasource configs; those GUIDs are remapped to the
+    target workspace at publish time by generated ``parameter.yml`` rules (see
+    ``deploy.scripts.deploy_config.render_parameter_file``).
+
+    Returns an empty list when no Data Agent sources exist.
+    """
+
+    source_dir = repo_root / "fabric" / "data-agents"
+    if not source_dir.is_dir():
+        return []
+    staged: list[Path] = []
+    for item_dir in sorted(source_dir.glob("*.DataAgent"), key=lambda path: path.name):
+        if not (item_dir / ".platform").is_file():
+            continue
+        destination = output_dir / DATA_AGENTS_FOLDER / item_dir.name
+        if destination.exists():
+            shutil.rmtree(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(item_dir, destination)
+        staged.append(destination)
+    return staged
+
+
 def build_workspace(
     repo_root: Path = REPO_ROOT,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
@@ -429,6 +459,12 @@ def build_workspace(
         staged_items.extend(
             item.name for item in stage_ml_experiments(output_dir / ML_FOLDER)
         )
+    # Data Agents (Fabric copilots over the semantic model and ontology) publish
+    # into a "Data Agents" folder. Their datasource GUID references are remapped
+    # to the target workspace via generated parameter.yml rules.
+    staged_items.extend(
+        item.name for item in stage_data_agents(repo_root, output_dir)
+    )
     return BuildResult(output_dir=output_dir, staged_items=sorted(staged_items))
 
 

--- a/deploy/scripts/deploy_config.py
+++ b/deploy/scripts/deploy_config.py
@@ -16,6 +16,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_ROOT = REPO_ROOT / "deploy"
 CONFIG_ROOT = DEPLOY_ROOT / "config"
 DEFAULT_CONFIG_PATH = CONFIG_ROOT / "deploy.yml"
+
+# Source-workspace GUIDs embedded in the committed Data Agent datasource configs
+# (fabric/data-agents/*.DataAgent). They are exported from the authoring
+# workspace and must be remapped to the target workspace at publish time via
+# generated parameter.yml rules. The semantic-model GUID resolves to the deployed
+# SemanticModel; the source workspace GUID resolves to the target workspace. The
+# ontology GUID points at a runtime-created artifact (the ontology notebook makes
+# it), so it cannot be resolved at deploy time and is rebound after that runs.
+DATA_AGENT_SOURCE_WORKSPACE_ID = "5219ac70-71d4-4dfc-af32-5b8a6c29a471"
+DATA_AGENT_SEMANTIC_MODEL_ID = "07e6f51e-aaac-4594-bf50-94db9c1daf89"
 ENVIRONMENTS_ROOT = CONFIG_ROOT / "environments"
 
 
@@ -445,6 +455,30 @@ def render_parameter_file(
                 }
             ]
         }
+
+    # Data Agent datasource configs reference the source workspace and the
+    # semantic model by GUID. Remap them to the target workspace and the deployed
+    # SemanticModel so the agents bind in the new workspace. (The ontology agent's
+    # ontology GUID points at a runtime-created artifact and is left as-is; it is
+    # rebound after the ontology notebook runs.)
+    parameters["find_replace"].extend(
+        [
+            {
+                "find_value": DATA_AGENT_SOURCE_WORKSPACE_ID,
+                "replace_value": {config.environment: "$workspace.$id"},
+                "item_type": "DataAgent",
+            },
+            {
+                "find_value": DATA_AGENT_SEMANTIC_MODEL_ID,
+                "replace_value": {
+                    config.environment: (
+                        f"$items.SemanticModel.{config.powerbi.semantic_model_name}.$id"
+                    )
+                },
+                "item_type": "DataAgent",
+            },
+        ]
+    )
 
     return parameters
 

--- a/fabric/taskflow/taskflow.json
+++ b/fabric/taskflow/taskflow.json
@@ -300,7 +300,7 @@
           "artifactUniqueId": "Ontology:ab4766aa-2ebf-4b76-86b6-7efe733d918d",
           "artifactType": "Ontology",
           "artifactObjectId": null,
-          "artifactName": "Retail Ontology"
+          "artifactName": "RetailOntology_AutoGen"
         }
       ],
       "loc": "800 -60"

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -29,12 +29,36 @@ def test_stage_notebook_creates_platform_and_notebook_content(tmp_path: Path) ->
         "displayName": "01-create-bronze-shortcuts",
     }
     notebook = json.loads((staged / "notebook-content.ipynb").read_text(encoding="utf-8"))
+    lakehouse_logical_id = build_artifacts._logical_id("Lakehouse", "retail_lakehouse")
     assert notebook["metadata"]["dependencies"]["lakehouse"] == {
-        "default_lakehouse": "$items.Lakehouse.retail_lakehouse.$id",
+        "default_lakehouse": lakehouse_logical_id,
         "default_lakehouse_name": "retail_lakehouse",
-        "default_lakehouse_workspace_id": "$workspace.$id",
-        "known_lakehouses": [{"id": "$items.Lakehouse.retail_lakehouse.$id"}],
+        "default_lakehouse_workspace_id": "00000000-0000-0000-0000-000000000000",
+        "known_lakehouses": [{"id": lakehouse_logical_id}],
     }
+
+
+def test_notebook_lakehouse_binding_matches_staged_lakehouse_logical_id(tmp_path: Path) -> None:
+    """The notebook's default-lakehouse id must equal the staged Lakehouse shell's
+    .platform logicalId so fabric-cicd resolves it to the deployed lakehouse GUID
+    (the $items.Lakehouse.<name>.$id token does NOT resolve in raw item content)."""
+
+    source = tmp_path / "fabric" / "lakehouse" / "01-create-bronze-shortcuts.ipynb"
+    _write_json(source, {"metadata": {}, "cells": [], "nbformat": 4, "nbformat_minor": 5})
+    output = tmp_path / "deploy" / "workspace"
+
+    lakehouse_dir = build_artifacts.stage_shell_item(output, "retail_lakehouse", "Lakehouse")
+    notebook_dir = build_artifacts.stage_notebook(source, output)
+
+    platform = json.loads((lakehouse_dir / ".platform").read_text(encoding="utf-8"))
+    notebook = json.loads((notebook_dir / "notebook-content.ipynb").read_text(encoding="utf-8"))
+    binding = notebook["metadata"]["dependencies"]["lakehouse"]
+
+    assert binding["default_lakehouse"] == platform["config"]["logicalId"]
+    assert binding["known_lakehouses"][0]["id"] == platform["config"]["logicalId"]
+    # No unresolved fabric-cicd tokens may leak into published notebook content.
+    assert "$workspace" not in json.dumps(notebook)
+    assert "$items" not in json.dumps(notebook)
 
 
 def test_stage_powerbi_items_copies_item_directories(tmp_path: Path) -> None:

--- a/tests/deploy/test_build_artifacts.py
+++ b/tests/deploy/test_build_artifacts.py
@@ -199,6 +199,57 @@ def test_stage_ml_experiments_creates_shell_items(tmp_path: Path) -> None:
     assert platform["metadata"]["displayName"] == "demand_forecast"
 
 
+def test_stage_data_agents_copies_item_folders(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    for agent in ("retail-semantic-model-agent", "retail-ontology-agent"):
+        agent_dir = repo / "fabric" / "data-agents" / f"{agent}.DataAgent"
+        _write_json(agent_dir / ".platform", {"metadata": {"type": "DataAgent"}})
+        _write_json(
+            agent_dir / "Files" / "Config" / "data_agent.json", {"schema": "x"}
+        )
+
+    output = tmp_path / "workspace"
+    staged = build_artifacts.stage_data_agents(repo, output)
+
+    names = sorted(p.name for p in staged)
+    assert names == ["retail-ontology-agent.DataAgent", "retail-semantic-model-agent.DataAgent"]
+    # The full item definition (not just .platform) is copied into the
+    # "Data Agents" workspace folder.
+    copied = output / "Data Agents" / "retail-semantic-model-agent.DataAgent"
+    assert (copied / ".platform").is_file()
+    assert (copied / "Files" / "Config" / "data_agent.json").is_file()
+
+
+def test_stage_data_agents_empty_without_source(tmp_path: Path) -> None:
+    assert build_artifacts.stage_data_agents(tmp_path / "repo", tmp_path / "ws") == []
+
+
+def test_build_workspace_stages_data_agents(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    for notebook_name in build_artifacts.NOTEBOOK_GROUPS["core"]:
+        _write_json(
+            repo / "fabric" / "lakehouse" / notebook_name,
+            {"metadata": {}, "cells": [], "nbformat": 4, "nbformat_minor": 5},
+        )
+    _write_json(
+        repo / "fabric" / "powerbi" / "retail_model.SemanticModel" / ".platform",
+        {"metadata": {"type": "SemanticModel"}},
+    )
+    _write_json(
+        repo / "fabric" / "powerbi" / "retail_model.Report" / ".platform",
+        {"metadata": {"type": "Report"}},
+    )
+    _write_json(
+        repo / "fabric" / "data-agents" / "retail-semantic-model-agent.DataAgent" / ".platform",
+        {"metadata": {"type": "DataAgent"}},
+    )
+
+    result = build_artifacts.build_workspace(repo, tmp_path / "ws", ["core"])
+
+    assert "retail-semantic-model-agent.DataAgent" in result.staged_items
+    assert (tmp_path / "ws" / "Data Agents" / "retail-semantic-model-agent.DataAgent").is_dir()
+
+
 def test_build_workspace_stages_ml_experiments_only_with_ml_group(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     for notebook_name in build_artifacts.NOTEBOOK_GROUPS["core"] + build_artifacts.NOTEBOOK_GROUPS["ml"]:

--- a/tests/deploy/test_deploy_config.py
+++ b/tests/deploy/test_deploy_config.py
@@ -26,6 +26,7 @@ def test_load_environment_merges_defaults_and_environment() -> None:
         "KQLQueryset",
         "DataPipeline",
         "MLExperiment",
+        "DataAgent",
     ]
 
 
@@ -89,6 +90,30 @@ def test_render_parameter_file_uses_dynamic_item_references() -> None:
         and entry["replace_value"]["dev"].startswith("$items.Notebook.")
     }
     assert "$items.Notebook.02-historical-data-load.$id" in notebook_replacements
+
+
+def test_render_parameter_file_remaps_data_agent_references() -> None:
+    config = deploy_config.load_environment("dev")
+    terraform_outputs = {
+        "workspace_id": "11111111-1111-1111-1111-111111111111",
+        "lakehouse_id": "22222222-2222-2222-2222-222222222222",
+        "lakehouse_name": "retail_lakehouse",
+    }
+
+    rendered = deploy_config.render_parameter_file(config, terraform_outputs)
+
+    agent_rules = {
+        entry["find_value"]: entry["replace_value"]["dev"]
+        for entry in rendered["find_replace"]
+        if entry.get("item_type") == "DataAgent"
+    }
+    # The Data Agents' source-workspace GUID resolves to the target workspace,
+    # and the semantic-model GUID resolves to the deployed SemanticModel.
+    assert agent_rules[deploy_config.DATA_AGENT_SOURCE_WORKSPACE_ID] == "$workspace.$id"
+    assert (
+        agent_rules[deploy_config.DATA_AGENT_SEMANTIC_MODEL_ID]
+        == f"$items.SemanticModel.{config.powerbi.semantic_model_name}.$id"
+    )
 
 
 def test_collect_pipeline_notebook_refs_maps_notebook_ids(tmp_path: Path) -> None:

--- a/tests/deploy/test_taskflow.py
+++ b/tests/deploy/test_taskflow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from deploy.scripts import taskflow
@@ -100,11 +102,17 @@ def test_committed_taskflow_has_only_bindable_items() -> None:
     data = _json.loads(
         (repo_root / "fabric" / "taskflow" / "taskflow.json").read_text(encoding="utf-8")
     )
+    # Hash-suffixed runtime artifacts (e.g. RetailOntology_AutoGen_graph_<32 hex>,
+    # *_lh_<32 hex>) get a fresh GUID-derived suffix every run and can never bind by
+    # name. The stable ontology item name (RetailOntology_AutoGen, no hash) is fine.
+    hashed_autogen = re.compile(r"_AutoGen_(?:graph|lh)_[0-9a-f]{16,}", re.IGNORECASE)
     for task in data["tasks"]:
         for item in task["items"]:
             name = item.get("artifactName")
             assert name, f"null artifactName in task {task.get('name')!r}"
-            assert "_AutoGen_" not in str(name), f"unportable auto-gen reference: {name}"
+            assert not hashed_autogen.search(str(name)), (
+                f"unportable hash-suffixed reference: {name}"
+            )
 
 
 def test_to_workspace_resolves_names_to_target_guids_and_reports_unresolved() -> None:

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -640,6 +640,8 @@ def _deploy_plan(
                 "core",
                 "setup",
                 "ml",
+                "ontology",
+                "reset",
                 "--lakehouse-name",
                 lakehouse_name,
             ],

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -25,7 +25,7 @@ def test_dry_run_prints_full_plan_and_executes_nothing(monkeypatch):
     assert calls == []
     out = result.output
     assert "generate_configs" in out and "terraform" in out
-    assert "build_artifacts" in out and "core setup ml" in out.replace("'", "")
+    assert "build_artifacts" in out and "core setup ml ontology reset" in out.replace("'", "")
     assert "deploy_items" in out and "apply_kql" in out and "validate_deployment" in out
 
 
@@ -34,6 +34,19 @@ def test_skip_terraform_drops_terraform_steps():
     flat = " ".join(" ".join(map(str, step.cmd)) for step in plan)
     assert "terraform" not in flat
     assert "generate_configs" in flat and "deploy_items" in flat
+
+
+def test_plan_builds_ontology_and_reset_notebook_groups():
+    plan = _deploy_plan("dev", skip_terraform=False)
+    build = next(s for s in plan if "build_artifacts" in " ".join(map(str, s.cmd)))
+    cmd = build.cmd
+    groups_idx = cmd.index("--notebook-groups")
+    lakehouse_idx = cmd.index("--lakehouse-name")
+    groups = cmd[groups_idx + 1 : lakehouse_idx]
+    # The deploy stages every notebook group needed to link the full task flow:
+    # ontology (30-create-ontology) and reset (99-reset-lakehouse) join the core
+    # pipeline, setup notebooks, and ML notebooks.
+    assert set(groups) == {"core", "setup", "ml", "ontology", "reset"}
 
 
 def test_plan_orders_steps_and_gates_apply():


### PR DESCRIPTION
## Summary

Makes the four previously-unbound task-flow nodes **deploy and link** by actually creating the items they reference.

| Unlinked item | How it now links |
| --- | --- |
| `99-reset-lakehouse` | `reset` notebook group added to the deploy plan |
| `retail-semantic-model-agent` | Data Agents are now staged + published (`DataAgent` in scope); bind to the deployed `retail_model` |
| `retail-ontology-agent` | Same; its ontology binding resolves after the ontology notebook runs |
| `Ontology:Retail Ontology` | Renamed node to `RetailOntology_AutoGen` (the name the ontology notebook actually creates); `ontology` group added to the deploy |

## Changes

- **Stage Data Agents** — `build_artifacts.stage_data_agents` copies `fabric/data-agents/*.DataAgent` into a **Data Agents** workspace folder; `build_workspace` calls it. `DataAgent` added to `item_types_in_scope` so fabric-cicd publishes them.
- **Remap Data Agent GUIDs** — the agents' datasource configs embed the source workspace + semantic-model GUIDs. `render_parameter_file` now emits `parameter.yml` rules: source workspace -> `\.\`, semantic-model GUID -> `\.SemanticModel.<name>.\` (resolved by fabric-cicd at publish).
- **Deploy ontology + reset notebooks** — the deploy plan stages `core setup ml ontology reset`, so `30-create-ontology` and `99-reset-lakehouse` are published.
- **Task flow** — ontology node renamed to `RetailOntology_AutoGen` (matches the notebook's output). The committed-task-flow guard now rejects only **hash-suffixed** runtime artifacts (`*_AutoGen_graph_<hex>`, `*_lh_<hex>`), not the stable ontology name.

## Linking timeline
- **At deploy:** reset notebook + both data agents link immediately.
- **After the ontology notebook runs** (and a task-flow re-deploy): the ontology node and the ontology agent's ontology datasource bind. The ontology is a *runtime* artifact, so it can't be pre-created at deploy — documented in `deploy/README.md`.

## Tests
- `stage_data_agents` copies full item folders; `build_workspace` includes agents; empty without source.
- `render_parameter_file` emits the two DataAgent remap rules.
- Deploy plan stages `ontology` + `reset` groups; dry-run shows `core setup ml ontology reset`.
- `item_types_in_scope` includes `DataAgent`.
- Deploy suite: **89 passed, 2 skipped** (env-guarded); `ruff` clean.

> **Stacks on #298 + #299 + #300 + #301** (merges them in as its base, since it touches `build_artifacts.py`, `cli/main.py`, and `taskflow.json`). Merge after those; it auto-retargets to `main`.
