### PR TITLE
feat(deploy): chain ML pipeline and ontology into the setup pipeline

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -124,23 +124,34 @@ does not.
 - Data Pipelines in `fabric\pipelines\*.DataPipeline` deploy into a **Pipelines**
   folder; each pipeline is staged only when its notebooks are part of the deploy,
   and notebook references are remapped via generated `parameter.yml` rules.
+- The **setup pipeline** orchestrates the full one-time setup end to end:
+  `setup-01..04` (seed -> dimensions -> facts -> gold), then the **ML notebooks**
+  (06-14), then `30-create-ontology`. The ontology reads gold *and* ML tables, so
+  it runs only after every ML notebook completes. (The ML notebooks are inlined as
+  activities rather than invoking the standalone `machine-learning` pipeline,
+  because Fabric's Invoke pipeline activity requires a connection object the deploy
+  can't yet provision; the notebooks themselves are shared items, and the
+  `machine-learning` pipeline still exists for manual/standalone runs.) The
+  ontology is a one-time **setup** step; there is no scheduled ontology refresh
+  after incremental loads.
 - Data Agents in `fabric\data-agents\*.DataAgent` deploy into a **Data Agents**
   folder (item type `DataAgent`, which must be in `item_types_in_scope`). Their
   datasource configs reference the source workspace and the semantic model by
   GUID; generated `parameter.yml` rules remap those to the target workspace and
   the deployed `SemanticModel`. The ontology agent also references the ontology,
-  which is created at **runtime** by the `30-create-ontology` notebook — that GUID
-  cannot be resolved at deploy time, so the ontology agent binds to its ontology
-  only after that notebook runs (re-run it / rebind in the workspace).
+  which is created when the setup pipeline runs `30-create-ontology`; the agent
+  binds to its ontology after that pipeline run completes.
 - The `retail-setup deploy` plan stages the `core`, `setup`, `ml`, `ontology`, and
   `reset` notebook groups, so `30-create-ontology` and `99-reset-lakehouse` are
-  deployed alongside the core pipeline and ML notebooks.
+  deployed alongside the core pipeline and ML notebooks. `99-reset-lakehouse` is
+  **not** orchestrated (it destroys lakehouse contents) — run it manually only.
 - Dashboard assets remain source inputs until their Fabric source-control item
   formats are validated. Task flows are deployed separately by
   `deploy.scripts.taskflow` (offered as a prompt at the end of deploy). The task
   flow links items by display name, so a node binds once its item exists in the
   workspace. The ontology node (`RetailOntology_AutoGen`) and ontology agent link
-  after the ontology notebook has run and the task flow is re-deployed.
+  after the setup pipeline has run (it creates the ontology) and the task flow is
+  re-deployed.
 - Secrets must come from Azure login, GitHub Actions secrets, environment
   variables, Key Vault, or ignored local files. Do not commit secrets to YAML,
   Terraform files, notebooks, or generated artifacts.

--- a/fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json
+++ b/fabric/pipelines/setup-pipeline.DataPipeline/pipeline-content.json
@@ -23,7 +23,9 @@
         "dependsOn": [
           {
             "activity": "setup-01-seed-dictionaries",
-            "dependencyConditions": ["Succeeded"]
+            "dependencyConditions": [
+              "Succeeded"
+            ]
           }
         ],
         "policy": {
@@ -44,7 +46,9 @@
         "dependsOn": [
           {
             "activity": "setup-02-generate-dimensions",
-            "dependencyConditions": ["Succeeded"]
+            "dependencyConditions": [
+              "Succeeded"
+            ]
           }
         ],
         "policy": {
@@ -65,7 +69,9 @@
         "dependsOn": [
           {
             "activity": "setup-03-generate-facts",
-            "dependencyConditions": ["Succeeded"]
+            "dependencyConditions": [
+              "Succeeded"
+            ]
           }
         ],
         "policy": {
@@ -77,6 +83,284 @@
         },
         "typeProperties": {
           "notebookId": "76ba8c81-cdcf-5f8b-99aa-22eb85079516",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "09-ml-churn-prediction",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-04-build-gold",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "875f69ea-f370-4702-b5f0-efc73e0a2ae0",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "06-ml-demand-forecast",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-04-build-gold",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "13c32a9a-70f8-4638-97a2-54f4ddf49d05",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "07-ml-market-basket",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-04-build-gold",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "e1aaa8df-b835-4f32-8240-f75d0d1889db",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "08-ml-customer-segmentation",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-04-build-gold",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "22cf947e-4e21-4f59-b653-fc2b316d4b27",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "10-ml-promotion-effectiveness",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-04-build-gold",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "20a387e3-668a-4ff0-a072-b33ab29a0b79",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "11-ml-journey-analysis",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-04-build-gold",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "09fc05bb-ef5f-45d3-85bf-de3b096c425b",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "13-ml-delivery-prediction",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-04-build-gold",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "72ac6599-7069-4679-8670-c0d74cb3ec6d",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "12-ml-stockout-prediction",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "setup-04-build-gold",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "e5f45d40-53c2-4a12-a9b5-c303f8c7347d",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "14-ml-dynamic-pricing",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "10-ml-promotion-effectiveness",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "fdef9c48-5c00-4edc-a9ca-fcf26f8b5be4",
+          "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
+        }
+      },
+      {
+        "name": "30-create-ontology",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "09-ml-churn-prediction",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "06-ml-demand-forecast",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "07-ml-market-basket",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "08-ml-customer-segmentation",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "10-ml-promotion-effectiveness",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "11-ml-journey-analysis",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "13-ml-delivery-prediction",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "12-ml-stockout-prediction",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "14-ml-dynamic-pricing",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "c0a5b621-80e5-52f2-815e-bcf28890413e",
           "workspaceId": "9c315f26-dcc7-5e85-b972-4f3af5aaf3a0"
         }
       }

--- a/tests/deploy/test_deploy_config.py
+++ b/tests/deploy/test_deploy_config.py
@@ -149,7 +149,59 @@ def test_collect_pipeline_notebook_refs_maps_notebook_ids(tmp_path: Path) -> Non
     }
 
 
+def test_committed_setup_pipeline_chains_ml_then_ontology() -> None:
+    """The committed setup pipeline must run data load -> ML notebooks -> ontology,
+    with the ML and ontology notebook references mapped to deployed items."""
 
+    repo_root = Path(__file__).resolve().parents[2]
+    content = json.loads(
+        (
+            repo_root
+            / "fabric"
+            / "pipelines"
+            / "setup-pipeline.DataPipeline"
+            / "pipeline-content.json"
+        ).read_text(encoding="utf-8")
+    )
+    activities = {a["name"]: a for a in content["properties"]["activities"]}
+
+    # ML notebooks run after gold is built; every ML activity (directly or via an
+    # intra-ML dependency) follows setup-04-build-gold.
+    ml_names = [n for n in activities if "-ml-" in n]
+    assert ml_names, "expected inlined ML notebooks in the setup pipeline"
+    for name in ml_names:
+        assert activities[name]["type"] == "TridentNotebook"
+
+    # Ontology runs only after every ML notebook completes (it reads gold + ML).
+    ontology = activities["30-create-ontology"]
+    assert ontology["type"] == "TridentNotebook"
+    ontology_deps = {d["activity"] for d in ontology["dependsOn"]}
+    assert set(ml_names).issubset(ontology_deps)
+
+    # The ML + ontology notebook GUIDs are mapped to deployed notebooks.
+    config = deploy_config.load_environment("dev")
+    rendered = deploy_config.render_parameter_file(
+        config,
+        {
+            "workspace_id": "11111111-1111-1111-1111-111111111111",
+            "lakehouse_id": "22222222-2222-2222-2222-222222222222",
+            "lakehouse_name": "retail_lakehouse",
+        },
+    )
+    replacements = {
+        entry["find_value"]: entry["replace_value"]["dev"]
+        for entry in rendered["find_replace"]
+        if isinstance(entry["replace_value"].get("dev"), str)
+    }
+    assert (
+        replacements[ontology["typeProperties"]["notebookId"]]
+        == "$items.Notebook.30-create-ontology.$id"
+    )
+    sample_ml = activities["06-ml-demand-forecast"]
+    assert (
+        replacements[sample_ml["typeProperties"]["notebookId"]]
+        == "$items.Notebook.06-ml-demand-forecast.$id"
+    )
 def test_write_generated_configs_creates_expected_files(tmp_path: Path) -> None:
     config = deploy_config.load_environment("dev")
     terraform_outputs = {

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -837,11 +837,12 @@ def deploy(
 
     if not yes:
         if typer.confirm(
-            "Run the setup pipeline now (apply KQL setup, then generate "
-            "dimensions, facts, and gold)?",
+            "Run the setup pipeline now (generate dimensions, facts, and gold, "
+            "then train the ML models and build the ontology)?",
             default=False,
         ):
             _run_setup_pipeline(repo_root, env)
+            _print_ontology_relink_hint(repo_root, env)
         else:
             typer.echo(
                 "Skipping. Run later with: "
@@ -871,6 +872,28 @@ def _deploy_taskflow(repo_root: Path, env: str) -> None:
         )
 
 
+def _print_ontology_relink_hint(repo_root: Path, env: str) -> None:
+    """Explain why the ontology task-flow node is unbound and how it links.
+
+    The ontology is created at the end of the setup pipeline (``30-create-ontology``),
+    which runs after the task flow was deployed, so its node is dropped (unbound) at
+    this deploy. It binds automatically on the next ``retail-setup deploy`` (the task
+    flow step re-runs and the ontology now resolves by name), or immediately via a
+    standalone task flow deploy once the pipeline finishes.
+    """
+
+    workspace = _workspace_name(repo_root, env)
+    typer.echo("")
+    typer.echo(
+        "Note: the ontology is created at the end of the setup pipeline you just\n"
+        "started, so its task-flow node ('RetailOntology_AutoGen') is not linked yet.\n"
+        "It links automatically the next time you run 'retail-setup deploy' (once the\n"
+        "ontology exists). To link it sooner, re-run the task flow deploy after the\n"
+        "pipeline finishes:\n"
+        f"    python -m deploy.scripts.taskflow deploy --workspace {workspace}"
+    )
+
+
 def _run_setup_pipeline(repo_root: Path, env: str) -> None:
     """Start an on-demand run of the deployed setup pipeline.
 
@@ -881,7 +904,8 @@ def _run_setup_pipeline(repo_root: Path, env: str) -> None:
 
     typer.echo("")
     _hr("=")
-    typer.echo("  Generating the historical data (dimensions, then facts, then gold).")
+    typer.echo("  Running the setup pipeline: historical data (dimensions, facts, gold),")
+    typer.echo("  then the ML models, then the ontology -- in one chained run.")
     typer.echo("  This can take a while -- often several minutes to an hour or more,")
     typer.echo("  depending on the months of history and store count. It runs in")
     typer.echo("  Fabric, so you can close this and track progress in the workspace.")

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -197,6 +197,22 @@ def test_run_setup_pipeline_gives_up_after_max_attempts(monkeypatch, capsys):
     assert "run 'setup-pipeline' manually" in captured.err
 
 
+def test_ontology_relink_hint_names_workspace_and_command(tmp_path, capsys):
+    cfg = tmp_path / "deploy" / "config"
+    (cfg / "environments").mkdir(parents=True)
+    (cfg / "deploy.yml").write_text("workspace:\n  name: retail-demo\n", encoding="utf-8")
+    (cfg / "environments" / "dev.yml").write_text(
+        "workspace:\n  name: retail-demo-dev\n", encoding="utf-8"
+    )
+    from retail_setup.cli.main import _print_ontology_relink_hint
+
+    _print_ontology_relink_hint(tmp_path, "dev")
+
+    out = capsys.readouterr().out
+    assert "RetailOntology_AutoGen" in out
+    assert "deploy.scripts.taskflow deploy --workspace retail-demo-dev" in out
+
+
 def test_deploy_reports_missing_terraform_without_traceback(monkeypatch):
     def fake_run(cmd, *args, **kwargs):
         if cmd and cmd[0] == "terraform":


### PR DESCRIPTION
## Summary

Makes the (auto-triggered) **setup pipeline** run the full one-time setup end to end, so the ML outputs and the ontology exist without manual steps:

`
setup-01 -> setup-02 -> setup-03 -> setup-04   (seed -> dimensions -> facts -> gold)
   -> ML notebooks 06-14   -> 30-create-ontology  (runs after ALL ML completes)
`

The ontology reads gold **and** ML tables (`CustomerSegment`, `ChurnPrediction`), so it must run after ML.

## Why inline the ML notebooks instead of invoking the ML pipeline?

I first tried invoking the reusable `machine-learning` pipeline (your preference). The deploy failed:

> `Failed to publish DataPipeline 'setup-pipeline': ... 'ExternalReferences' cannot be null`

Fabric's **Invoke pipeline** activity requires a **connection object** (`externalReferences.connection` — verified against a real exported Fabric pipeline). The legacy same-workspace invoke needs one too, and this deploy framework can't yet provision/parameterize a connection. So I **inlined the ML notebooks** as `TridentNotebook` activities — the same proven, connection-free pattern as `setup-01..04`.

- The ML **notebooks are shared items** (still reused), and the standalone `machine-learning` pipeline still exists for manual runs.
- Switching the setup pipeline to a true pipeline-invoke is a clean **future enhancement** once connection provisioning is added.

## Changes
- **`setup-pipeline.DataPipeline`** — inlined ML notebooks 06-14 after `setup-04` (preserving the intra-ML `14 -> 10` dependency), then `30-create-ontology` depending on all ML notebooks.
- No new deploy-config/build-artifacts machinery needed: the existing `collect_pipeline_notebook_refs` maps the ML + ontology notebook GUIDs to `\.Notebook.<name>.\`, and `stage_pipelines` already requires a pipeline's notebooks to be deployed — so the setup pipeline stages only when `ml` + `ontology` groups are included (verified: excluding `ml` correctly skips it).
- CLI prompt/banner + `deploy/README.md` updated.

## Scope decisions (you were away)
- **`99-reset-lakehouse` stays manual** — destructive; deployed but not orchestrated.
- **Ontology is a one-time setup step** — no scheduled refresh after incremental loads (structural).

## Tests
- Committed setup-pipeline chain guard (ML notebooks inlined; ontology depends on all ML; GUIDs mapped).
- Existing pipeline-staging tests confirm the notebook-subset gate.
- Deploy suite: **87 passed, 2 skipped** (env-guarded); `ruff` clean.

> **Stacks on #302 -> #301 -> #300 -> #299 (+#298)**. Merge after those; auto-retargets to `main`.
