### PR TITLE
fix(setup): create the conda env with Python 3.13 instead of 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Set-Location retail-demo
 
 `setup.ps1` is the Windows entry point for machines with **nothing installed**.
 If conda is installed it uses a `retail-demo` conda environment (created with
-Python 3.14 when missing); otherwise it uses a local `.venv` (created from a
+Python 3.13 when missing); otherwise it uses a local `.venv` (created from a
 system Python 3.11+); and if neither is available it installs Miniforge with
 winget. It activates that environment, runs the guided setup, and then switches
 your shell back to the environment you started from.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@ Utility scripts for configuring and deploying the retail demo components.
 Guided Windows bootstrap. It prepares a Python environment, delegates to
 `setup.py`, then switches your shell back to the environment that was active
 before it ran. It uses a conda environment named `retail-demo` (created with
-Python 3.14 when missing) if conda is installed; otherwise a local `.venv` in
+Python 3.13 when missing) if conda is installed; otherwise a local `.venv` in
 the repo root (created from a system Python 3.11+ when missing); and if neither
 is available, it installs Miniforge with winget. All arguments are forwarded.
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -9,7 +9,7 @@
 
     Environment selection order:
       1. If conda is installed, use a conda environment named 'retail-demo'
-         (created with Python 3.14 when it does not exist) and activate it.
+         (created with Python 3.13 when it does not exist) and activate it.
       2. Otherwise, if a local virtual environment (.venv in the repo root)
          exists, activate it; if it does not exist, create it from a suitable
          system Python (3.11+) and activate it.
@@ -41,7 +41,7 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 $SetupPy = Join-Path $PSScriptRoot 'setup.py'
 $CondaEnvName = 'retail-demo'
-$CondaPythonVersion = '3.14'
+$CondaPythonVersion = '3.13'
 $VenvPath = Join-Path $RepoRoot '.venv'
 
 function Get-EnvSnapshot {

--- a/utility/README.md
+++ b/utility/README.md
@@ -42,7 +42,7 @@ On Windows, from the repository root:
 ```
 
 `setup.ps1` works even with nothing installed. If conda is installed it uses a
-`retail-demo` conda environment (created with Python 3.14 when missing);
+`retail-demo` conda environment (created with Python 3.13 when missing);
 otherwise it uses a local `.venv` (created from a system Python 3.11+); and if
 neither is available it installs Miniforge with winget. It activates that
 environment, delegates to `scripts\setup.py`, and then switches your shell back


### PR DESCRIPTION
## Summary

Follow-up to #305: that PR was merged moments before the Python-version change landed, so `main` still creates the `retail-demo` conda environment with **Python 3.14**. This sets it to **Python 3.13** as requested.

### Fix
- `scripts/setup.ps1`: `$CondaPythonVersion = '3.13'` (was `3.14`) — the conda env path of the Windows bootstrap now creates `retail-demo` with Python 3.13.
- Docs aligned: `README.md`, `scripts/README.md`, `utility/README.md`.

## Testing
- `scripts/setup.ps1` parses cleanly (PowerShell AST parser).
- No `3.14` references remain in the four files.

No Python/runtime code is touched.
