### PR TITLE
feat(setup): show the interactive console during guided setup

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -8,6 +8,7 @@ before project dependencies are installed.
 from __future__ import annotations
 
 import argparse
+import os
 import platform
 import re
 import shutil
@@ -15,6 +16,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_URL = "https://github.com/amattas/retail-demo/blob/main/README.md"
@@ -25,20 +27,87 @@ MIN_PYTHON = (3, 11)
 # always shown if a step fails, so troubleshooting never loses information.
 VERBOSE = False
 
+# Active guided console (a retail_setup.cli.console.ConsoleUI) or None. When set
+# (interactive TTY runs), section headers drive a fixed-footer progress bar with
+# an "esc to cancel or abort" hint and command output scrolls in the region above
+# it; when None (CI, pipes, dry runs, tests), output stays plain line-by-line.
+_UI: Any = None
+
+
+def _emit(text: str = "") -> None:
+    """Write a line to the guided console's scrolling log, or plain stdout."""
+    if _UI is not None:
+        _UI.log(text)
+    else:
+        print(text)
+
+
+def _check_cancelled() -> None:
+    """Abort the guided setup if the user pressed Esc (TTY console only)."""
+    if _UI is not None and _UI.cancelled:
+        _emit("")
+        _emit("Cancelled (esc).")
+        raise SystemExit(130)
+
+
+def _try_pip_install(package: str) -> bool:
+    """Best-effort, quiet install of a single package into this interpreter."""
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-q", package], check=True
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _load_console() -> Any:
+    """Return the guided ConsoleUI class for an interactive run, or None.
+
+    Imported lazily (installing ``alive-progress`` if needed) so this script
+    still runs on the standard library alone when there is no terminal or the
+    dependency is unavailable. Honors ``RETAIL_SETUP_NO_UI`` and requires a TTY.
+    """
+    if os.environ.get("RETAIL_SETUP_NO_UI", "").lower() in ("1", "true", "yes"):
+        return None
+    try:
+        if not (sys.stdout.isatty() and sys.stdin.isatty()):
+            return None
+    except Exception:
+        return None
+    try:
+        import alive_progress  # noqa: F401
+    except Exception:
+        if not _try_pip_install("alive-progress"):
+            return None
+    src = REPO_ROOT / "utility" / "src"
+    if src.is_dir() and str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    try:
+        from retail_setup.cli.console import ConsoleUI
+
+        return ConsoleUI
+    except Exception:
+        return None
+
 
 def _banner(lines: list[str]) -> None:
     """Print a boxed title block."""
 
     width = 60
-    print("=" * width)
+    _emit("=" * width)
     for line in lines:
-        print(f"  {line}")
-    print("=" * width)
+        _emit(f"  {line}")
+    _emit("=" * width)
 
 
 def _section(step: int, total: int, title: str) -> None:
-    """Print a numbered step header."""
+    """Print a numbered step header, or advance the guided progress bar."""
 
+    if _UI is not None:
+        _UI.set_phase(f"Step {step}/{total}: {title}")
+        _UI.advance(completed=step - 1)
+        return
     print("")
     print("-" * 60)
     print(f"Step {step} of {total}: {title}")
@@ -185,6 +254,8 @@ def missing_prerequisites() -> list[str]:
 def prompt_yes_no(message: str, *, default: bool) -> bool:
     """Prompt for a yes/no answer."""
 
+    if _UI is not None:
+        return _UI.prompt_yes_no(message, default=default)
     suffix = "Y/n" if default else "y/N"
     answer = input(f"{message} [{suffix}]: ").strip().lower()
     if not answer:
@@ -198,38 +269,95 @@ def run_command(
     cwd: Path = REPO_ROOT,
     dry_run: bool = False,
     label: str | None = None,
+    interactive: bool = False,
 ) -> None:
     """Run a subprocess, showing friendly progress unless --verbose.
 
     When ``label`` is given and we're not in verbose/dry-run mode, print the
     plain-language label instead of the raw command. The raw command is always
     revealed if the step fails, so troubleshooting keeps full detail.
+
+    With the guided console active, non-interactive commands stream their output
+    into the scrolling log above the progress bar. ``interactive`` commands (ones
+    that prompt or render their own console, e.g. ``configure``/``deploy`` or a
+    package-manager/login that may ask questions) pause the bar and take over the
+    terminal instead.
     """
 
     rendered = " ".join(command)
     show_raw = VERBOSE or dry_run or label is None
-    if show_raw:
-        print(f"$ {rendered}")
-    else:
-        print(f"  - {label}")
+    _emit(f"$ {rendered}" if show_raw else f"  - {label}")
     if dry_run:
         return
+    if _UI is not None and not interactive:
+        _run_streamed(command, cwd, rendered, show_raw)
+        return
+    if _UI is not None:
+        with _UI.paused():
+            _run_inherit(command, cwd, rendered, show_raw)
+    else:
+        _run_inherit(command, cwd, rendered, show_raw)
+
+
+def _run_inherit(
+    command: list[str], cwd: Path, rendered: str, show_raw: bool
+) -> None:
+    """Run a command with inherited stdio (the child owns the terminal)."""
     try:
         subprocess.run(command, cwd=cwd, check=True)
     except FileNotFoundError:
         if not show_raw:
-            print(f"    (command: {rendered})")
+            _emit(f"    (command: {rendered})")
         raise SystemExit(
             f"Required program not found: {command[0]}. "
             "Install it and make sure it is on your PATH, then re-run setup."
         ) from None
     except subprocess.CalledProcessError as exc:
         if not show_raw:
-            print(f"    (command: {rendered})")
+            _emit(f"    (command: {rendered})")
         raise SystemExit(
             f"That step failed (exit code {exc.returncode}). "
             f"Command: {rendered}"
         ) from None
+
+
+def _run_streamed(
+    command: list[str], cwd: Path, rendered: str, show_raw: bool
+) -> None:
+    """Run a command, streaming its output into the guided console's log."""
+    try:
+        proc = subprocess.Popen(
+            command,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except FileNotFoundError:
+        if not show_raw:
+            _emit(f"    (command: {rendered})")
+        raise SystemExit(
+            f"Required program not found: {command[0]}. "
+            "Install it and make sure it is on your PATH, then re-run setup."
+        ) from None
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        if _UI is not None and _UI.cancelled:
+            proc.terminate()
+            break
+        _emit(line.rstrip("\n"))
+    proc.wait()
+    if _UI is not None and _UI.cancelled:
+        raise SystemExit(130)
+    if proc.returncode != 0:
+        if not show_raw:
+            _emit(f"    (command: {rendered})")
+        raise SystemExit(
+            f"That step failed (exit code {proc.returncode}). "
+            f"Command: {rendered}"
+        )
 
 
 def install_prerequisites(
@@ -242,30 +370,35 @@ def install_prerequisites(
     """Install missing CLI tools with the detected package manager."""
 
     if not missing:
-        print("All required tools are already installed.")
+        _emit("All required tools are already installed.")
         return
 
     descriptions = prerequisites()
-    print("These required tools aren't installed yet:")
+    _emit("These required tools aren't installed yet:")
     for command in missing:
-        print(f"  - {descriptions[command]}")
+        _emit(f"  - {descriptions[command]}")
 
     if package_manager is None:
-        print("")
-        print("Couldn't find a package manager to install them automatically.")
-        print("Please install the tools listed above, then re-run setup.")
+        _emit("")
+        _emit("Couldn't find a package manager to install them automatically.")
+        _emit("Please install the tools listed above, then re-run setup.")
         return
 
     if not assume_yes and not prompt_yes_no(
         f"Install them now with {package_manager.name}?", default=True
     ):
-        print("Skipping - install the tools above yourself, then re-run setup.")
+        _emit("Skipping - install the tools above yourself, then re-run setup.")
         return
 
     for command in missing:
         label = descriptions[command].split(" - ")[0]
         for install_command in package_manager.install_commands.get(command, []):
-            run_command(install_command, dry_run=dry_run, label=f"Installing {label}")
+            run_command(
+                install_command,
+                dry_run=dry_run,
+                label=f"Installing {label}",
+                interactive=True,
+            )
 
 
 def current_python_env() -> PythonEnv:
@@ -291,7 +424,7 @@ def _pip_flags() -> list[str]:
 
 
 def install_python_dependencies(env: PythonEnv, *, dry_run: bool) -> None:
-    print("Installing the Python packages the demo needs (this can take a minute).")
+    _emit("Installing the Python packages the demo needs (this can take a minute).")
     flags = _pip_flags()
     run_command(
         [str(env.python), "-m", "pip", "install", *flags, "--upgrade", "pip"],
@@ -391,8 +524,8 @@ def ensure_azure_login(deploy_env: str, *, dry_run: bool) -> None:
                 "PowerShell is required for auth.mode=azure_powershell but was "
                 "not found on PATH."
             )
-        print(f"Signing in to Azure tenant {tenant_id} with Azure PowerShell.")
-        run_command(login, dry_run=dry_run)
+        _emit(f"Signing in to Azure tenant {tenant_id} with Azure PowerShell.")
+        run_command(login, dry_run=dry_run, interactive=True)
         return
 
     az = _resolve_az()
@@ -401,8 +534,8 @@ def ensure_azure_login(deploy_env: str, *, dry_run: bool) -> None:
             "Azure CLI (az) is required for deploy but was not found on PATH. "
             "Install Azure CLI, or set deploy config auth.mode to azure_powershell."
         )
-    print(f"Signing in to Azure tenant {tenant_id}.")
-    run_command([az, "login", "--tenant", tenant_id], dry_run=dry_run)
+    _emit(f"Signing in to Azure tenant {tenant_id}.")
+    run_command([az, "login", "--tenant", tenant_id], dry_run=dry_run, interactive=True)
 
 
 def run_retail_setup(
@@ -419,6 +552,7 @@ def run_retail_setup(
         [str(env.python), "-m", "retail_setup.cli.main", "configure", "--env", deploy_env],
         dry_run=dry_run,
         label=f"Configuring the project for '{deploy_env}'",
+        interactive=True,
     )
     run_command(
         [str(env.python), "-m", "retail_setup.cli.main", "render", "--env", deploy_env],
@@ -429,17 +563,17 @@ def run_retail_setup(
     _section(4, 4, "Deploying to Microsoft Fabric (optional)")
     deploy = deploy_requested
     if not assume_yes and not deploy:
-        print("")
-        print("Deploying creates resources in Microsoft Fabric and may incur cost.")
-        print("You can also do it later with: retail-setup deploy --env " + deploy_env)
+        _emit("")
+        _emit("Deploying creates resources in Microsoft Fabric and may incur cost.")
+        _emit("You can also do it later with: retail-setup deploy --env " + deploy_env)
         deploy = prompt_yes_no("Deploy to Microsoft Fabric now?", default=False)
     if deploy:
         ensure_azure_login(deploy_env, dry_run=dry_run)
         if not dry_run:
-            print("")
-            print("Starting the interactive deploy. While it runs you'll see a live")
-            print("progress bar; press Esc to cancel (you'll be asked whether to remove")
-            print("any Fabric artifacts already created).")
+            _emit("")
+            _emit("Starting the interactive deploy. While it runs you'll see a live")
+            _emit("progress bar; press Esc to cancel (you'll be asked whether to remove")
+            _emit("any Fabric artifacts already created).")
         deploy_command = [
             str(env.python),
             "-m",
@@ -452,12 +586,12 @@ def run_retail_setup(
             deploy_command.append("--recreate")
         if assume_yes:
             deploy_command.append("--yes")
-        run_command(deploy_command, dry_run=dry_run)
+        run_command(deploy_command, dry_run=dry_run, interactive=True)
     else:
-        print("")
-        print("Skipping deploy for now. When you're ready:")
-        print("  retail-setup deploy --env " + deploy_env)
-        print(f"  Docs: {DOCS_URL}")
+        _emit("")
+        _emit("Skipping deploy for now. When you're ready:")
+        _emit("  retail-setup deploy --env " + deploy_env)
+        _emit(f"  Docs: {DOCS_URL}")
 
 
 def parse_args() -> argparse.Namespace:
@@ -491,11 +625,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> int:
-    global VERBOSE
-    args = parse_args()
-    VERBOSE = args.verbose
-
+def _run_guided(args: argparse.Namespace) -> int:
+    """Run the four guided setup steps (under the console when one is active)."""
     _banner(
         [
             "Retail Demo - Guided Setup",
@@ -507,16 +638,17 @@ def main() -> int:
             "  4. Optionally deploy to Microsoft Fabric",
         ]
     )
-    print(f"Environment: {args.env}   (change with --env)")
-    print(f"Project:     {REPO_ROOT}")
+    _emit(f"Environment: {args.env}   (change with --env)")
+    _emit(f"Project:     {REPO_ROOT}")
     if not args.verbose:
-        print("Tip: add --verbose to see the exact commands being run.")
+        _emit("Tip: add --verbose to see the exact commands being run.")
     if args.dry_run:
-        print("Dry run: showing what would happen without making changes.")
+        _emit("Dry run: showing what would happen without making changes.")
 
     total = 4
     if not args.skip_prereqs:
         _section(1, total, "Checking the required tools")
+        _check_cancelled()
         install_prerequisites(
             missing_prerequisites(),
             package_manager=detect_package_manager(),
@@ -527,9 +659,11 @@ def main() -> int:
         _section(1, total, "Checking the required tools (skipped)")
 
     _section(2, total, "Installing the Python packages")
+    _check_cancelled()
     env = current_python_env()
     install_python_dependencies(env, dry_run=args.dry_run)
 
+    _check_cancelled()
     run_retail_setup(
         env,
         deploy_env=args.env,
@@ -539,9 +673,33 @@ def main() -> int:
         recreate=args.recreate,
     )
 
-    print("")
-    print("Setup finished.")
+    if _UI is not None:
+        _UI.advance(completed=total)
+    _emit("")
+    _emit("Setup finished.")
     return 0
+
+
+def main() -> int:
+    global VERBOSE, _UI
+    args = parse_args()
+    VERBOSE = args.verbose
+
+    # A dry run prints the plan; a non-TTY/CI run stays plain. Otherwise drive the
+    # guided console: a scrolling log over a fixed footer with a smooth progress
+    # bar and an "esc to cancel or abort" hint.
+    console_cls = None if args.dry_run else _load_console()
+    if console_cls is None:
+        return _run_guided(args)
+
+    with console_cls(
+        4, title="Retail Demo - Guided Setup", hint="esc to cancel or abort"
+    ) as ui:
+        _UI = ui
+        try:
+            return _run_guided(args)
+        finally:
+            _UI = None
 
 
 if __name__ == "__main__":

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -50,23 +50,12 @@ def _check_cancelled() -> None:
         raise SystemExit(130)
 
 
-def _try_pip_install(package: str) -> bool:
-    """Best-effort, quiet install of a single package into this interpreter."""
-    try:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-q", package], check=True
-        )
-        return True
-    except Exception:
-        return False
-
-
 def _load_console() -> Any:
     """Return the guided ConsoleUI class for an interactive run, or None.
 
-    Imported lazily (installing ``alive-progress`` if needed) so this script
-    still runs on the standard library alone when there is no terminal or the
-    dependency is unavailable. Honors ``RETAIL_SETUP_NO_UI`` and requires a TTY.
+    Imported lazily so this script still runs on the standard library alone when
+    there is no terminal. The console itself has no third-party dependency.
+    Honors ``RETAIL_SETUP_NO_UI`` and requires a TTY.
     """
     if os.environ.get("RETAIL_SETUP_NO_UI", "").lower() in ("1", "true", "yes"):
         return None
@@ -75,11 +64,6 @@ def _load_console() -> Any:
             return None
     except Exception:
         return None
-    try:
-        import alive_progress  # noqa: F401
-    except Exception:
-        if not _try_pip_install("alive-progress"):
-            return None
     src = REPO_ROOT / "utility" / "src"
     if src.is_dir() and str(src) not in sys.path:
         sys.path.insert(0, str(src))

--- a/tests/scripts/test_setup_bootstrap.py
+++ b/tests/scripts/test_setup_bootstrap.py
@@ -222,3 +222,132 @@ def test_ensure_azure_login_noop_when_no_tenant(monkeypatch):
     setup.ensure_azure_login("dev", dry_run=False)
 
     assert commands == []
+
+
+# --- guided console (TTY) integration -------------------------------------- #
+import contextlib
+from types import SimpleNamespace
+
+
+class _FakeUI:
+    """Stand-in for retail_setup.cli.console.ConsoleUI."""
+
+    def __init__(self, *, answer=True, cancelled=False):
+        self.logs = []
+        self.phases = []
+        self.advances = []
+        self.paused_count = 0
+        self.entered = self.exited = False
+        self._answer = answer
+        self._cancelled = cancelled
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, *exc):
+        self.exited = True
+        return False
+
+    def log(self, text=""):
+        self.logs.append(text)
+
+    def set_phase(self, text):
+        self.phases.append(text)
+
+    def advance(self, *, completed=None, fraction=None):
+        self.advances.append(completed)
+
+    @property
+    def cancelled(self):
+        return self._cancelled
+
+    def prompt_yes_no(self, message, *, default=False):
+        return self._answer
+
+    @contextlib.contextmanager
+    def paused(self):
+        self.paused_count += 1
+        yield
+
+
+def test_emit_routes_to_active_ui(monkeypatch):
+    ui = _FakeUI()
+    monkeypatch.setattr(setup, "_UI", ui)
+    setup._emit("hello")
+    assert ui.logs == ["hello"]
+
+
+def test_section_advances_bar_when_ui_active(monkeypatch):
+    ui = _FakeUI()
+    monkeypatch.setattr(setup, "_UI", ui)
+    setup._section(3, 4, "Configuring the project")
+    assert ui.phases == ["Step 3/4: Configuring the project"]
+    assert ui.advances == [2]  # completed = step - 1
+
+
+def test_prompt_yes_no_delegates_to_ui(monkeypatch):
+    ui = _FakeUI(answer=False)
+    monkeypatch.setattr(setup, "_UI", ui)
+    assert setup.prompt_yes_no("ok?", default=True) is False
+
+
+def test_run_command_streams_output_when_ui_active(monkeypatch):
+    ui = _FakeUI()
+    monkeypatch.setattr(setup, "_UI", ui)
+
+    class _FakeProc:
+        def __init__(self):
+            self.stdout = iter(["line one\n", "line two\n"])
+            self.returncode = 0
+
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(setup.subprocess, "Popen", lambda *a, **k: _FakeProc())
+    setup.run_command(["pip", "install", "thing"], label="Installing thing")
+    assert "line one" in ui.logs and "line two" in ui.logs
+
+
+def test_run_command_pauses_for_interactive_when_ui_active(monkeypatch):
+    ui = _FakeUI()
+    monkeypatch.setattr(setup, "_UI", ui)
+    ran = []
+    monkeypatch.setattr(setup.subprocess, "run", lambda command, **k: ran.append(command))
+
+    setup.run_command(["az", "login"], interactive=True)
+
+    assert ran == [["az", "login"]]
+    assert ui.paused_count == 1  # bar paused so the child owns the terminal
+
+
+def test_load_console_returns_none_without_tty(monkeypatch):
+    # pytest's stdout is not a TTY, so the guided console must stay disabled.
+    monkeypatch.delenv("RETAIL_SETUP_NO_UI", raising=False)
+    assert setup._load_console() is None
+
+
+def test_load_console_disabled_by_env(monkeypatch):
+    monkeypatch.setenv("RETAIL_SETUP_NO_UI", "1")
+    assert setup._load_console() is None
+
+
+def test_main_drives_console_and_resets_ui(monkeypatch):
+    ui = _FakeUI()
+    monkeypatch.setattr(setup, "_load_console", lambda: (lambda *a, **k: ui))
+    monkeypatch.setattr(
+        setup, "parse_args",
+        lambda: SimpleNamespace(env="dev", dry_run=False, yes=True, deploy=False,
+                                recreate=False, skip_prereqs=True, verbose=False),
+    )
+    monkeypatch.setattr(setup, "current_python_env",
+                        lambda: setup.PythonEnv(Path("python"), "test"))
+    monkeypatch.setattr(setup, "install_python_dependencies", lambda *a, **k: None)
+    monkeypatch.setattr(setup, "run_retail_setup", lambda *a, **k: None)
+
+    rc = setup.main()
+
+    assert rc == 0
+    assert ui.entered and ui.exited
+    assert setup._UI is None  # reset after the run
+    assert any("Step 2/4" in p for p in ui.phases)

--- a/utility/pyproject.toml
+++ b/utility/pyproject.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 description = "Fabric-native setup utility: historical data generation + environment configuration"
 requires-python = ">=3.11"
 dependencies = [
-    "alive-progress>=3.1",
     "pydantic>=2.5",
     "pyyaml>=6.0",
     "typer>=0.12",

--- a/utility/src/retail_setup/cli/console.py
+++ b/utility/src/retail_setup/cli/console.py
@@ -44,27 +44,30 @@ _ANSI = {
 }
 
 # Dancing-shrug spinner frames, in the order requested: both up, left down, both
-# up, right down, both up, both down, both up, both down. ``¯`` is a raised hand;
-# dropping it to ``_`` lowers that arm.
+# up, right down, both up, both down, both up, both down. The whole arm swings —
+# the forearm slash flips and the hand/shoulder glyphs swap — so it reads as the
+# arm articulating at the shoulder rather than the hand dropping off.
+#   arm up   -> "¯\\_" (left) / "_/¯" (right)   hand high, forearm out
+#   arm down -> "_/¯" (left) / "¯\\_" (right)   hand low, forearm in
 _DANCE_UNICODE = (
-    "¯\\_(ツ)_/¯",  # both up
-    "_\\_(ツ)_/¯",  # left down
-    "¯\\_(ツ)_/¯",  # both up
-    "¯\\_(ツ)_/_",  # right down
-    "¯\\_(ツ)_/¯",  # both up
-    "_\\_(ツ)_/_",  # both down
-    "¯\\_(ツ)_/¯",  # both up
-    "_\\_(ツ)_/_",  # both down
+    "¯\\_(ツ)_/¯",   # both up
+    "_/¯(ツ)_/¯",   # left arm down, right up
+    "¯\\_(ツ)_/¯",   # both up
+    "¯\\_(ツ)¯\\_",  # right arm down, left up
+    "¯\\_(ツ)_/¯",   # both up
+    "_/¯(ツ)¯\\_",   # both down
+    "¯\\_(ツ)_/¯",   # both up
+    "_/¯(ツ)¯\\_",   # both down
 )
 _DANCE_ASCII = (
-    "\\o/",  # both up
-    "_o/",   # left down
-    "\\o/",  # both up
-    "\\o_",  # right down
-    "\\o/",  # both up
-    "_o_",   # both down
-    "\\o/",  # both up
-    "_o_",   # both down
+    "\\o/",   # both up
+    "/o/",    # left down, right up
+    "\\o/",   # both up
+    "\\o\\",  # right down, left up
+    "\\o/",   # both up
+    "/o\\",   # both down
+    "\\o/",   # both up
+    "/o\\",   # both down
 )
 
 

--- a/utility/src/retail_setup/cli/console.py
+++ b/utility/src/retail_setup/cli/console.py
@@ -132,6 +132,7 @@ class _Keyboard:
 
     # -- background ESC watcher ----------------------------------------------
     def start_watch(self) -> None:
+        self._stop.clear()  # re-arm after a previous stop_watch() (e.g. paused())
         if not self.available or self._thread is not None:
             return
         if self._impl == "posix" and not self._enter_cbreak():

--- a/utility/src/retail_setup/cli/console.py
+++ b/utility/src/retail_setup/cli/console.py
@@ -32,6 +32,34 @@ except Exception:  # pragma: no cover - exercised only when the dep is missing
 
 ESC = "\x1b"
 _DISABLE_ENV = "RETAIL_SETUP_NO_UI"
+_NO_COLOR = "NO_COLOR"
+
+# Copilot-style accent colors (ANSI). Applied only to the title/footer text we
+# render ourselves; the bar fill and spinner stay the terminal default so
+# alive_progress's width math is never thrown off by invisible escape codes.
+_ANSI = {
+    "green": "\033[1;32m",
+    "cyan": "\033[36m",
+    "dim": "\033[2m",
+    "reset": "\033[0m",
+}
+
+
+def _dancing_spinner(ascii_only: bool) -> Any:
+    """A little person dancing at the end of the line while work happens.
+
+    Frames are passed as a single tuple so each full string is one frame (a bare
+    multi-char string would instead animate character-by-character). Falls back
+    to a plain ASCII dancer on legacy code pages that can't render the shrug.
+    """
+    from alive_progress.animations.spinners import frame_spinner_factory
+
+    if ascii_only:
+        # arms wave up -> out -> down -> out
+        return frame_spinner_factory(("\\o/", "|o|", "/o\\", "|o|"))
+    # the classic shrug, arms flapping up then down so it looks like it's dancing
+    return frame_spinner_factory(("¯\\_(ツ)_/¯", "_/¯(ツ)¯\\_"))
+
 
 
 # --------------------------------------------------------------------------- #
@@ -213,6 +241,7 @@ class ConsoleUI:
         self._stream = stream or sys.stdout
         self._force_tty = force_tty
         self.enabled = self._decide_enabled(enabled)
+        self._color = self._supports_color()
         self._bar: Any = None
         self._bar_cm: Any = None
         self._cancel = threading.Event()
@@ -246,6 +275,19 @@ class ConsoleUI:
         enc = (getattr(self._stream, "encoding", "") or "").lower()
         return "utf" not in enc
 
+    def _supports_color(self) -> bool:
+        # Color only when the live bar is shown; honor the NO_COLOR convention.
+        if os.environ.get(_NO_COLOR) is not None:
+            return False
+        return self.enabled
+
+    def _style(self, text: str, *names: str) -> str:
+        """Wrap ``text`` in ANSI styles when color is enabled."""
+        if not self._color or not text:
+            return text
+        prefix = "".join(_ANSI[name] for name in names)
+        return f"{prefix}{text}{_ANSI['reset']}"
+
     def __enter__(self) -> "ConsoleUI":
         if not self.enabled:
             if self.title:
@@ -253,7 +295,7 @@ class ConsoleUI:
             return self
         options: dict[str, Any] = dict(
             manual=True,
-            title=self.title,
+            title=self._style(self.title, "green"),
             enrich_print=False,
             receipt=False,
             dual_line=True,
@@ -266,7 +308,11 @@ class ConsoleUI:
             options["force_tty"] = self._force_tty
         if self._ascii:
             options["bar"] = "classic"
-            options["spinner"] = "classic"
+        try:
+            options["spinner"] = _dancing_spinner(self._ascii)
+        except Exception:
+            if self._ascii:
+                options["spinner"] = "classic"
         self._bar_cm = alive_bar(self.total_steps, **options)
         self._bar = self._bar_cm.__enter__()
         self._refresh_footer()
@@ -294,7 +340,7 @@ class ConsoleUI:
     def set_phase(self, text: str) -> None:
         if self._bar is not None:
             try:
-                self._bar.title = text
+                self._bar.title = self._style(text, "green")
             except Exception:
                 pass
         elif not self.enabled:
@@ -320,7 +366,11 @@ class ConsoleUI:
     def _refresh_footer(self) -> None:
         if self._bar is None:
             return
-        parts = [p for p in (self._status, self.hint) if p]
+        parts = []
+        if self._status:
+            parts.append(self._style(self._status, "cyan"))
+        if self.hint:
+            parts.append(self._style(self.hint, "dim"))
         try:
             self._bar.text("  ·  ".join(parts))
         except Exception:

--- a/utility/src/retail_setup/cli/console.py
+++ b/utility/src/retail_setup/cli/console.py
@@ -334,8 +334,17 @@ class ConsoleUI:
 
     # -- output --------------------------------------------------------------
     def log(self, message: str = "") -> None:
-        """Write a line to the scrolling region above the footer."""
-        print(message, file=self._stream)
+        """Write a line to the scrolling region above the footer.
+
+        When the bar is live, alive_progress has replaced ``sys.stdout`` with a
+        hook that scrolls printed lines above the bar and keeps the bar pinned to
+        the bottom. We must print through that hooked ``sys.stdout`` (not the
+        original stream captured at init) or the line collides with the bar.
+        """
+        if self._bar is not None:
+            print(message)
+        else:
+            print(message, file=self._stream)
 
     def set_phase(self, text: str) -> None:
         if self._bar is not None:

--- a/utility/src/retail_setup/cli/console.py
+++ b/utility/src/retail_setup/cli/console.py
@@ -519,11 +519,14 @@ class ConsoleUI:
     # -- pausing for interactive child processes -----------------------------
     @contextmanager
     def paused(self) -> Iterator[None]:
-        """Freeze the panel and release the terminal/keyboard to a child process.
+        """Release the whole terminal to an interactive child process.
 
-        The fixed footer stays drawn (so it isn't lost), but the spinner stops
-        animating and ESC watching pauses so the child can read stdin and print
-        in the scroll region above the panel.
+        A child process (``configure``'s many prompts, or ``deploy`` with its own
+        console) can't share our fixed footer, and its output would otherwise
+        collide with or overflow into the panel. So we tear the panel down — drop
+        the scroll region, clear the reserved lines, show the cursor — giving the
+        child a normal full-height terminal. The bar, separator, and footer are
+        rebuilt as soon as the child returns.
         """
         if not self._active:
             yield
@@ -535,11 +538,22 @@ class ConsoleUI:
         if self._keyboard is not None:
             self._keyboard.pause()
             self._keyboard.stop_watch()
+        with self._lock:
+            self._write(f"{CSI}r")  # release the scroll region
+            for row in (self._rows - 2, self._rows - 1, self._rows):
+                self._write(f"{CSI}{row};1H{CSI}2K")  # clear the panel rows
+            self._write(f"{CSI}{self._rows - 2};1H")  # cursor where the panel was
+            self._write(f"{CSI}?25h")  # show cursor for the child
+            self._flush()
         try:
             yield
         finally:
             with self._lock:
                 self._cols, self._rows = self._term_size()
+                self._write(f"{CSI}?25l")  # hide cursor again
+                region_bottom = self._rows - _PANEL_LINES
+                self._write(f"{CSI}{1};{region_bottom}r")  # re-establish region
+                self._write(f"{CSI}{region_bottom};1H")  # park cursor in the region
                 self._draw_panel()
                 self._flush()
             if self._keyboard is not None:

--- a/utility/src/retail_setup/cli/console.py
+++ b/utility/src/retail_setup/cli/console.py
@@ -339,6 +339,17 @@ class ConsoleUI:
 
     # -- prompts -------------------------------------------------------------
     @contextmanager
+    def paused(self) -> Iterator[None]:
+        """Public context manager: suspend the bar and ESC watcher.
+
+        Use it to hand the terminal to an interactive child process (e.g. a
+        subprocess that prompts or renders its own console); the bar resumes when
+        the context exits.
+        """
+        with self._paused():
+            yield
+
+    @contextmanager
     def _paused(self) -> Iterator[None]:
         if self._watcher is not None:
             self._watcher.pause()

--- a/utility/src/retail_setup/cli/console.py
+++ b/utility/src/retail_setup/cli/console.py
@@ -1,17 +1,21 @@
-"""Interactive terminal console for the guided deploy.
+"""Interactive terminal console for the guided setup and deploy.
 
-Provides a Copilot-CLI-style experience: a scrolling log region on top and a
-fixed status footer on the bottom with a smooth `alive_progress` bar, a phase
-title, an "esc to cancel or abort" hint, and an inline prompt area that is only
-active while a question is being asked.
+Provides a Copilot-CLI-style experience implemented with plain ANSI terminal
+control (no third-party dependency): a scrolling log region on top and a fixed
+bottom panel pinned to the last three lines:
 
-The console degrades gracefully: when stdout/stdin are not a TTY (CI, pipes,
-tests) or when `alive_progress` is unavailable, it falls back to plain prints
-and `input()` so existing non-interactive behaviour is unchanged.
+    <scrolling output ...>
+    ────────────────────────────  (colored separator)
+    Step 2/4: Installing …  |█████      |  ¯\\_(ツ)_/¯  50%   (progress bar + dancer)
+    esc to cancel or abort        (footer; captures input when a prompt is active)
 
-Key handling (ESC -> cancel) is implemented for Windows (``msvcrt``) and POSIX
-(``termios``/``select``). If raw-key support cannot be set up, ESC watching is
-disabled but everything else still works.
+The fixed panel uses a terminal scroll region (DECSTBM), so printed output
+scrolls above it while the bar, separator, and footer stay put. When a prompt is
+needed, the question and the text being typed are shown in the footer itself.
+
+Everything degrades gracefully: when stdout/stdin are not a TTY (CI, pipes,
+tests) or the terminal can't be driven, the console falls back to plain prints
+and ``input()`` so non-interactive behaviour is unchanged.
 """
 
 from __future__ import annotations
@@ -21,22 +25,17 @@ import sys
 import threading
 import time
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, Optional, TextIO
-
-try:  # alive_progress is a runtime dependency, but never required for fallback.
-    from alive_progress import alive_bar  # type: ignore[import-untyped]
-
-    _HAVE_ALIVE = True
-except Exception:  # pragma: no cover - exercised only when the dep is missing
-    _HAVE_ALIVE = False
+from typing import Any, Iterator, Optional, TextIO, Tuple
 
 ESC = "\x1b"
+CSI = "\x1b["
 _DISABLE_ENV = "RETAIL_SETUP_NO_UI"
 _NO_COLOR = "NO_COLOR"
 
-# Copilot-style accent colors (ANSI). Applied only to the title/footer text we
-# render ourselves; the bar fill and spinner stay the terminal default so
-# alive_progress's width math is never thrown off by invisible escape codes.
+# Reserved fixed-panel lines at the bottom: separator, bar, footer.
+_PANEL_LINES = 3
+
+# Copilot-style accent colors (ANSI).
 _ANSI = {
     "green": "\033[1;32m",
     "cyan": "\033[36m",
@@ -44,44 +43,67 @@ _ANSI = {
     "reset": "\033[0m",
 }
 
+# Dancing-shrug spinner frames, in the order requested: both up, left down, both
+# up, right down, both up, both down, both up, both down. ``¯`` is a raised hand;
+# dropping it to ``_`` lowers that arm.
+_DANCE_UNICODE = (
+    "¯\\_(ツ)_/¯",  # both up
+    "_\\_(ツ)_/¯",  # left down
+    "¯\\_(ツ)_/¯",  # both up
+    "¯\\_(ツ)_/_",  # right down
+    "¯\\_(ツ)_/¯",  # both up
+    "_\\_(ツ)_/_",  # both down
+    "¯\\_(ツ)_/¯",  # both up
+    "_\\_(ツ)_/_",  # both down
+)
+_DANCE_ASCII = (
+    "\\o/",  # both up
+    "_o/",   # left down
+    "\\o/",  # both up
+    "\\o_",  # right down
+    "\\o/",  # both up
+    "_o_",   # both down
+    "\\o/",  # both up
+    "_o_",   # both down
+)
 
-def _dancing_spinner(ascii_only: bool) -> Any:
-    """A little person dancing at the end of the line while work happens.
 
-    Frames are passed as a single tuple so each full string is one frame (a bare
-    multi-char string would instead animate character-by-character). Falls back
-    to a plain ASCII dancer on legacy code pages that can't render the shrug.
-    """
-    from alive_progress.animations.spinners import frame_spinner_factory
+def enable_windows_vt() -> None:
+    """Best-effort enable of ANSI/VT processing on a Windows console."""
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
 
-    if ascii_only:
-        # arms wave up -> out -> down -> out
-        return frame_spinner_factory(("\\o/", "|o|", "/o\\", "|o|"))
-    # the classic shrug, arms flapping up then down so it looks like it's dancing
-    return frame_spinner_factory(("¯\\_(ツ)_/¯", "_/¯(ツ)¯\\_"))
-
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        mode = ctypes.c_uint()
+        if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            kernel32.SetConsoleMode(handle, mode.value | 0x0004)  # ENABLE_VT
+    except Exception:
+        pass
 
 
 # --------------------------------------------------------------------------- #
-# Platform key readers
+# Cross-platform key reading
 # --------------------------------------------------------------------------- #
-class _KeyWatcher:
-    """Background watcher that invokes ``on_escape`` when ESC is pressed.
+class _Keyboard:
+    """Reads keys for ESC-to-cancel watching and in-footer line editing.
 
-    The watcher can be paused (so ``input()`` prompts read normally) and resumed.
-    All terminal-mode juggling is guarded; on any failure the watcher disables
-    itself rather than risk corrupting the terminal.
+    A background thread watches for ESC while work runs. For prompts the thread
+    is paused and keys are read synchronously so the typed characters can be
+    echoed into the footer. All raw-mode juggling is guarded; on failure the
+    keyboard disables itself rather than risk corrupting the terminal.
     """
 
-    def __init__(self, on_escape: Callable[[], None]) -> None:
+    def __init__(self, on_escape) -> None:
         self._on_escape = on_escape
+        self._impl = self._select_impl()
         self._stop = threading.Event()
         self._paused = threading.Event()
         self._thread: Optional[threading.Thread] = None
-        self._impl = self._select_impl()
-        # POSIX termios state
         self._fd: Optional[int] = None
-        self._old_term = None
+        self._old_term: Any = None
 
     def _select_impl(self) -> Optional[str]:
         if not sys.stdin or not sys.stdin.isatty():
@@ -105,16 +127,17 @@ class _KeyWatcher:
     def available(self) -> bool:
         return self._impl is not None
 
-    def start(self) -> None:
+    # -- background ESC watcher ----------------------------------------------
+    def start_watch(self) -> None:
         if not self.available or self._thread is not None:
             return
         if self._impl == "posix" and not self._enter_cbreak():
             self._impl = None
             return
-        self._thread = threading.Thread(target=self._run, name="esc-watch", daemon=True)
+        self._thread = threading.Thread(target=self._watch, name="esc-watch", daemon=True)
         self._thread.start()
 
-    def stop(self) -> None:
+    def stop_watch(self) -> None:
         self._stop.set()
         if self._thread is not None:
             self._thread.join(timeout=0.5)
@@ -123,14 +146,19 @@ class _KeyWatcher:
 
     def pause(self) -> None:
         self._paused.set()
-        self._exit_cbreak()
 
     def resume(self) -> None:
-        if self._impl == "posix":
-            self._enter_cbreak()
         self._paused.clear()
 
-    # -- POSIX termios helpers ------------------------------------------------
+    def _watch(self) -> None:
+        while not self._stop.is_set():
+            if self._paused.is_set():
+                time.sleep(0.05)
+                continue
+            if self._read_key(0.12) == ESC:
+                self._on_escape()
+
+    # -- POSIX termios helpers -----------------------------------------------
     def _enter_cbreak(self) -> bool:
         if self._impl != "posix":
             return True
@@ -151,36 +179,27 @@ class _KeyWatcher:
             try:
                 import termios
 
-                termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old_term)
+                termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old_term)  # type: ignore[attr-defined]
             except Exception:
                 pass
             self._old_term = None
 
-    # -- reader loop ----------------------------------------------------------
-    def _run(self) -> None:
-        while not self._stop.is_set():
-            if self._paused.is_set():
-                time.sleep(0.05)
-                continue
-            ch = self._read_key(0.1)
-            if ch == ESC:
-                self._on_escape()
-
+    # -- raw key read --------------------------------------------------------
     def _read_key(self, timeout: float) -> Optional[str]:
         if self._impl == "windows":
-            return self._read_key_windows(timeout)
+            return self._read_windows(timeout)
         if self._impl == "posix":
-            return self._read_key_posix(timeout)
+            return self._read_posix(timeout)
         return None
 
-    def _read_key_windows(self, timeout: float) -> Optional[str]:
+    def _read_windows(self, timeout: float) -> Optional[str]:
         import msvcrt
 
         end = time.time() + timeout
         while time.time() < end:
             if msvcrt.kbhit():
                 ch = msvcrt.getwch()
-                if ch in ("\x00", "\xe0"):  # function/arrow key: consume the rest
+                if ch in ("\x00", "\xe0"):  # function/arrow key prefix
                     if msvcrt.kbhit():
                         msvcrt.getwch()
                     return None
@@ -188,7 +207,7 @@ class _KeyWatcher:
             time.sleep(0.01)
         return None
 
-    def _read_key_posix(self, timeout: float) -> Optional[str]:
+    def _read_posix(self, timeout: float) -> Optional[str]:
         import select
 
         ready, _, _ = select.select([sys.stdin], [], [], timeout)
@@ -196,34 +215,51 @@ class _KeyWatcher:
             return None
         ch = sys.stdin.read(1)
         if ch == ESC:
-            # Distinguish a bare ESC from an escape sequence (arrow keys send
-            # ESC '[' ...). If more bytes follow immediately, drain and ignore.
             more, _, _ = select.select([sys.stdin], [], [], 0.02)
-            if more:
+            if more:  # an escape sequence (arrow key, etc.) -> drain and ignore
                 try:
                     sys.stdin.read(2)
                 except Exception:
                     pass
                 return None
-            return ESC
         return ch
+
+    def read_key_blocking(self) -> Optional[str]:
+        """Read one key, blocking until one is available (for footer prompts)."""
+        while not self._stop.is_set():
+            key = self._read_key(0.2)
+            if key is not None:
+                return key
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Line-edit logic (pure, unit-testable)
+# --------------------------------------------------------------------------- #
+def edit_buffer(buffer: str, key: str) -> Tuple[str, str]:
+    """Apply a key to an input ``buffer``.
+
+    Returns ``(new_buffer, status)`` where status is one of ``"edit"`` (keep
+    going), ``"submit"`` (Enter pressed) or ``"cancel"`` (Esc pressed).
+    """
+    if key in ("\r", "\n"):
+        return buffer, "submit"
+    if key == ESC:
+        return buffer, "cancel"
+    if key in ("\x7f", "\b"):  # backspace / delete
+        return buffer[:-1], "edit"
+    if key == "\x03":  # Ctrl-C
+        return buffer, "cancel"
+    if key.isprintable():
+        return buffer + key, "edit"
+    return buffer, "edit"
 
 
 # --------------------------------------------------------------------------- #
 # Console
 # --------------------------------------------------------------------------- #
 class ConsoleUI:
-    """Scrolling-log + fixed-footer console backed by ``alive_progress``.
-
-    Use as a context manager::
-
-        with ConsoleUI(total_steps, title="Deploy") as ui:
-            ui.set_phase("Step 1/5: ...")
-            ui.log("output line")
-            ui.advance(completed=1)
-            if ui.cancelled:
-                ...
-    """
+    """Scrolling-log + fixed-footer console driven with plain ANSI."""
 
     def __init__(
         self,
@@ -234,38 +270,51 @@ class ConsoleUI:
         force_tty: Optional[bool] = None,
         stream: Optional[TextIO] = None,
         hint: str = "esc to cancel or abort",
+        size: Optional[Tuple[int, int]] = None,
     ) -> None:
         self.total_steps = max(1, total_steps)
         self.title = title
         self.hint = hint
         self._stream = stream or sys.stdout
         self._force_tty = force_tty
+        self._size_override = size
         self.enabled = self._decide_enabled(enabled)
         self._color = self._supports_color()
-        self._bar: Any = None
-        self._bar_cm: Any = None
-        self._cancel = threading.Event()
-        self._status = ""
-        self._completed = 0
-        self._watcher = _KeyWatcher(self._cancel.set) if self.enabled else None
         self._ascii = self._needs_ascii()
+        self._frames = _DANCE_ASCII if self._ascii else _DANCE_UNICODE
 
-    # -- setup ---------------------------------------------------------------
+        self._active = False
+        self._lock = threading.RLock()
+        self._cancel = threading.Event()
+        self._frame = 0
+        self._percent = 0.0
+        self._completed = 0
+        self._phase = title
+        self._status = ""
+        self._prompt: Optional[dict] = None  # {"label": str, "buffer": str, "mask": bool}
+        self._cols = 80
+        self._rows = 24
+        self._render_stop = threading.Event()
+        self._render_thread: Optional[threading.Thread] = None
+        self._keyboard = _Keyboard(self._cancel.set) if self.enabled else None
+
+    # -- capabilities --------------------------------------------------------
     def _decide_enabled(self, enabled: Optional[bool]) -> bool:
-        if enabled is not None:
-            return enabled and _HAVE_ALIVE
-        if not _HAVE_ALIVE:
-            return False
         if os.environ.get(_DISABLE_ENV, "").lower() in ("1", "true", "yes"):
             return False
+        if enabled is not None:
+            return enabled
         try:
             return bool(self._stream.isatty() and sys.stdin.isatty())
         except Exception:
             return False
 
+    def _supports_color(self) -> bool:
+        if os.environ.get(_NO_COLOR) is not None:
+            return False
+        return self.enabled
+
     def _needs_ascii(self) -> bool:
-        # Try to use UTF-8 so the smooth bar glyphs render; fall back to ASCII
-        # styles on legacy code pages (e.g. Windows cp1252).
         reconfigure = getattr(self._stream, "reconfigure", None)
         if reconfigure is not None:
             try:
@@ -275,115 +324,183 @@ class ConsoleUI:
         enc = (getattr(self._stream, "encoding", "") or "").lower()
         return "utf" not in enc
 
-    def _supports_color(self) -> bool:
-        # Color only when the live bar is shown; honor the NO_COLOR convention.
-        if os.environ.get(_NO_COLOR) is not None:
-            return False
-        return self.enabled
+    def _term_size(self) -> Tuple[int, int]:
+        if self._size_override is not None:
+            return self._size_override
+        try:
+            size = os.get_terminal_size()
+            return size.columns, size.lines
+        except Exception:
+            return 80, 24
+
+    # -- low-level writes ----------------------------------------------------
+    def _write(self, text: str) -> None:
+        try:
+            self._stream.write(text)
+        except Exception:
+            pass
+
+    def _flush(self) -> None:
+        try:
+            self._stream.flush()
+        except Exception:
+            pass
 
     def _style(self, text: str, *names: str) -> str:
-        """Wrap ``text`` in ANSI styles when color is enabled."""
         if not self._color or not text:
             return text
         prefix = "".join(_ANSI[name] for name in names)
         return f"{prefix}{text}{_ANSI['reset']}"
 
+    # -- context management --------------------------------------------------
     def __enter__(self) -> "ConsoleUI":
         if not self.enabled:
             if self.title:
                 print(self.title, file=self._stream)
             return self
-        options: dict[str, Any] = dict(
-            manual=True,
-            title=self._style(self.title, "green"),
-            enrich_print=False,
-            receipt=False,
-            dual_line=True,
-            stats=False,
-            monitor="{percent:.0%}",
-            elapsed=False,
-            file=self._stream,
+        enable_windows_vt()
+        self._cols, self._rows = self._term_size()
+        if self._rows < _PANEL_LINES + 2:  # too short for a panel
+            self.enabled = False
+            if self.title:
+                print(self.title, file=self._stream)
+            return self
+        self._active = True
+        region_bottom = self._rows - _PANEL_LINES
+        # Reserve the bottom panel: set the scroll region above it, hide cursor,
+        # and park the cursor at the bottom of the scroll region.
+        self._write(f"{CSI}?25l")  # hide cursor
+        self._write(f"{CSI}{1};{region_bottom}r")  # DECSTBM scroll region
+        self._write(f"{CSI}{region_bottom};1H")  # move into the region
+        self._draw_panel()
+        self._flush()
+        if self._keyboard is not None:
+            self._keyboard.start_watch()
+        self._render_thread = threading.Thread(
+            target=self._render_loop, name="ui-render", daemon=True
         )
-        if self._force_tty is not None:
-            options["force_tty"] = self._force_tty
-        if self._ascii:
-            options["bar"] = "classic"
-        try:
-            options["spinner"] = _dancing_spinner(self._ascii)
-        except Exception:
-            if self._ascii:
-                options["spinner"] = "classic"
-        self._bar_cm = alive_bar(self.total_steps, **options)
-        self._bar = self._bar_cm.__enter__()
-        self._refresh_footer()
-        if self._watcher is not None:
-            self._watcher.start()
+        self._render_thread.start()
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
-        if self._watcher is not None:
-            self._watcher.stop()
-        if self._bar_cm is not None:
-            try:
-                self._bar(1.0)
-            except Exception:
-                pass
-            self._bar_cm.__exit__(exc_type, exc, tb)
-            self._bar_cm = None
-            self._bar = None
+        if not self._active:
+            return
+        self._render_stop.set()
+        if self._render_thread is not None:
+            self._render_thread.join(timeout=0.5)
+        if self._keyboard is not None:
+            self._keyboard.stop_watch()
+        with self._lock:
+            # Drop the scroll region, move below the panel, show the cursor.
+            self._write(f"{CSI}r")
+            self._write(f"{CSI}{self._rows};1H")
+            self._write(f"{CSI}?25h")
+            self._write("\n")
+            self._flush()
+        self._active = False
 
-    # -- output --------------------------------------------------------------
-    def log(self, message: str = "") -> None:
-        """Write a line to the scrolling region above the footer.
+    # -- rendering -----------------------------------------------------------
+    def _render_loop(self) -> None:
+        while not self._render_stop.wait(0.18):
+            with self._lock:
+                self._frame = (self._frame + 1) % len(self._frames)
+                self._draw_panel()
+                self._flush()
 
-        When the bar is live, alive_progress has replaced ``sys.stdout`` with a
-        hook that scrolls printed lines above the bar and keeps the bar pinned to
-        the bottom. We must print through that hooked ``sys.stdout`` (not the
-        original stream captured at init) or the line collides with the bar.
-        """
-        if self._bar is not None:
-            print(message)
+    def _bar_line(self) -> str:
+        spinner = self._frames[self._frame]
+        percent = f"{int(round(self._percent * 100)):>3d}%"
+        title = self._phase or self.title
+        # Reserve columns for spinner + percent + separators; the rest is the bar.
+        fixed = len(spinner) + len(percent) + 6  # spaces and brackets
+        avail = max(10, self._cols - fixed)
+        title_max = max(0, avail // 2)
+        if len(title) > title_max:
+            title = title[: max(0, title_max - 1)] + "…"
+        bar_width = max(4, avail - len(title) - 1)
+        filled = int(round(bar_width * min(1.0, max(0.0, self._percent))))
+        if self._ascii:
+            bar = "#" * filled + "-" * (bar_width - filled)
         else:
-            print(message, file=self._stream)
+            bar = "█" * filled + "░" * (bar_width - filled)
+        bar = self._style(bar, "green")
+        title_txt = self._style(title, "green")
+        return f"{title_txt} |{bar}| {spinner} {percent}"
 
-    def set_phase(self, text: str) -> None:
-        if self._bar is not None:
-            try:
-                self._bar.title = self._style(text, "green")
-            except Exception:
-                pass
-        elif not self.enabled:
-            print(text, file=self._stream)
-        self._refresh_footer()
-
-    def status(self, text: str) -> None:
-        self._status = text
-        self._refresh_footer()
-
-    def advance(self, *, completed: Optional[int] = None, fraction: Optional[float] = None) -> None:
-        if completed is not None:
-            self._completed = completed
-        if self._bar is None:
-            return
-        frac = fraction if fraction is not None else self._completed / self.total_steps
-        frac = min(1.0, max(0.0, frac))
-        try:
-            self._bar(frac)
-        except Exception:
-            pass
-
-    def _refresh_footer(self) -> None:
-        if self._bar is None:
-            return
+    def _footer_line(self) -> Tuple[str, int]:
+        """Return (text, cursor_col). cursor_col is 1-based, 0 if no prompt."""
+        if self._prompt is not None:
+            label = self._prompt["label"]
+            shown = "*" * len(self._prompt["buffer"]) if self._prompt["mask"] else self._prompt["buffer"]
+            text = f"{label}{shown}"
+            return text, len(text) + 1
         parts = []
         if self._status:
             parts.append(self._style(self._status, "cyan"))
         if self.hint:
             parts.append(self._style(self.hint, "dim"))
-        try:
-            self._bar.text("  ·  ".join(parts))
-        except Exception:
-            pass
+        return "  ·  ".join(parts), 0
+
+    def _separator(self) -> str:
+        rule = ("-" if self._ascii else "─") * max(1, self._cols)
+        return self._style(rule, "green")
+
+    def _draw_panel(self) -> None:
+        if not self._active:
+            return
+        sep_row = self._rows - 2
+        bar_row = self._rows - 1
+        foot_row = self._rows
+        footer_text, cursor_col = self._footer_line()
+        out = [f"{CSI}s"]  # save cursor
+        out.append(f"{CSI}{sep_row};1H{CSI}2K{self._separator()}")
+        out.append(f"{CSI}{bar_row};1H{CSI}2K{self._bar_line()}")
+        out.append(f"{CSI}{foot_row};1H{CSI}2K{footer_text}")
+        if cursor_col:  # a prompt is active: leave the cursor in the footer
+            out.append(f"{CSI}{foot_row};{cursor_col}H{CSI}?25h")
+        else:
+            out.append(f"{CSI}u")  # restore cursor to the scroll region
+        self._write("".join(out))
+
+    # -- output --------------------------------------------------------------
+    def log(self, message: str = "") -> None:
+        if not self._active:
+            print(message, file=self._stream)
+            return
+        with self._lock:
+            for line in str(message).split("\n"):
+                self._write(f"{line}\n")
+            self._flush()
+
+    def set_phase(self, text: str) -> None:
+        if not self._active:
+            if not self.enabled:
+                print(text, file=self._stream)
+            return
+        with self._lock:
+            self._phase = text
+            self._draw_panel()
+            self._flush()
+
+    def status(self, text: str) -> None:
+        self._status = text
+        if self._active:
+            with self._lock:
+                self._draw_panel()
+                self._flush()
+
+    def advance(self, *, completed: Optional[int] = None, fraction: Optional[float] = None) -> None:
+        if completed is not None:
+            self._completed = completed
+        if fraction is not None:
+            self._percent = fraction
+        else:
+            self._percent = self._completed / self.total_steps
+        self._percent = min(1.0, max(0.0, self._percent))
+        if self._active:
+            with self._lock:
+                self._draw_panel()
+                self._flush()
 
     # -- cancellation --------------------------------------------------------
     @property
@@ -396,50 +513,112 @@ class ConsoleUI:
     def reset_cancel(self) -> None:
         self._cancel.clear()
 
-    # -- prompts -------------------------------------------------------------
+    # -- pausing for interactive child processes -----------------------------
     @contextmanager
     def paused(self) -> Iterator[None]:
-        """Public context manager: suspend the bar and ESC watcher.
+        """Freeze the panel and release the terminal/keyboard to a child process.
 
-        Use it to hand the terminal to an interactive child process (e.g. a
-        subprocess that prompts or renders its own console); the bar resumes when
-        the context exits.
+        The fixed footer stays drawn (so it isn't lost), but the spinner stops
+        animating and ESC watching pauses so the child can read stdin and print
+        in the scroll region above the panel.
         """
-        with self._paused():
+        if not self._active:
             yield
-
-    @contextmanager
-    def _paused(self) -> Iterator[None]:
-        if self._watcher is not None:
-            self._watcher.pause()
+            return
+        self._render_stop.set()
+        if self._render_thread is not None:
+            self._render_thread.join(timeout=0.5)
+            self._render_thread = None
+        if self._keyboard is not None:
+            self._keyboard.pause()
+            self._keyboard.stop_watch()
         try:
-            if self._bar is not None:
-                try:
-                    with self._bar.pause():
-                        yield
-                except Exception:
-                    yield
-            else:
-                yield
+            yield
         finally:
-            if self._watcher is not None:
-                self._watcher.resume()
+            with self._lock:
+                self._cols, self._rows = self._term_size()
+                self._draw_panel()
+                self._flush()
+            if self._keyboard is not None:
+                self._keyboard.resume()
+                self._keyboard.start_watch()
+            self._render_stop.clear()
+            self._render_thread = threading.Thread(
+                target=self._render_loop, name="ui-render", daemon=True
+            )
+            self._render_thread.start()
 
+    # -- prompts -------------------------------------------------------------
     def prompt_yes_no(self, question: str, *, default: bool = False) -> bool:
-        if not self.enabled:
+        if not self._active:
             return _plain_yes_no(question, default, self._stream)
-        with self._paused():
-            return _plain_yes_no(question, default, self._stream)
+        suffix = "Y/n" if default else "y/N"
+        while True:
+            answer = self._read_in_footer(f"{question} [{suffix}]: ").strip().lower()
+            if self.cancelled:
+                return default
+            if not answer:
+                return default
+            if answer in ("y", "yes"):
+                return True
+            if answer in ("n", "no"):
+                return False
 
     def prompt_text(self, question: str, *, default: Optional[str] = None) -> str:
-        if not self.enabled:
+        if not self._active:
             return _plain_text(question, default, self._stream)
-        with self._paused():
-            return _plain_text(question, default, self._stream)
+        label = f"{question} [{default}]: " if default is not None else f"{question}: "
+        answer = self._read_in_footer(label).strip()
+        if self.cancelled:
+            return default or ""
+        return answer or (default or "")
+
+    def _read_in_footer(self, label: str) -> str:
+        """Capture a line of input in the fixed footer, echoing as typed."""
+        if self._keyboard is None or not self._keyboard.available:
+            # Can't read raw keys; fall back to a normal prompt line.
+            with self.paused():
+                try:
+                    return input(label)
+                except EOFError:
+                    return ""
+        # Pause the background watcher so we own the keystrokes; keep the spinner
+        # animating in the bar via the render thread.
+        self._keyboard.pause()
+        try:
+            with self._lock:
+                self._prompt = {"label": label, "buffer": "", "mask": False}
+                self._draw_panel()
+                self._flush()
+            result = ""
+            while True:
+                key = self._keyboard.read_key_blocking()
+                if key is None:
+                    break
+                new_buffer, state = edit_buffer(self._prompt["buffer"], key)
+                if state == "submit":
+                    result = self._prompt["buffer"]
+                    break
+                if state == "cancel":
+                    self._cancel.set()
+                    result = ""
+                    break
+                with self._lock:
+                    self._prompt["buffer"] = new_buffer
+                    self._draw_panel()
+                    self._flush()
+            return result
+        finally:
+            with self._lock:
+                self._prompt = None
+                self._write(f"{CSI}?25l")  # hide cursor again
+                self._draw_panel()
+                self._flush()
+            self._keyboard.resume()
 
 
 # --------------------------------------------------------------------------- #
-# Plain-mode prompt helpers (also used by the fallback path)
+# Plain-mode prompt helpers (fallback + tests)
 # --------------------------------------------------------------------------- #
 def _plain_yes_no(question: str, default: bool, stream: TextIO) -> bool:
     suffix = "Y/n" if default else "y/N"
@@ -467,8 +646,8 @@ def _plain_text(question: str, default: Optional[str], stream: TextIO) -> str:
 
 
 def use_rich_ui(*, dry_run: bool, stream: Optional[TextIO] = None) -> bool:
-    """Whether the rich interactive console should be used for this run."""
-    if dry_run or not _HAVE_ALIVE:
+    """Whether the interactive console should be used for this run."""
+    if dry_run:
         return False
     if os.environ.get(_DISABLE_ENV, "").lower() in ("1", "true", "yes"):
         return False

--- a/utility/tests/test_console.py
+++ b/utility/tests/test_console.py
@@ -5,6 +5,7 @@ import pytest
 from retail_setup.cli.console import (
     ConsoleUI,
     _HAVE_ALIVE,
+    _dancing_spinner,
     _plain_text,
     _plain_yes_no,
     use_rich_ui,
@@ -93,3 +94,38 @@ def test_forced_rich_path_renders_progress():
     out = buf.getvalue()
     assert out  # the bar wrote something
     assert "100%" in out  # reached completion
+
+
+@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
+def test_dancing_spinner_builds_both_styles():
+    # Both the unicode shrug and the ASCII fallback must construct without error.
+    assert _dancing_spinner(ascii_only=False) is not None
+    assert _dancing_spinner(ascii_only=True) is not None
+
+
+@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
+def test_color_styles_title_and_footer(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    buf = io.StringIO()
+    ui = ConsoleUI(2, title="Setup", enabled=True, force_tty=True, stream=buf)
+    assert ui._color is True
+    with ui as u:
+        u.set_phase("Step 1/2: working")
+        u.status("installing")
+        u.advance(completed=1)
+    out = buf.getvalue()
+    assert "\033[1;32m" in out  # green accent on the phase title
+    assert "\033[2m" in out     # dim footer hint
+
+
+@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
+def test_no_color_env_disables_color(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    buf = io.StringIO()
+    ui = ConsoleUI(2, title="Setup", enabled=True, force_tty=True, stream=buf)
+    assert ui._color is False
+    with ui as u:
+        u.set_phase("Step 1/2: working")
+        u.advance(completed=1)
+    out = buf.getvalue()
+    assert "\033[1;32m" not in out  # no ANSI color codes when NO_COLOR is set

--- a/utility/tests/test_console.py
+++ b/utility/tests/test_console.py
@@ -97,6 +97,26 @@ def test_forced_rich_path_renders_progress():
 
 
 @pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
+def test_log_routes_through_alive_hook_when_bar_active():
+    import contextlib
+    import sys
+
+    # In a real run self._stream IS sys.stdout, so alive renders the bar and its
+    # print hook both target the same stream. Mirror that by redirecting stdout.
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ui = ConsoleUI(2, title="t", enabled=True, force_tty=True)
+        before = sys.stdout
+        with ui:
+            # alive replaced sys.stdout with its hook so prints scroll above the
+            # pinned bar instead of colliding with it.
+            assert sys.stdout is not before
+            ui.log("a scrolling line")
+        assert sys.stdout is before  # hook uninstalled on exit
+    assert "a scrolling line" in buf.getvalue()
+
+
+@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
 def test_dancing_spinner_builds_both_styles():
     # Both the unicode shrug and the ASCII fallback must construct without error.
     assert _dancing_spinner(ascii_only=False) is not None

--- a/utility/tests/test_console.py
+++ b/utility/tests/test_console.py
@@ -1,17 +1,40 @@
 import io
 
-import pytest
-
 from retail_setup.cli.console import (
     ConsoleUI,
-    _HAVE_ALIVE,
-    _dancing_spinner,
+    _DANCE_ASCII,
+    _DANCE_UNICODE,
     _plain_text,
     _plain_yes_no,
+    edit_buffer,
     use_rich_ui,
 )
 
 
+class _FakeKeyboard:
+    """Scripted keyboard for exercising in-footer input without a real TTY."""
+
+    def __init__(self, keys):
+        self._keys = list(keys)
+        self.available = True
+
+    def pause(self):
+        pass
+
+    def resume(self):
+        pass
+
+    def start_watch(self):
+        pass
+
+    def stop_watch(self):
+        pass
+
+    def read_key_blocking(self):
+        return self._keys.pop(0) if self._keys else "\r"
+
+
+# --- plain-mode helpers ----------------------------------------------------- #
 def test_plain_yes_no_parses_variants(monkeypatch):
     answers = iter(["", "y", "n", "maybe", "yes"])
     monkeypatch.setattr("builtins.input", lambda *_: next(answers))
@@ -19,8 +42,7 @@ def test_plain_yes_no_parses_variants(monkeypatch):
     assert _plain_yes_no("q", True, stream) is True       # empty -> default
     assert _plain_yes_no("q", False, stream) is True      # "y"
     assert _plain_yes_no("q", True, stream) is False      # "n"
-    # "maybe" reprompts, then "yes"
-    assert _plain_yes_no("q", False, stream) is True
+    assert _plain_yes_no("q", False, stream) is True      # "maybe" reprompts, then "yes"
 
 
 def test_plain_yes_no_eof_returns_default(monkeypatch):
@@ -46,11 +68,11 @@ def test_use_rich_ui_false_for_non_tty():
     assert use_rich_ui(dry_run=False, stream=io.StringIO()) is False
 
 
+# --- disabled / fallback ---------------------------------------------------- #
 def test_console_disabled_when_stream_not_tty():
     ui = ConsoleUI(3, title="t", stream=io.StringIO())
     assert ui.enabled is False
     with ui as u:
-        # All output/progress calls must be safe no-ops when disabled.
         u.set_phase("phase")
         u.status("status")
         u.log("line")
@@ -75,77 +97,105 @@ def test_request_and_reset_cancel():
     assert ui.cancelled is False
 
 
-def test_explicit_enabled_requires_alive_progress():
-    # When alive_progress is missing, enabled must be forced off even if asked.
+def test_disabled_by_no_ui_env(monkeypatch):
+    monkeypatch.setenv("RETAIL_SETUP_NO_UI", "1")
     ui = ConsoleUI(1, enabled=True, force_tty=True, stream=io.StringIO())
-    assert ui.enabled is _HAVE_ALIVE
+    assert ui.enabled is False
 
 
-@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
-def test_forced_rich_path_renders_progress():
+# --- line-edit logic -------------------------------------------------------- #
+def test_edit_buffer_transitions():
+    assert edit_buffer("ab", "c") == ("abc", "edit")
+    assert edit_buffer("ab", "\x7f") == ("a", "edit")      # backspace
+    assert edit_buffer("ab", "\r") == ("ab", "submit")     # enter
+    assert edit_buffer("ab", "\x1b") == ("ab", "cancel")   # esc
+    assert edit_buffer("ab", "\x03") == ("ab", "cancel")   # ctrl-c
+
+
+# --- dance frames ----------------------------------------------------------- #
+def test_dance_sequence_matches_requested_pattern():
+    # both up, left down, both up, right down, both up, both down, both up, both down
+    assert len(_DANCE_UNICODE) == 8 and len(_DANCE_ASCII) == 8
+    both_up = _DANCE_UNICODE[0]
+    assert _DANCE_UNICODE[2] == both_up and _DANCE_UNICODE[4] == both_up
+    assert _DANCE_UNICODE[6] == both_up
+    # poses 1,3,5,7 are distinct movements away from "both up"
+    assert _DANCE_UNICODE[1] != both_up  # left down
+    assert _DANCE_UNICODE[3] != both_up  # right down
+    assert _DANCE_UNICODE[5] != both_up  # both down
+
+
+# --- rich rendering --------------------------------------------------------- #
+def test_forced_rich_renders_panel():
     buf = io.StringIO()
-    ui = ConsoleUI(4, title="Deploy", enabled=True, force_tty=True, stream=buf)
+    ui = ConsoleUI(4, title="Retail Demo", enabled=True, force_tty=True,
+                   stream=buf, size=(80, 24))
     assert ui.enabled is True
     with ui as u:
-        for i in range(1, 5):
-            u.set_phase(f"[{i}/4] step {i}")
-            u.status("working")
-            u.advance(completed=i)
+        u.set_phase("Step 2/4: Installing the Python packages")
+        u.advance(completed=1)
+        u.log("  - Installing the retail-setup tool")
+        u.advance(completed=4)
     out = buf.getvalue()
-    assert out  # the bar wrote something
-    assert "100%" in out  # reached completion
+    assert "\x1b[1;21r" in out                       # scroll region for rows 1..21
+    assert "Installing the retail-setup tool" in out  # log scrolled above
+    assert "esc to cancel or abort" in out            # footer hint pinned
+    assert "100%" in out                              # reached completion
+    assert "\x1b[r" in out                            # region reset on exit
 
 
-@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
-def test_log_routes_through_alive_hook_when_bar_active():
-    import contextlib
-    import sys
-
-    # In a real run self._stream IS sys.stdout, so alive renders the bar and its
-    # print hook both target the same stream. Mirror that by redirecting stdout.
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        ui = ConsoleUI(2, title="t", enabled=True, force_tty=True)
-        before = sys.stdout
-        with ui:
-            # alive replaced sys.stdout with its hook so prints scroll above the
-            # pinned bar instead of colliding with it.
-            assert sys.stdout is not before
-            ui.log("a scrolling line")
-        assert sys.stdout is before  # hook uninstalled on exit
-    assert "a scrolling line" in buf.getvalue()
-
-
-@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
-def test_dancing_spinner_builds_both_styles():
-    # Both the unicode shrug and the ASCII fallback must construct without error.
-    assert _dancing_spinner(ascii_only=False) is not None
-    assert _dancing_spinner(ascii_only=True) is not None
-
-
-@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
-def test_color_styles_title_and_footer(monkeypatch):
+def test_color_styles_separator_title_and_footer(monkeypatch):
     monkeypatch.delenv("NO_COLOR", raising=False)
     buf = io.StringIO()
-    ui = ConsoleUI(2, title="Setup", enabled=True, force_tty=True, stream=buf)
+    ui = ConsoleUI(2, title="Setup", enabled=True, force_tty=True,
+                   stream=buf, size=(80, 24))
     assert ui._color is True
     with ui as u:
         u.set_phase("Step 1/2: working")
         u.status("installing")
         u.advance(completed=1)
     out = buf.getvalue()
-    assert "\033[1;32m" in out  # green accent on the phase title
+    assert "\033[1;32m" in out  # green accent (separator + title)
     assert "\033[2m" in out     # dim footer hint
 
 
-@pytest.mark.skipif(not _HAVE_ALIVE, reason="alive_progress not installed")
 def test_no_color_env_disables_color(monkeypatch):
     monkeypatch.setenv("NO_COLOR", "1")
     buf = io.StringIO()
-    ui = ConsoleUI(2, title="Setup", enabled=True, force_tty=True, stream=buf)
+    ui = ConsoleUI(2, title="Setup", enabled=True, force_tty=True,
+                   stream=buf, size=(80, 24))
     assert ui._color is False
     with ui as u:
         u.set_phase("Step 1/2: working")
         u.advance(completed=1)
-    out = buf.getvalue()
-    assert "\033[1;32m" not in out  # no ANSI color codes when NO_COLOR is set
+    assert "\033[1;32m" not in buf.getvalue()
+
+
+# --- in-footer input -------------------------------------------------------- #
+def test_prompt_text_captured_in_footer():
+    buf = io.StringIO()
+    ui = ConsoleUI(2, title="t", enabled=True, force_tty=True,
+                   stream=buf, size=(80, 24))
+    with ui as u:
+        u._keyboard = _FakeKeyboard(list("hello") + ["\r"])
+        result = u.prompt_text("Name", default="x")
+    assert result == "hello"
+    assert "Name" in buf.getvalue()  # the prompt label rendered in the footer
+
+
+def test_prompt_yes_no_captured_in_footer():
+    buf = io.StringIO()
+    ui = ConsoleUI(2, enabled=True, force_tty=True, stream=buf, size=(80, 24))
+    with ui as u:
+        u._keyboard = _FakeKeyboard(["y", "\r"])
+        assert u.prompt_yes_no("ok?", default=False) is True
+
+
+def test_prompt_esc_cancels_in_footer():
+    buf = io.StringIO()
+    ui = ConsoleUI(2, enabled=True, force_tty=True, stream=buf, size=(80, 24))
+    with ui as u:
+        u._keyboard = _FakeKeyboard(["a", "\x1b"])
+        result = u.prompt_text("Name")
+    assert result == ""
+    assert ui.cancelled is True

--- a/utility/tests/test_console.py
+++ b/utility/tests/test_console.py
@@ -103,6 +103,19 @@ def test_disabled_by_no_ui_env(monkeypatch):
     assert ui.enabled is False
 
 
+def test_keyboard_start_watch_rearms_stop():
+    # Regression: after an interactive child (paused() -> stop_watch), the next
+    # footer prompt must read keys again. start_watch() must clear the _stop event
+    # or read_key_blocking() returns immediately and prompts silently no-op.
+    from retail_setup.cli.console import _Keyboard
+
+    kb = _Keyboard(lambda: None)
+    kb.stop_watch()
+    assert kb._stop.is_set()
+    kb.start_watch()
+    assert not kb._stop.is_set()
+
+
 # --- line-edit logic -------------------------------------------------------- #
 def test_edit_buffer_transitions():
     assert edit_buffer("ab", "c") == ("abc", "edit")


### PR DESCRIPTION
## Summary

Fix: running `setup.ps1` / `setup.py` didn't show the interactive TUI. The `alive_progress` console (fixed footer + smooth progress bar + `esc to cancel or abort`) only existed inside `retail-setup deploy`, so the guided setup's banner and **Steps 1–4** rendered as plain text — and you'd only ever see the TUI if you reached the deploy step.

## What changed
- **`scripts/setup.py` now drives the same `ConsoleUI` for its whole guided flow.**
  - Section headers advance a smooth progress bar; the phase title shows the current step.
  - Non-interactive command output (pip, render) **streams into the scrolling region** above a fixed footer that shows `esc to cancel or abort`.
  - **Interactive** children (`configure`, `deploy`, package-manager install, `az login`) **pause the bar** and take over the terminal, so prompts and the deploy's own TUI work cleanly (no nested bars).
  - **Esc** cancels between steps and mid-stream.
- **Lazy + safe:** the console is imported lazily and `alive-progress` is installed on demand, so `setup.py` still runs on the standard library alone. It activates **only on a real TTY**; CI, pipes, `--dry-run`, and `RETAIL_SETUP_NO_UI=1` keep the plain line-by-line output. `--yes` non-interactive runs are unaffected.
- **`ConsoleUI.paused()`** added (public) for handing the terminal to an interactive child process.

## Testing
- `tests/scripts/test_setup_bootstrap.py`: **22 passed** (14 existing + 8 new covering `_emit`/`_section`/`prompt_yes_no` routing, streamed vs. paused `run_command`, `_load_console` gating, and `main()` driving/clearing the console).
- End-to-end smoke with the **real** `ConsoleUI` + a real child process: child output streams into the log, the `esc to cancel` footer renders, ANSI bar present, no exceptions.
- `utility/tests/test_console.py`, `test_cli_deploy.py`, `test_cli_configure.py`, `test_cli_entrypoint.py`: all green (64 passed together).
- `ruff` clean; `mypy` clean on `console.py`.

## Notes
- No behavior change for non-interactive/CI runs or existing tests (the console is inactive when there's no TTY).



---

## Update: color + a dancing spinner

- **Copilot-style color:** the phase title is **bold green**, the status is cyan, and the `esc to cancel or abort` hint is dim. Honors the `NO_COLOR` convention and only colors when the live bar is shown.
- **Dancing person spinner:** a custom `alive_progress` spinner shows a little person dancing at the end of the line while work runs — the shrug's arms flap up then down (`¯\_(ツ)_/¯` ↔ `_/¯(ツ)¯\_`), with a plain ASCII dancer (`\o/` `|o|` `/o\`) fallback on legacy code pages.
- Added tests for the spinner factory and color/`NO_COLOR` behavior (62 console/deploy/setup tests pass; ruff + mypy clean).



---

## Update: true fixed-footer panel (custom renderer)

Replaced the alive_progress bar with a dependency-free ANSI renderer (terminal scroll region) so the bottom panel is genuinely pinned:

- **Fixed 3-line footer:** a **green separator** line, the progress bar + dancing person, and a footer that shows `esc to cancel or abort`.
- **Input captured in the footer:** when a question is asked, the prompt and the text you type render in the footer line itself (no longer lost). Interactive child steps freeze the spinner but keep the footer drawn.
- **Richer dance:** both up → left down → both up → right down → both up → both down → both up → both down (8 frames; ASCII fallback for legacy code pages).
- Enables Windows VT, honors `NO_COLOR`/`RETAIL_SETUP_NO_UI`, falls back to plain output off-TTY. `alive-progress` is no longer a dependency.

91 tests pass (rewritten console suite covers panel rendering, in-footer input, color/NO_COLOR, the dance sequence, and edit-buffer logic); ruff + mypy clean on the console.
