### PR TITLE
docs: remove retired generator references

### DIFF
--- a/docs/requirements/core/demo.md
+++ b/docs/requirements/core/demo.md
@@ -7,8 +7,8 @@
 The supported path shall use the Fabric-native `retail-setup` utility, setup
 notebooks, deployment framework, and Fabric source assets.
 
-**Acceptance:** A new contributor can identify one supported entry point and no
-public guide presents a removed local generator as an alternative.
+**Acceptance:** A new contributor can identify one supported entry point, and
+every public guide uses that Fabric-native path.
 
 ### REQ-CORE-002 - Synthetic data handling
 

--- a/docs/requirements/modules/generation/backlog.md
+++ b/docs/requirements/modules/generation/backlog.md
@@ -21,6 +21,6 @@
 ## Settled - do not reopen
 
 - Generation is Spark-native and deterministic.
-- Lakehouse Delta tables replace local DuckDB/parquet as the active contract.
+- Lakehouse Delta tables are the persistence contract.
 - New data columns use `snake_case`; legacy TMDL-bound exceptions remain
   documented until migrated.

--- a/docs/specifications/modules/generation/data-contract.md
+++ b/docs/specifications/modules/generation/data-contract.md
@@ -86,12 +86,6 @@ Current derived defaults include:
 - `brands_per_product = 3`
 - `truck_capacity = 15000`
 
-## Removed active-path behavior
-
-Local FastAPI control, DuckDB persistence, parquet export, Blob upload, Event
-Hubs, outbox, DLQ, and Prometheus surfaces are not part of the supported
-Fabric-native contract.
-
 ## Verification
 
 - `utility/tests/generation/test_schema_contract.py`


### PR DESCRIPTION
## Summary

Removes the remaining canonical documentation references to the retired local web data generator.

## Changes

- State the supported-path acceptance criterion entirely in terms of the Fabric-native workflow.
- Describe Lakehouse Delta as the persistence contract without comparing it to retired local storage.
- Remove the historical FastAPI/DuckDB/export/streaming implementation section from the active data contract.

## Validation

- `python -m zensical build --clean` — no issues found.
- Confirmed neither canonical Markdown nor generated `site/` contains FastAPI, DuckDB, datagen, local/legacy web generator, parquet export, or Blob upload references.