### PR TITLE
ci: pin workflow dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /utility
+    schedule:
+      interval: weekly

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1.0.171
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1.0.171
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,19 +6,22 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   utility-tests:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: "17"

--- a/tests/scripts/test_workflow_references.py
+++ b/tests/scripts/test_workflow_references.py
@@ -1,8 +1,22 @@
 import re
+from itertools import chain
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+ACTION_REFERENCE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
+FULL_COMMIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def _is_mutable_action_reference(reference: str) -> bool:
+    reference = reference.strip("\"'")
+    if reference.startswith("./"):
+        return False
+
+    _, separator, revision = reference.rpartition("@")
+    return not separator or FULL_COMMIT_SHA.fullmatch(revision) is None
 
 
 def test_workflow_working_directories_exist() -> None:
@@ -18,3 +32,33 @@ def test_workflow_working_directories_exist() -> None:
                 missing.append(f"{workflow.name}: {directory}")
 
     assert not missing, f"Workflow working directories do not exist: {missing}"
+
+
+@pytest.mark.parametrize(
+    ("reference", "expected"),
+    [
+        ("actions/checkout@v4", True),
+        ("actions/checkout@main", True),
+        ("actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5", False),
+        ("owner/repository/action@0123456789abcdef0123456789abcdef01234567", False),
+        ("./.github/actions/setup", False),
+        ("./.github/workflows/reusable.yml", False),
+    ],
+)
+def test_mutable_action_reference_detection(reference: str, expected: bool) -> None:
+    assert _is_mutable_action_reference(reference) is expected
+
+
+def test_workflow_action_references_are_immutable() -> None:
+    mutable: list[str] = []
+    workflows = chain(WORKFLOWS.glob("*.yml"), WORKFLOWS.glob("*.yaml"))
+
+    for workflow in workflows:
+        text = workflow.read_text(encoding="utf-8")
+        for reference in ACTION_REFERENCE.findall(text):
+            if _is_mutable_action_reference(reference):
+                mutable.append(f"{workflow.name}: {reference}")
+
+    assert not mutable, (
+        f"Workflow action references must use full commit SHAs: {mutable}"
+    )

--- a/tests/scripts/test_workflow_references.py
+++ b/tests/scripts/test_workflow_references.py
@@ -1,16 +1,31 @@
 import re
+from collections.abc import Iterator
 from itertools import chain
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
-ACTION_REFERENCE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
 FULL_COMMIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
 
 
-def _is_mutable_action_reference(reference: str) -> bool:
+def _action_references(value: object) -> Iterator[object]:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            if key == "uses":
+                yield nested_value
+            yield from _action_references(nested_value)
+    elif isinstance(value, list):
+        for nested_value in value:
+            yield from _action_references(nested_value)
+
+
+def _is_mutable_action_reference(reference: object) -> bool:
+    if not isinstance(reference, str):
+        return True
+
     reference = reference.strip("\"'")
     if reference.startswith("./"):
         return False
@@ -49,15 +64,48 @@ def test_mutable_action_reference_detection(reference: str, expected: bool) -> N
     assert _is_mutable_action_reference(reference) is expected
 
 
+@pytest.mark.parametrize(
+    "workflow_text",
+    [
+        'steps:\n  - "uses": actions/checkout@v4\n',
+        "steps:\n  - { uses: actions/checkout@v4 }\n",
+    ],
+)
+def test_yaml_forms_expose_mutable_action_references(workflow_text: str) -> None:
+    workflow = yaml.safe_load(workflow_text)
+    references = list(_action_references(workflow))
+
+    assert references == ["actions/checkout@v4"]
+    assert _is_mutable_action_reference(references[0])
+
+
+def test_yaml_action_references_allow_local_and_full_sha() -> None:
+    workflow = yaml.safe_load(
+        """
+steps:
+  - "uses": ./.github/actions/setup
+  - { uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 }
+"""
+    )
+
+    references = list(_action_references(workflow))
+
+    assert references == [
+        "./.github/actions/setup",
+        "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+    ]
+    assert not any(_is_mutable_action_reference(reference) for reference in references)
+
+
 def test_workflow_action_references_are_immutable() -> None:
     mutable: list[str] = []
     workflows = chain(WORKFLOWS.glob("*.yml"), WORKFLOWS.glob("*.yaml"))
 
     for workflow in workflows:
-        text = workflow.read_text(encoding="utf-8")
-        for reference in ACTION_REFERENCE.findall(text):
+        content = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+        for reference in _action_references(content):
             if _is_mutable_action_reference(reference):
-                mutable.append(f"{workflow.name}: {reference}")
+                mutable.append(f"{workflow.name}: {reference!r}")
 
     assert not mutable, (
         f"Workflow action references must use full commit SHAs: {mutable}"


### PR DESCRIPTION
## Summary
- Pin remaining privileged workflow actions to reviewed full commit SHAs with readable version comments.
- Add explicit read-only test workflow permissions and Dependabot coverage for GitHub Actions and Python manifests.
- Enforce immutable external action references while allowing local actions and full-SHA references.

## Test Plan
- `python -m pytest tests/scripts/test_workflow_references.py -q`
- `python -m ruff check tests/scripts/test_workflow_references.py`
- `python -m ruff format --check tests/scripts/test_workflow_references.py`
- Parse all workflow and Dependabot YAML files with PyYAML.

Closes #316