### PR TITLE
docs(guides): add persona presenter journeys

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,6 +8,7 @@ must link to those owners rather than redefine contracts.
 | --- | --- |
 | [Getting started](getting-started.md) | Configure, render, deploy, run, and validate a workspace |
 | [Presenter demo](demo-script.md) | Run a defensible 15-20 minute walkthrough |
+| [Presenter journeys](presenter-journeys.md) | Run focused 5-7 minute persona prompt packs |
 | [Use cases](use-cases.md) | Select implemented and proposed business stories |
 | [Operations](operations.md) | Monitor, troubleshoot, recover, and reset |
 | [Documentation](documentation.md) | Build and publish the Zensical site |

--- a/docs/guides/demo-script.md
+++ b/docs/guides/demo-script.md
@@ -4,6 +4,10 @@
 **Duration:** 15-20 minutes  
 **Data:** Synthetic
 
+For a standalone 5-7 minute persona walkthrough, use the
+[presenter journeys](presenter-journeys.md) for retail operations,
+merchandising, or executive/analytics audiences.
+
 ## Before the audience arrives
 
 1. Complete the [getting-started guide](getting-started.md).
@@ -51,7 +55,8 @@ partition fields) and typed payload mapping.
 
 ## 3. Ask operational questions
 
-Use checked-in queryset tabs for:
+Choose a supported path from the [presenter journeys](presenter-journeys.md),
+or use checked-in queryset tabs for:
 
 - Recent sales and top products.
 - Inventory movements and stockout detections.
@@ -59,7 +64,8 @@ Use checked-in queryset tabs for:
 - Store presence and zone dwell.
 
 Be precise: recent stockout detections are not the same as unresolved current
-stockout state.
+stockout state. Truck dwell is not a supported proof point until
+[issue #317](https://github.com/amattas/retail-demo/issues/317) is completed.
 
 ## 4. Show durable history
 

--- a/docs/guides/presenter-journeys.md
+++ b/docs/guides/presenter-journeys.md
@@ -10,10 +10,28 @@ Before presenting:
 
 1. Complete [Getting started](getting-started.md), including the ordered KQL
    scripts and rendered `stream-events.ipynb`.
-2. Set the notebook sink to `eventhouse`, confirm the target KQL database, and
-   run a bounded stream.
+2. Override the stream parameters with these presenter settings:
+
+    ```python
+    source_rows_per_second = 10
+    sink = "eventhouse"
+    run_seconds = 180
+    ```
+
+   The source template defaults to `source_rows_per_second = 5` and
+   `run_seconds = 0`; zero runs indefinitely. Each source row emits one
+   scenario bundle, so the presenter settings create a three-minute bounded
+   run rather than a fixed business-event count.
 3. Confirm the `retail_querysets.KQLQueryset` item is bound to that database.
 4. Keep the [Operations guide](operations.md) open for recovery.
+
+After the notebook prints `stopped after 180s`, run the persona readiness query
+every 15 seconds for up to five minutes. Proceed only when every required row
+in that query has `rows > 0` and a `latest` timestamp within the last 10
+minutes. Eventhouse ingestion is asynchronous, so notebook completion alone is
+not readiness proof. For journeys that use `mv_store_sales_minute`, also run
+the store-sales query during that polling window and require at least one
+recent minute bucket.
 
 The following surfaces are not part of these reproducible core journeys:
 
@@ -55,6 +73,7 @@ Run this readiness check:
 ```kql
 union withsource=table_name receipt_created, online_order_created,
   online_order_picked, online_order_shipped
+| where ingest_timestamp > ago(10m)
 | summarize rows = count(), latest = max(ingest_timestamp) by table_name
 | order by table_name asc
 ```
@@ -114,12 +133,13 @@ union withsource=table_name receipt_created, online_order_created,
 
 ### Reset and recovery
 
-1. Stop the bounded stream if it is still running.
-2. Rerun it with the same saved notebook parameters; wait for the readiness
-   query's `latest` values to advance.
-3. If they do not advance, verify the Query URI, database name, permissions,
+1. If the notebook exceeds its bounded run, cancel the active Spark query.
+2. Rerun it with `source_rows_per_second = 10` and `run_seconds = 180`.
+3. Poll the readiness query every 15 seconds for up to five minutes; require
+   all four tables and recent `latest` values.
+4. If they do not advance, verify the Query URI, database name, permissions,
    and notebook errors using [Operations](operations.md#common-recovery-paths).
-4. Do not run the destructive Lakehouse reset for a presenter retry.
+5. Do not run the destructive Lakehouse reset for a presenter retry.
 
 ## Merchandising: product demand and replenishment signals
 
@@ -141,9 +161,15 @@ Run this readiness check:
 ```kql
 union withsource=signal receipt_line_added, inventory_updated,
   stockout_detected, reorder_triggered
+| where ingest_timestamp > ago(10m)
 | summarize rows = count(), latest = max(ingest_timestamp) by signal
 | order by signal asc
 ```
+
+`stockout_detected` and `reorder_triggered` are conditional inventory events.
+If either row is absent after the first five-minute readiness wait, run one
+more bounded stream with the same presenter settings and repeat the wait.
+Present the replenishment step only after all four rows pass.
 
 ### Run the journey
 
@@ -218,13 +244,17 @@ union withsource=signal receipt_line_added, inventory_updated,
 
 ### Reset and recovery
 
-1. Stop and rerun the bounded stream with the same parameters.
-2. Confirm `latest` advances for `receipt_line_added` and at least one inventory
-   signal before presenting.
-3. If a table is missing, reapply the ordered KQL scripts to the intended
+1. Rerun the bounded stream with `source_rows_per_second = 10` and
+   `run_seconds = 180`.
+2. Poll every 15 seconds for up to five minutes and require recent rows for
+   `receipt_line_added`, `inventory_updated`, `stockout_detected`, and
+   `reorder_triggered`.
+3. Because the last two events are conditional, run one additional identical
+   bounded stream and repeat the poll before using the fallback.
+4. If a table is missing, reapply the ordered KQL scripts to the intended
    database; if rows are missing, follow the live-ingestion recovery path in
    [Operations](operations.md#common-recovery-paths).
-4. Preserve prior events; no destructive reset is needed.
+5. Preserve prior events; no destructive reset is needed.
 
 ## Executive and analytics: recent performance summary
 
@@ -246,6 +276,7 @@ Run this readiness check:
 
 ```kql
 union withsource=table_name payment_processed, online_order_created
+| where ingest_timestamp > ago(10m)
 | summarize rows = count(), latest = max(ingest_timestamp) by table_name
 | order by table_name asc
 ```
@@ -318,9 +349,10 @@ union withsource=table_name payment_processed, online_order_created
 
 ### Reset and recovery
 
-1. Stop and rerun the bounded stream with the saved parameters.
-2. Rerun the readiness and store-sales queries until their latest timestamps
-   advance.
+1. Rerun the bounded stream with `source_rows_per_second = 10` and
+   `run_seconds = 180`.
+2. Poll the readiness query every 15 seconds for up to five minutes, then rerun
+   the store-sales query and confirm recent minute buckets.
 3. If only a visualization surface fails, remain in the KQL queryset and follow
    the Power BI recovery entry in
    [Operations](operations.md#common-recovery-paths).

--- a/docs/guides/presenter-journeys.md
+++ b/docs/guides/presenter-journeys.md
@@ -1,0 +1,334 @@
+# Presenter journeys
+
+Use one of these standalone journeys when a persona needs a focused,
+repeatable 5-7 minute demo. They use the deployed Eventhouse tables and
+`retail_querysets.KQLQueryset`; no optional surface is required.
+
+## Common preflight and boundaries
+
+Before presenting:
+
+1. Complete [Getting started](getting-started.md), including the ordered KQL
+   scripts and rendered `stream-events.ipynb`.
+2. Set the notebook sink to `eventhouse`, confirm the target KQL database, and
+   run a bounded stream.
+3. Confirm the `retail_querysets.KQLQueryset` item is bound to that database.
+4. Keep the [Operations guide](operations.md) open for recovery.
+
+The following surfaces are not part of these reproducible core journeys:
+
+- Dashboard templates require validated import and binding
+  ([ENH-001](../requirements/modules/analytics/backlog.md#enh-001)).
+- Ontology and agent experiences require their capability, source, and access
+  gates; the journeys do not depend on conversational answers.
+- ML output remains optional until its trust gates pass
+  ([IMP-008](../requirements/modules/ml-ai/backlog.md#imp-008)).
+- Pricing actions and writeback remain optional
+  ([ENH-002](../requirements/modules/power-bi/backlog.md#enh-002)).
+- Recent inventory and stockout events are signals, not unresolved
+  current-state KPIs
+  ([IMP-009](../requirements/modules/power-bi/backlog.md#imp-009)).
+- Marketing attribution remains limited
+  ([IMP-007](../requirements/modules/streaming/backlog.md#imp-007)).
+- Truck dwell is unavailable as a supported proof point until
+  [issue #317](https://github.com/amattas/retail-demo/issues/317) is completed.
+
+## Retail operations: live store and fulfillment pulse
+
+**Audience goal:** Verify that store sales and omnichannel fulfillment events
+are arriving and can be investigated by store or lifecycle stage.
+
+**Presenter prompt:** "What is happening across stores and fulfillment right
+now, and what evidence shows that the feed is live?"
+
+### Assets and readiness
+
+| Required source asset | Readiness check |
+| --- | --- |
+| Rendered `utility/out/stream-events.ipynb` from `utility/notebooks/templates/driver-05-stream.py` | A bounded Eventhouse run completes without connector errors. |
+| Tables `receipt_created`, `online_order_created`, `online_order_picked`, and `online_order_shipped` from `fabric/kql_database/01-create-tables.kql` | The preflight query below returns each table with a recent `latest` timestamp after streaming. |
+| Materialized view `mv_store_sales_minute` from `fabric/kql_database/04-create-materialized-views.kql` | The sales query returns recent minute buckets. |
+| Queryset tab `q_online_orders_15m` from `fabric/querysets/q_online_orders_15m.kql` | The tab opens against the intended KQL database. |
+
+Run this readiness check:
+
+```kql
+union withsource=table_name receipt_created, online_order_created,
+  online_order_picked, online_order_shipped
+| summarize rows = count(), latest = max(ingest_timestamp) by table_name
+| order by table_name asc
+```
+
+### Run the journey
+
+1. **Frame the question (30 seconds).** State that this is a live operational
+   pulse, not a promised current-state control plane.
+2. **Show store sales (2 minutes).** Run:
+
+    ```kql
+    let lookback = 60m;
+    mv_store_sales_minute
+    | where ts > ago(lookback)
+    | project ts, store_id, total_sales, receipts, avg_basket
+    | order by ts desc
+    ```
+
+   **Expected observation:** Recent minute buckets appear for one or more
+   stores. Sales, receipt count, and average basket vary by store and time.
+
+   **Talk track:** "The stream lands typed receipt events in Eventhouse. This
+   materialized view turns them into a bounded operational sales trend without
+   waiting for a report refresh."
+
+3. **Show fulfillment progression (2 minutes).** Run:
+
+    ```kql
+    let window = 24h;
+    union withsource=stage online_order_created, online_order_picked,
+      online_order_shipped
+    | where ingest_timestamp > ago(window)
+    | summarize events = count() by stage
+    | order by stage asc
+    ```
+
+   **Expected observation:** The result shows event counts for created, picked,
+   and shipped stages. Counts need not match because the window is bounded and
+   events can arrive out of order.
+
+   **Talk track:** "These are lifecycle event counts, not a claim that every
+   order is currently in one stage. The shared order identifier supports deeper
+   investigation when needed."
+
+4. **Close (1 minute).** Point back to the latest ingestion timestamps as the
+   evidence of freshness. Do not add truck dwell unless issue #317 is closed
+   and its acceptance criteria have been validated in the demo workspace.
+
+### Fallback
+
+- If the materialized view is empty, query recent `receipt_created` rows
+  directly and show `ingest_timestamp`, `store_id`, and `total`.
+- If fulfillment stages are sparse, show `q_online_orders_15m` and describe
+  order creation only.
+- If no live rows arrive, use the last successful bounded run and label its
+  timestamp; do not substitute dashboard or truck-dwell claims.
+
+### Reset and recovery
+
+1. Stop the bounded stream if it is still running.
+2. Rerun it with the same saved notebook parameters; wait for the readiness
+   query's `latest` values to advance.
+3. If they do not advance, verify the Query URI, database name, permissions,
+   and notebook errors using [Operations](operations.md#common-recovery-paths).
+4. Do not run the destructive Lakehouse reset for a presenter retry.
+
+## Merchandising: product demand and replenishment signals
+
+**Audience goal:** Identify products generating recent sales and correlate that
+activity with inventory, stockout-detection, and reorder signals.
+
+**Presenter prompt:** "Which products are moving, and where should a
+merchandiser investigate replenishment signals?"
+
+### Assets and readiness
+
+| Required source asset | Readiness check |
+| --- | --- |
+| Tables `receipt_line_added`, `inventory_updated`, `stockout_detected`, and `reorder_triggered` from `fabric/kql_database/01-create-tables.kql` | The preflight query returns the available signal types and recent timestamps. |
+| Queryset tab `q_top_products_by_sales` from `fabric/querysets/q_top_products_by_sales.kql` | The tab returns products with revenue and unit totals. |
+
+Run this readiness check:
+
+```kql
+union withsource=signal receipt_line_added, inventory_updated,
+  stockout_detected, reorder_triggered
+| summarize rows = count(), latest = max(ingest_timestamp) by signal
+| order by signal asc
+```
+
+### Run the journey
+
+1. **Frame the question (30 seconds).** Explain that the journey combines
+   demand and replenishment events without claiming a current inventory
+   balance.
+2. **Rank recent product demand (2 minutes).** Open
+   `q_top_products_by_sales`, or run:
+
+    ```kql
+    let window = 15m;
+    receipt_line_added
+    | where ingest_timestamp > ago(window)
+    | summarize revenue = sum(extended_price), units = sum(quantity)
+        by product_id
+    | top 25 by revenue desc
+    ```
+
+   **Expected observation:** Products rank differently by revenue and units;
+   the result uses product identifiers from typed receipt-line events.
+
+   **Talk track:** "This is a recent demand ranking at product grain. It is a
+   starting point for investigation, not a forecast or recommendation."
+
+3. **Inspect inventory movement (90 seconds).** Run:
+
+    ```kql
+    let window = 30m;
+    inventory_updated
+    | where ingest_timestamp > ago(window)
+    | summarize movements = count(), net_quantity_delta = sum(quantity_delta),
+        latest = max(ingest_timestamp)
+        by store_id, product_id, reason
+    | top 25 by latest desc
+    ```
+
+   **Expected observation:** Recent movement reasons and signed quantity
+   changes appear for store/product combinations.
+
+   **Talk track:** "These are movements within the selected window. Summing
+   deltas here does not reconstruct an authoritative on-hand balance."
+
+4. **Show replenishment signals (90 seconds).** Run:
+
+    ```kql
+    let window = 30m;
+    union withsource=signal stockout_detected, reorder_triggered
+    | where ingest_timestamp > ago(window)
+    | summarize events = count(), latest = max(ingest_timestamp)
+        by signal, store_id, product_id
+    | top 25 by latest desc
+    ```
+
+   **Expected observation:** Detection and reorder event types appear by
+   store/product when generated in the selected window.
+
+   **Talk track:** "A detection or reorder is evidence that a workflow emitted
+   a signal. We are not labeling the item as currently out of stock or the
+   reorder as still pending."
+
+5. **Close (30 seconds).** Emphasize traceable event grain and explicit KPI
+   limits. Do not extend this into marketing attribution, ML recommendations,
+   or pricing writeback without their separate gates.
+
+### Fallback
+
+- Expand `window` to `24h` after confirming older rows exist.
+- If inventory signals are absent, present the product-demand query and use the
+  readiness result to explain which event types are missing.
+- If product detail is required but no validated dimension shortcut exists,
+  keep `product_id`; do not invent names or categories.
+
+### Reset and recovery
+
+1. Stop and rerun the bounded stream with the same parameters.
+2. Confirm `latest` advances for `receipt_line_added` and at least one inventory
+   signal before presenting.
+3. If a table is missing, reapply the ordered KQL scripts to the intended
+   database; if rows are missing, follow the live-ingestion recovery path in
+   [Operations](operations.md#common-recovery-paths).
+4. Preserve prior events; no destructive reset is needed.
+
+## Executive and analytics: recent performance summary
+
+**Audience goal:** Summarize recent store sales, payment mix, and online-order
+volume while making time window and grain explicit.
+
+**Presenter prompt:** "What can leadership learn from the latest activity, and
+what evidence supports each headline?"
+
+### Assets and readiness
+
+| Required source asset | Readiness check |
+| --- | --- |
+| Tables `payment_processed` and `online_order_created` from `fabric/kql_database/01-create-tables.kql` | Each table returns a row count and latest ingestion timestamp. |
+| Materialized view `mv_store_sales_minute` from `fabric/kql_database/04-create-materialized-views.kql` | Recent store/minute buckets are present. |
+| Queryset tabs `q_tender_mix` and `q_online_orders_15m` from `fabric/querysets/` | Both tabs run against the intended KQL database. |
+
+Run this readiness check:
+
+```kql
+union withsource=table_name payment_processed, online_order_created
+| summarize rows = count(), latest = max(ingest_timestamp) by table_name
+| order by table_name asc
+```
+
+### Run the journey
+
+1. **Frame the summary (30 seconds).** State that every result is synthetic,
+   recent, and bounded by the query window.
+2. **Show store performance (2 minutes).** Run:
+
+    ```kql
+    let lookback = 60m;
+    mv_store_sales_minute
+    | where ts > ago(lookback)
+    | project ts, store_id, total_sales, receipts, avg_basket
+    | order by ts desc
+    ```
+
+   **Expected observation:** Store/minute results provide recent sales,
+   transaction volume, and basket context without requiring a dashboard.
+
+   **Talk track:** "We can inspect the metric, grain, and freshness directly.
+   The strongest headline is the observable variation, not a fixed demo
+   number."
+
+3. **Show payment mix (90 seconds).** Open `q_tender_mix`, or run:
+
+    ```kql
+    let window = 15m;
+    payment_processed
+    | where ingest_timestamp > ago(window)
+    | summarize amount = sum(amount) by payment_method
+    | order by amount desc
+    ```
+
+   **Expected observation:** Payment methods contribute different portions of
+   recent processed amount.
+
+   **Talk track:** "This is payment-event mix for the selected window. It does
+   not infer customer preference beyond the observed synthetic transactions."
+
+4. **Show online demand (90 seconds).** Open `q_online_orders_15m`, or run:
+
+    ```kql
+    let window = 15m;
+    online_order_created
+    | where ingest_timestamp > ago(window)
+    | summarize orders = count(), subtotal = sum(subtotal), tax = sum(tax),
+        total = sum(total)
+    | extend aov = toreal(total) / toreal(orders)
+    | project orders, subtotal, tax, total, aov
+    ```
+
+   **Expected observation:** One bounded summary reports created-order count,
+   value components, and average order value when rows are present.
+
+   **Talk track:** "This is created online demand, not completed revenue or a
+   fulfillment service-level claim."
+
+5. **Close (30 seconds).** Restate source, time window, and grain. Use Power BI
+   or a dashboard only if its binding and current data period were validated
+   before the session. Do not replace evidence with an ungated agent answer.
+
+### Fallback
+
+- Expand the query window after confirming the most recent available timestamp.
+- If one channel has no recent rows, present the other supported queries and
+  show the readiness result instead of manufacturing a complete scorecard.
+- Use direct KQL output if a report or dashboard binding is stale.
+
+### Reset and recovery
+
+1. Stop and rerun the bounded stream with the saved parameters.
+2. Rerun the readiness and store-sales queries until their latest timestamps
+   advance.
+3. If only a visualization surface fails, remain in the KQL queryset and follow
+   the Power BI recovery entry in
+   [Operations](operations.md#common-recovery-paths).
+4. Do not clear Eventhouse or Lakehouse data between presentations.
+
+## Remaining ENH-005 boundary
+
+These journeys complete only the documentation-first prompt-pack slice.
+Deployment presets named `lite`, `standard`, and `full-demo`, including measured
+runtimes and preset-specific asset controls, are not implemented. ENH-005
+therefore remains open.

--- a/docs/requirements/modules/setup/backlog.md
+++ b/docs/requirements/modules/setup/backlog.md
@@ -9,6 +9,9 @@
   expected assets, presenter controls, and persona-specific questions.
 - **Acceptance:** A presenter can choose a preset and reproduce its documented
   "wow moment" without inventing setup steps.
+- **Current boundary:** Persona journeys and prompt packs are documented in the
+  [presenter guide](../../../guides/presenter-journeys.md). The deployment
+  presets, measured runtimes, and preset-specific asset controls remain open.
 
 ## Settled - do not reopen
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -16,6 +16,7 @@ nav = [
     { "Guide index" = "guides/README.md" },
     { "Getting started" = "guides/getting-started.md" },
     { "Presenter demo" = "guides/demo-script.md" },
+    { "Presenter journeys" = "guides/presenter-journeys.md" },
     { "Use cases" = "guides/use-cases.md" },
     { "Operations" = "guides/operations.md" },
     { "Documentation" = "guides/documentation.md" },


### PR DESCRIPTION
## Summary
- Add reproducible 5-7 minute presenter journeys for retail operations, merchandising, and executive/analytics audiences.
- Include supported KQL assets, readiness checks, talk tracks, fallbacks, recovery steps, and explicit optional-capability gates.
- Expose the journeys from the presenter script, guide index, navigation, and ENH-005 backlog boundary.

## Test Plan
- `python -m zensical build --clean`
- `python -m pytest tests\scripts\test_reference_integrity.py tests\scripts\test_workflow_references.py -q`

Closes #319