### PR TITLE
fix(deploy): propagate configured auth mode

### DIFF
--- a/deploy/scripts/_auth.py
+++ b/deploy/scripts/_auth.py
@@ -1,0 +1,30 @@
+"""Shared credential construction for deployment clients."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
+
+AUTH_MODES = ("azure_cli", "azure_powershell")
+
+
+def build_credential(
+    auth_mode: str,
+    *,
+    process_timeout: int = 120,
+) -> TokenCredential:
+    """Build the operator credential selected by deployment configuration."""
+
+    if auth_mode == "azure_cli":
+        from azure.identity import AzureCliCredential
+
+        return AzureCliCredential(process_timeout=process_timeout)
+    if auth_mode == "azure_powershell":
+        from azure.identity import AzurePowerShellCredential
+
+        return AzurePowerShellCredential(process_timeout=process_timeout)
+    raise ValueError(
+        f"Unsupported auth mode {auth_mode!r}. Use 'azure_cli' or 'azure_powershell'."
+    )

--- a/deploy/scripts/apply_kql.py
+++ b/deploy/scripts/apply_kql.py
@@ -1,11 +1,11 @@
 """Prepare or execute ordered KQL database scripts.
 
 ``--execute`` applies the combined script directly to the Fabric Eventhouse KQL
-database using the operator's Azure CLI login (``AzureCliCredential``). This is
-the supported path: the deploy runs locally with the user's credentials, which
-have Eventhouse admin rights — unlike a Fabric notebook's identity, which does
-not. The script resolves the database's ``queryServiceUri`` from the Fabric REST
-API, then runs the batch with the Kusto Python SDK.
+database using the configured operator credential. This is the supported path:
+the deploy runs locally with the user's permissions, which include Eventhouse
+administration — unlike a Fabric notebook's identity. The script resolves the
+database's ``queryServiceUri`` from the Fabric REST API, then runs the batch with
+the Kusto Python SDK.
 """
 
 from __future__ import annotations
@@ -15,9 +15,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from deploy.scripts import _output as console
+from deploy.scripts._auth import AUTH_MODES, build_credential
 
 if TYPE_CHECKING:
-    from azure.identity import AzureCliCredential
+    from azure.core.credentials import TokenCredential
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 KQL_SOURCE_DIR = REPO_ROOT / "fabric" / "kql_database"
@@ -52,23 +53,20 @@ def build_database_script(scripts: list[Path]) -> str:
     return "\n".join(parts).rstrip() + "\n"
 
 
-def _credential(credential: AzureCliCredential | None = None) -> AzureCliCredential:
-    """Azure CLI credential with a generous process timeout.
+def _credential(
+    credential: TokenCredential | None = None,
+    *,
+    auth_mode: str = "azure_cli",
+) -> TokenCredential:
+    """Return an injected credential or construct the configured operator login."""
 
-    A *cold* ``az account get-access-token`` for the Kusto/Eventhouse audience can
-    take ~90s on Windows (warm calls are ~1s). 120s absorbs the cold-start
-    without making a genuinely-broken ``az`` hang excessively.
-    """
-
-    from azure.identity import AzureCliCredential
-
-    return credential or AzureCliCredential(process_timeout=120)
+    return credential or build_credential(auth_mode)
 
 
 def resolve_kql_database(
     workspace_id: str,
     kql_database_id: str,
-    credential: AzureCliCredential,
+    credential: TokenCredential,
 ) -> tuple[str, str]:
     """Return ``(query_service_uri, database_name)`` for a Fabric KQL database."""
 
@@ -97,13 +95,15 @@ def execute_database_script(
     query_uri: str,
     database_name: str,
     script: str,
-    credential: AzureCliCredential,
+    credential: TokenCredential,
 ) -> Any:
     """Run a KQL management script against the database with the Kusto SDK."""
 
     from azure.kusto.data import KustoClient, KustoConnectionStringBuilder
 
-    kcsb = KustoConnectionStringBuilder.with_azure_token_credential(query_uri, credential)
+    kcsb = KustoConnectionStringBuilder.with_azure_token_credential(
+        query_uri, credential
+    )
     with KustoClient(kcsb) as client:
         return client.execute_mgmt(database_name, script)
 
@@ -159,11 +159,12 @@ def apply_to_database(
     workspace_id: str,
     kql_database_id: str,
     kql_database_name: str | None = None,
-    credential: AzureCliCredential | None = None,
+    auth_mode: str = "azure_cli",
+    credential: TokenCredential | None = None,
 ) -> int:
     """Resolve the KQL database and apply the combined script. Returns row count."""
 
-    credential = _credential(credential)
+    credential = _credential(credential, auth_mode=auth_mode)
     query_uri, resolved_name = resolve_kql_database(
         workspace_id, kql_database_id, credential
     )
@@ -215,12 +216,21 @@ def main() -> int:
         "--environment",
         help="Read workspace/database ids from deploy/.generated/<env>/terraform-output.json.",
     )
-    parser.add_argument("--workspace-id", help="Fabric workspace id (overrides --environment).")
+    parser.add_argument(
+        "--workspace-id", help="Fabric workspace id (overrides --environment)."
+    )
     parser.add_argument(
         "--kql-database-id", help="Fabric KQL database id (overrides --environment)."
     )
     parser.add_argument(
-        "--kql-database-name", help="KQL database name (overrides resolved display name)."
+        "--kql-database-name",
+        help="KQL database name (overrides resolved display name).",
+    )
+    parser.add_argument(
+        "--auth-mode",
+        choices=AUTH_MODES,
+        default="azure_cli",
+        help="Operator credential used for Fabric and Kusto requests.",
     )
     args = parser.parse_args()
 
@@ -251,6 +261,7 @@ def main() -> int:
         workspace_id=str(workspace_id),
         kql_database_id=str(kql_database_id),
         kql_database_name=kql_database_name and str(kql_database_name),
+        auth_mode=args.auth_mode,
     )
     return 0
 

--- a/deploy/scripts/deploy_items.py
+++ b/deploy/scripts/deploy_items.py
@@ -6,23 +6,8 @@ import argparse
 from pathlib import Path
 
 from deploy.scripts import _output as console
+from deploy.scripts._auth import AUTH_MODES, build_credential
 from deploy.scripts.deploy_config import DEPLOY_ROOT
-
-
-def build_credential(auth_mode: str):
-    """Build an explicit Azure credential for fabric-cicd."""
-
-    if auth_mode == "azure_cli":
-        from azure.identity import AzureCliCredential
-
-        return AzureCliCredential()
-    if auth_mode == "azure_powershell":
-        from azure.identity import AzurePowerShellCredential
-
-        return AzurePowerShellCredential()
-    raise ValueError(
-        "Unsupported auth mode. Use 'azure_cli' or 'azure_powershell' for this wrapper."
-    )
 
 
 def deploy(config_path: Path, environment: str, auth_mode: str) -> None:
@@ -60,7 +45,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--auth-mode",
-        choices=["azure_cli", "azure_powershell"],
+        choices=AUTH_MODES,
         default="azure_cli",
     )
     args = parser.parse_args()

--- a/deploy/scripts/export_items.py
+++ b/deploy/scripts/export_items.py
@@ -4,9 +4,8 @@ Fetches each item definition from a live Fabric workspace via the
 ``getDefinition`` REST API and writes it as a source-control item folder
 (``<name>.<ItemType>/`` containing ``.platform`` and the returned definition
 parts, e.g. ``pipeline-content.json`` for pipelines or ``Files/Config/...`` for
-data agents). Authentication uses the Azure CLI login (``AzureCliCredential``),
-matching the ``azure_cli`` auth mode used by the rest of the deployment
-framework.
+data agents). Authentication uses the operator login selected by deployment
+configuration.
 
 Example:
     python -m deploy.scripts.export_items \
@@ -23,9 +22,11 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from deploy.scripts._auth import AUTH_MODES, build_credential
+
 if TYPE_CHECKING:
     import requests
-    from azure.identity import AzureCliCredential
+    from azure.core.credentials import TokenCredential
 
 FABRIC_API = "https://api.fabric.microsoft.com/v1"
 FABRIC_SCOPE = "https://api.fabric.microsoft.com/.default"
@@ -35,25 +36,34 @@ _JSON_PART_SUFFIXES = (".json",)
 _JSON_PART_NAMES = {".platform", ".schedules"}
 
 
-def build_session(credential: AzureCliCredential | None = None) -> requests.Session:
-    """Create an authenticated requests session for the Fabric REST API.
+def _token(scope: str, credential: TokenCredential) -> str:
+    """Acquire a token, retrying transient operator-login failures."""
 
-    Uses a generous credential process timeout and retries transient cold-``az``
-    token failures (the deploy's pipeline trigger runs this right after a long
-    Terraform/publish step, when the token cache may have lapsed).
-    """
-
-    import requests
     from azure.core.exceptions import ClientAuthenticationError
-    from azure.identity import AzureCliCredential
 
     from deploy.scripts._retry import retry_call
 
-    credential = credential or AzureCliCredential(process_timeout=120)
-    token = retry_call(
-        lambda: credential.get_token(FABRIC_SCOPE).token,
+    return retry_call(
+        lambda: credential.get_token(scope).token,
         retry_on=(ClientAuthenticationError,),
     )
+
+
+def build_session(
+    credential: TokenCredential | None = None,
+    *,
+    auth_mode: str = "azure_cli",
+) -> requests.Session:
+    """Create an authenticated requests session for the Fabric REST API.
+
+    Retries transient operator-login failures because the deploy can request a
+    token after a long Terraform/publish step.
+    """
+
+    import requests
+
+    credential = credential or build_credential(auth_mode)
+    token = _token(FABRIC_SCOPE, credential)
     session = requests.Session()
     session.headers["Authorization"] = f"Bearer {token}"
     return session
@@ -151,11 +161,13 @@ def export_items(
     workspace_name: str,
     item_type: str,
     output_dir: Path,
-    credential: AzureCliCredential | None = None,
+    credential: TokenCredential | None = None,
+    *,
+    auth_mode: str = "azure_cli",
 ) -> list[Path]:
     """Export all items of ``item_type`` from a workspace into item folders."""
 
-    session = build_session(credential)
+    session = build_session(credential, auth_mode=auth_mode)
     workspace_id = find_workspace_id(session, workspace_name)
     written: list[Path] = []
     for item in list_items(session, workspace_id, item_type):
@@ -183,9 +195,20 @@ def main() -> int:
         help="Fabric item type to export, e.g. DataPipeline or DataAgent.",
     )
     parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--auth-mode",
+        choices=AUTH_MODES,
+        default="azure_cli",
+        help="Operator credential used for Fabric REST requests.",
+    )
     args = parser.parse_args()
 
-    written = export_items(args.workspace_name, args.item_type, args.output_dir)
+    written = export_items(
+        args.workspace_name,
+        args.item_type,
+        args.output_dir,
+        auth_mode=args.auth_mode,
+    )
     print(f"Exported {len(written)} {args.item_type} item(s) to {args.output_dir}")
     for item in written:
         print(f"  {item.name}")

--- a/deploy/scripts/export_pipelines.py
+++ b/deploy/scripts/export_pipelines.py
@@ -14,6 +14,7 @@ import argparse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from deploy.scripts._auth import AUTH_MODES
 from deploy.scripts.export_items import (
     build_session,
     export_items,
@@ -23,7 +24,7 @@ from deploy.scripts.export_items import (
 )
 
 if TYPE_CHECKING:
-    from azure.identity import AzureCliCredential
+    from azure.core.credentials import TokenCredential
 
 ITEM_TYPE = "DataPipeline"
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -58,11 +59,19 @@ def write_item(output_dir: Path, display_name: str, definition: dict[str, Any]) 
 def export_pipelines(
     workspace_name: str,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
-    credential: AzureCliCredential | None = None,
+    credential: TokenCredential | None = None,
+    *,
+    auth_mode: str = "azure_cli",
 ) -> list[Path]:
     """Export all DataPipeline items from a workspace into item folders."""
 
-    return export_items(workspace_name, ITEM_TYPE, output_dir, credential)
+    return export_items(
+        workspace_name,
+        ITEM_TYPE,
+        output_dir,
+        credential,
+        auth_mode=auth_mode,
+    )
 
 
 def main() -> int:
@@ -77,9 +86,19 @@ def main() -> int:
         help='Source workspace display name, e.g. "Retail Demo".',
     )
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--auth-mode",
+        choices=AUTH_MODES,
+        default="azure_cli",
+        help="Operator credential used for Fabric REST requests.",
+    )
     args = parser.parse_args()
 
-    written = export_pipelines(args.workspace_name, args.output_dir)
+    written = export_pipelines(
+        args.workspace_name,
+        args.output_dir,
+        auth_mode=args.auth_mode,
+    )
     print(f"Exported {len(written)} pipeline(s) to {args.output_dir}")
     for item in written:
         print(f"  {item.name}")

--- a/deploy/scripts/run_pipeline.py
+++ b/deploy/scripts/run_pipeline.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from deploy.scripts import _output as console
+from deploy.scripts._auth import AUTH_MODES
 from deploy.scripts.export_items import build_session, list_items
 
 if TYPE_CHECKING:
@@ -72,10 +73,16 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run a Fabric Data Pipeline on demand")
     parser.add_argument("--environment", default="dev")
     parser.add_argument("--pipeline", required=True, help="Pipeline display name.")
+    parser.add_argument(
+        "--auth-mode",
+        choices=AUTH_MODES,
+        default="azure_cli",
+        help="Operator credential used for Fabric REST requests.",
+    )
     args = parser.parse_args()
 
     workspace_id = workspace_id_from_outputs(args.environment)
-    session = build_session()
+    session = build_session(auth_mode=args.auth_mode)
     pipeline_id = find_pipeline_id(session, workspace_id, args.pipeline)
     location = run_pipeline(session, workspace_id, pipeline_id)
     console.info(f"Started pipeline run for {args.pipeline!r} ({pipeline_id}).")

--- a/deploy/scripts/taskflow.py
+++ b/deploy/scripts/taskflow.py
@@ -31,10 +31,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from deploy.scripts import _output as console
+from deploy.scripts._auth import AUTH_MODES, build_credential
 
 if TYPE_CHECKING:
     import requests
-    from azure.identity import AzureCliCredential
+    from azure.core.credentials import TokenCredential
 
 PBI_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
 FABRIC_SCOPE = "https://api.fabric.microsoft.com/.default"
@@ -63,27 +64,18 @@ ARTIFACT_TO_ITEM_TYPE = {
 }
 
 
-def _credential(credential: AzureCliCredential | None = None) -> AzureCliCredential:
-    """Azure CLI credential with a generous process timeout.
+def _credential(
+    credential: TokenCredential | None = None,
+    *,
+    auth_mode: str = "azure_cli",
+) -> TokenCredential:
+    """Return an injected credential or construct the configured operator login."""
 
-    On Windows ``az.cmd`` is slow to start, and a *cold* token for the Power BI /
-    Fabric audience can take ~90s (the deploy fetches both back to back; warm
-    calls are ~1s). 120s absorbs the cold-start without making a genuinely-broken
-    ``az`` hang excessively. One credential is reused for both token requests.
-    """
-
-    from azure.identity import AzureCliCredential
-
-    return credential or AzureCliCredential(process_timeout=120)
+    return credential or build_credential(auth_mode)
 
 
-def _token(scope: str, credential: AzureCliCredential) -> str:
-    """Acquire an access token, retrying transient cold-``az`` auth failures.
-
-    A cold ``az account get-access-token`` (Power BI / Fabric audience) can time
-    out even with a generous process timeout; a retry usually succeeds once ``az``
-    has warmed up.
-    """
+def _token(scope: str, credential: TokenCredential) -> str:
+    """Acquire an access token, retrying transient operator-login failures."""
 
     from azure.core.exceptions import ClientAuthenticationError
 
@@ -205,7 +197,9 @@ def create_taskflow(
         "tasks": task_flow.get("tasks", []),
         "edges": task_flow.get("edges", []),
     }
-    response = pbi_session.post(url, json=body, headers={"Content-Type": "application/json"})
+    response = pbi_session.post(
+        url, json=body, headers={"Content-Type": "application/json"}
+    )
     response.raise_for_status()
     return response.status_code
 
@@ -214,7 +208,9 @@ def _guid_name_map(items: list[dict[str, Any]]) -> dict[str, str]:
     return {str(i["id"]): str(i.get("displayName", "")) for i in items}
 
 
-def to_portable(task_flow: dict[str, Any], guid_to_name: dict[str, str]) -> dict[str, Any]:
+def to_portable(
+    task_flow: dict[str, Any], guid_to_name: dict[str, str]
+) -> dict[str, Any]:
     """Replace each item's GUID with its display name so the flow is workspace-agnostic.
 
     Items whose GUID can't be resolved to a name (deleted/stale references, or ids
@@ -227,7 +223,9 @@ def to_portable(task_flow: dict[str, Any], guid_to_name: dict[str, str]) -> dict
     for task in portable.get("tasks", []):
         kept: list[dict[str, Any]] = []
         for item in task.get("items", []):
-            artifact_type, _, guid = str(item.get("artifactUniqueId", "")).partition(":")
+            artifact_type, _, guid = str(item.get("artifactUniqueId", "")).partition(
+                ":"
+            )
             name = guid_to_name.get(item.get("artifactObjectId") or guid)
             if name is None:
                 continue
@@ -271,15 +269,19 @@ def to_workspace(
 def export_taskflow(
     workspace: str,
     output_path: Path = DEFAULT_TASKFLOW_PATH,
-    credential: AzureCliCredential | None = None,
+    credential: TokenCredential | None = None,
+    *,
+    auth_mode: str = "azure_cli",
 ) -> Path:
     """Export a workspace task flow to a portable JSON file (artifacts by name)."""
 
-    credential = _credential(credential)
+    credential = _credential(credential, auth_mode=auth_mode)
     pbi = _session(_token(PBI_SCOPE, credential))
     fabric = _session(_token(FABRIC_SCOPE, credential))
-    workspace_id = workspace if _looks_like_guid(workspace) else find_workspace_id(
-        fabric, workspace
+    workspace_id = (
+        workspace
+        if _looks_like_guid(workspace)
+        else find_workspace_id(fabric, workspace)
     )
     cluster = resolve_cluster(pbi)
     record = get_taskflow(pbi, cluster, workspace_id)
@@ -297,16 +299,20 @@ def export_taskflow(
 def deploy_taskflow(
     workspace: str,
     input_path: Path = DEFAULT_TASKFLOW_PATH,
-    credential: AzureCliCredential | None = None,
+    credential: TokenCredential | None = None,
+    *,
+    auth_mode: str = "azure_cli",
 ) -> list[str]:
     """Deploy a portable task flow to a workspace. Returns unresolved references."""
 
     portable = json.loads(input_path.read_text(encoding="utf-8"))
-    credential = _credential(credential)
+    credential = _credential(credential, auth_mode=auth_mode)
     pbi = _session(_token(PBI_SCOPE, credential))
     fabric = _session(_token(FABRIC_SCOPE, credential))
-    workspace_id = workspace if _looks_like_guid(workspace) else find_workspace_id(
-        fabric, workspace
+    workspace_id = (
+        workspace
+        if _looks_like_guid(workspace)
+        else find_workspace_id(fabric, workspace)
     )
     items = list_workspace_items(fabric, workspace_id)
     name_type_to_guid = {
@@ -332,13 +338,27 @@ def main() -> int:
     parser.add_argument("action", choices=["export", "deploy"])
     parser.add_argument("--workspace", required=True, help="Workspace name or id.")
     parser.add_argument("--path", type=Path, default=DEFAULT_TASKFLOW_PATH)
+    parser.add_argument(
+        "--auth-mode",
+        choices=AUTH_MODES,
+        default="azure_cli",
+        help="Operator credential used for Power BI and Fabric requests.",
+    )
     args = parser.parse_args()
 
     if args.action == "export":
-        out = export_taskflow(args.workspace, args.path)
+        out = export_taskflow(
+            args.workspace,
+            args.path,
+            auth_mode=args.auth_mode,
+        )
         console.info(f"Exported task flow to {out}")
     else:
-        unresolved = deploy_taskflow(args.workspace, args.path)
+        unresolved = deploy_taskflow(
+            args.workspace,
+            args.path,
+            auth_mode=args.auth_mode,
+        )
         console.info("Deployed task flow.")
         if unresolved:
             console.warn("Unresolved references (left unbound):")

--- a/tests/deploy/test_apply_kql.py
+++ b/tests/deploy/test_apply_kql.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+import sys
 from pathlib import Path
 
 import pytest
@@ -81,7 +83,9 @@ def test_resolve_kql_database_returns_uri_and_name(monkeypatch) -> None:
         def json(self) -> dict:
             return {
                 "displayName": "retail_kql",
-                "properties": {"queryServiceUri": "https://cluster.kusto.fabric.microsoft.com"},
+                "properties": {
+                    "queryServiceUri": "https://cluster.kusto.fabric.microsoft.com"
+                },
             }
 
     captured: dict[str, object] = {}
@@ -173,6 +177,82 @@ def test_apply_to_database_runs_resolved_script(monkeypatch) -> None:
     assert calls["query_uri"] == "https://cluster"
     assert calls["database_name"] == "retail_kql"
     assert "ThrowOnErrors=true" in calls["script"]
+
+
+def test_apply_to_database_uses_selected_auth_mode(monkeypatch) -> None:
+    assert "auth_mode" in inspect.signature(apply_kql.apply_to_database).parameters
+    calls: dict[str, object] = {}
+    credential = object()
+
+    def fake_credential(provided=None, *, auth_mode: str):
+        calls["provided"] = provided
+        calls["auth_mode"] = auth_mode
+        return credential
+
+    monkeypatch.setattr(apply_kql, "_credential", fake_credential)
+    monkeypatch.setattr(
+        apply_kql,
+        "resolve_kql_database",
+        lambda *_args: ("https://cluster", "retail_kql"),
+    )
+
+    class _Response:
+        primary_results = [_FakeTable([])]
+
+    monkeypatch.setattr(
+        apply_kql,
+        "execute_database_script",
+        lambda *_args: _Response(),
+    )
+
+    apply_kql.apply_to_database(
+        script=".execute database script <| .show tables",
+        workspace_id="workspace-id",
+        kql_database_id="non-default-database-id",
+        auth_mode="azure_powershell",
+    )
+
+    assert calls == {"provided": None, "auth_mode": "azure_powershell"}
+
+
+def test_main_passes_selected_auth_mode(monkeypatch, tmp_path: Path) -> None:
+    output = tmp_path / "database.kql"
+    calls: dict[str, object] = {}
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "apply_kql",
+            "--execute",
+            "--workspace-id",
+            "workspace-id",
+            "--kql-database-id",
+            "database-id",
+            "--auth-mode",
+            "azure_powershell",
+            "--output",
+            str(output),
+        ],
+    )
+    monkeypatch.setattr(apply_kql, "collect_kql_scripts", lambda _source: [])
+    monkeypatch.setattr(
+        apply_kql,
+        "build_database_script",
+        lambda _scripts: ".execute database script <| .show tables",
+    )
+    monkeypatch.setattr(
+        apply_kql,
+        "apply_to_database",
+        lambda **kwargs: calls.update(kwargs) or 0,
+    )
+
+    try:
+        result = apply_kql.main()
+    except SystemExit as exc:
+        pytest.fail(f"--auth-mode was not accepted: {exc}")
+
+    assert result == 0
+    assert calls["auth_mode"] == "azure_powershell"
 
 
 def test_summarize_result_is_concise_on_success(capsys) -> None:

--- a/tests/deploy/test_auth.py
+++ b/tests/deploy/test_auth.py
@@ -1,0 +1,49 @@
+"""Tests for deployment credential selection."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from deploy.scripts import _auth
+
+
+@pytest.mark.parametrize(
+    ("auth_mode", "expected_kind"),
+    [
+        ("azure_cli", "cli"),
+        ("azure_powershell", "powershell"),
+    ],
+)
+def test_build_credential_uses_selected_operator_login(
+    monkeypatch,
+    auth_mode: str,
+    expected_kind: str,
+) -> None:
+    identity = ModuleType("azure.identity")
+
+    class _Credential:
+        def __init__(self, kind: str, *, process_timeout: int) -> None:
+            self.kind = kind
+            self.process_timeout = process_timeout
+
+    identity.AzureCliCredential = lambda **kwargs: _Credential("cli", **kwargs)
+    identity.AzurePowerShellCredential = lambda **kwargs: _Credential(
+        "powershell", **kwargs
+    )
+    azure = ModuleType("azure")
+    azure.identity = identity
+    monkeypatch.setitem(sys.modules, "azure", azure)
+    monkeypatch.setitem(sys.modules, "azure.identity", identity)
+
+    credential = _auth.build_credential(auth_mode)
+
+    assert credential.kind == expected_kind
+    assert credential.process_timeout == 120
+
+
+def test_build_credential_rejects_unsupported_mode() -> None:
+    with pytest.raises(ValueError, match="Unsupported auth mode"):
+        _auth.build_credential("managed_identity")

--- a/tests/deploy/test_export_items.py
+++ b/tests/deploy/test_export_items.py
@@ -3,15 +3,68 @@
 from __future__ import annotations
 
 import base64
+import inspect
 import json
+import sys
 from pathlib import Path
 
-from deploy.scripts import export_items
+import pytest
+
+from deploy.scripts import export_items, export_pipelines
 
 
 def _b64(payload: object) -> str:
     text = payload if isinstance(payload, str) else json.dumps(payload)
     return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def test_export_clients_accept_selected_auth_mode() -> None:
+    assert "auth_mode" in inspect.signature(export_items.build_session).parameters
+    assert "auth_mode" in inspect.signature(export_items.export_items).parameters
+    assert (
+        "auth_mode" in inspect.signature(export_pipelines.export_pipelines).parameters
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "function_name"),
+    [
+        (export_items, "export_items"),
+        (export_pipelines, "export_pipelines"),
+    ],
+)
+def test_export_main_passes_selected_auth_mode(
+    monkeypatch,
+    tmp_path: Path,
+    module,
+    function_name: str,
+) -> None:
+    calls: dict[str, object] = {}
+    argv = [
+        module.__name__,
+        "--workspace-name",
+        "retail-demo",
+        "--output-dir",
+        str(tmp_path),
+        "--auth-mode",
+        "azure_powershell",
+    ]
+    if module is export_items:
+        argv.extend(["--item-type", "DataAgent"])
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(
+        module,
+        function_name,
+        lambda *args, **kwargs: calls.update(kwargs) or [],
+    )
+
+    try:
+        result = module.main()
+    except SystemExit as exc:
+        pytest.fail(f"--auth-mode was not accepted: {exc}")
+
+    assert result == 0
+    assert calls["auth_mode"] == "azure_powershell"
 
 
 def test_write_item_writes_nested_parts_for_data_agent(tmp_path: Path) -> None:
@@ -37,7 +90,9 @@ def test_write_item_writes_nested_parts_for_data_agent(tmp_path: Path) -> None:
     platform = json.loads((item_dir / ".platform").read_text(encoding="utf-8"))
     assert platform["metadata"]["type"] == "DataAgent"
     # Nested part directories are created.
-    datasource = item_dir / "Files/Config/draft/semantic-model-retail_model/datasource.json"
+    datasource = (
+        item_dir / "Files/Config/draft/semantic-model-retail_model/datasource.json"
+    )
     assert json.loads(datasource.read_text(encoding="utf-8"))["artifactId"] == "abc"
 
 

--- a/tests/deploy/test_run_pipeline.py
+++ b/tests/deploy/test_run_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -40,9 +41,7 @@ def test_find_pipeline_id_matches_display_name() -> None:
         def get(self, url: str, params: dict | None = None) -> _FakeResponse:
             return _FakeResponse()
 
-    assert (
-        run_pipeline.find_pipeline_id(_FakeSession(), "ws", "setup-pipeline") == "2"
-    )
+    assert run_pipeline.find_pipeline_id(_FakeSession(), "ws", "setup-pipeline") == "2"
 
 
 def test_find_pipeline_id_raises_when_missing() -> None:
@@ -59,3 +58,38 @@ def test_find_pipeline_id_raises_when_missing() -> None:
 
     with pytest.raises(ValueError, match="not found"):
         run_pipeline.find_pipeline_id(_FakeSession(), "ws", "setup-pipeline")
+
+
+def test_main_passes_selected_auth_mode_to_session(monkeypatch) -> None:
+    calls: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_pipeline",
+            "--environment",
+            "dev",
+            "--pipeline",
+            "setup-pipeline",
+            "--auth-mode",
+            "azure_powershell",
+        ],
+    )
+    monkeypatch.setattr(run_pipeline, "workspace_id_from_outputs", lambda _env: "ws")
+
+    def fake_build_session(*, auth_mode: str):
+        calls["auth_mode"] = auth_mode
+        return object()
+
+    monkeypatch.setattr(run_pipeline, "build_session", fake_build_session)
+    monkeypatch.setattr(run_pipeline, "find_pipeline_id", lambda *_args: "pipeline-id")
+    monkeypatch.setattr(run_pipeline, "run_pipeline", lambda *_args: None)
+
+    try:
+        result = run_pipeline.main()
+    except SystemExit as exc:
+        pytest.fail(f"--auth-mode was not accepted: {exc}")
+
+    assert result == 0
+    assert calls["auth_mode"] == "azure_powershell"

--- a/tests/deploy/test_taskflow.py
+++ b/tests/deploy/test_taskflow.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
 import re
+import sys
 
 import pytest
 
@@ -25,6 +27,61 @@ def test_token_retries_transient_auth_failure(monkeypatch) -> None:
 
     assert taskflow._token("scope", _Cred()) == "tok"
     assert calls["n"] == 2
+
+
+def test_taskflow_clients_accept_selected_auth_mode() -> None:
+    assert "auth_mode" in inspect.signature(taskflow.export_taskflow).parameters
+    assert "auth_mode" in inspect.signature(taskflow.deploy_taskflow).parameters
+
+
+def test_credential_uses_selected_auth_mode(monkeypatch) -> None:
+    assert "auth_mode" in inspect.signature(taskflow._credential).parameters
+    calls: list[str] = []
+    expected = object()
+    monkeypatch.setattr(
+        taskflow,
+        "build_credential",
+        lambda auth_mode: calls.append(auth_mode) or expected,
+        raising=False,
+    )
+
+    actual = taskflow._credential(auth_mode="azure_powershell")
+
+    assert actual is expected
+    assert calls == ["azure_powershell"]
+
+
+def test_main_passes_selected_auth_mode(monkeypatch, tmp_path) -> None:
+    calls: dict[str, object] = {}
+    path = tmp_path / "taskflow.json"
+    path.write_text('{"tasks": [], "edges": []}', encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "taskflow",
+            "deploy",
+            "--workspace",
+            "retail-demo",
+            "--path",
+            str(path),
+            "--auth-mode",
+            "azure_powershell",
+        ],
+    )
+    monkeypatch.setattr(
+        taskflow,
+        "deploy_taskflow",
+        lambda *args, **kwargs: calls.update(kwargs) or [],
+    )
+
+    try:
+        result = taskflow.main()
+    except SystemExit as exc:
+        pytest.fail(f"--auth-mode was not accepted: {exc}")
+
+    assert result == 0
+    assert calls["auth_mode"] == "azure_powershell"
 
 
 def test_to_portable_resolves_guids_to_names() -> None:
@@ -50,7 +107,10 @@ def test_to_portable_resolves_guids_to_names() -> None:
         ],
         "edges": [],
     }
-    guid_to_name = {"nb-guid": "02-historical-data-load", "pl-guid": "historical-data-load"}
+    guid_to_name = {
+        "nb-guid": "02-historical-data-load",
+        "pl-guid": "historical-data-load",
+    }
 
     portable = taskflow.to_portable(task_flow, guid_to_name)
 
@@ -100,7 +160,9 @@ def test_committed_taskflow_has_only_bindable_items() -> None:
 
     repo_root = Path(__file__).resolve().parents[2]
     data = _json.loads(
-        (repo_root / "fabric" / "taskflow" / "taskflow.json").read_text(encoding="utf-8")
+        (repo_root / "fabric" / "taskflow" / "taskflow.json").read_text(
+            encoding="utf-8"
+        )
     )
     # Hash-suffixed runtime artifacts (e.g. RetailOntology_AutoGen_graph_<32 hex>,
     # *_lh_<32 hex>) get a fresh GUID-derived suffix every run and can never bind by
@@ -121,7 +183,10 @@ def test_to_workspace_resolves_names_to_target_guids_and_reports_unresolved() ->
             {
                 "id": "t1",
                 "items": [
-                    {"artifactType": "SynapseNotebook", "artifactName": "02-historical-data-load"},
+                    {
+                        "artifactType": "SynapseNotebook",
+                        "artifactName": "02-historical-data-load",
+                    },
                     {"artifactType": "Pipeline", "artifactName": "missing-pipeline"},
                 ],
             }
@@ -154,7 +219,10 @@ def test_deploy_creates_taskflow_when_workspace_has_none(monkeypatch, tmp_path) 
                     {
                         "id": "t1",
                         "items": [
-                            {"artifactType": "Pipeline", "artifactName": "setup-pipeline"}
+                            {
+                                "artifactType": "Pipeline",
+                                "artifactName": "setup-pipeline",
+                            }
                         ],
                     }
                 ],
@@ -172,7 +240,9 @@ def test_deploy_creates_taskflow_when_workspace_has_none(monkeypatch, tmp_path) 
     monkeypatch.setattr(
         taskflow,
         "list_workspace_items",
-        lambda *_a: [{"type": "DataPipeline", "displayName": "setup-pipeline", "id": "pl"}],
+        lambda *_a: [
+            {"type": "DataPipeline", "displayName": "setup-pipeline", "id": "pl"}
+        ],
     )
     monkeypatch.setattr(taskflow, "resolve_cluster", lambda *_a: "https://c")
     monkeypatch.setattr(taskflow, "get_taskflow", lambda *_a: None)  # no existing flow
@@ -183,7 +253,9 @@ def test_deploy_creates_taskflow_when_workspace_has_none(monkeypatch, tmp_path) 
         return 201
 
     monkeypatch.setattr(taskflow, "create_taskflow", fake_create)
-    monkeypatch.setattr(taskflow, "put_taskflow", lambda *a, **k: calls.update(put=calls["put"] + 1))
+    monkeypatch.setattr(
+        taskflow, "put_taskflow", lambda *a, **k: calls.update(put=calls["put"] + 1)
+    )
 
     unresolved = taskflow.deploy_taskflow("retail-demo-dev", path)
 
@@ -195,7 +267,9 @@ def test_deploy_updates_taskflow_when_workspace_has_one(monkeypatch, tmp_path) -
     import json as _json
 
     path = tmp_path / "taskflow.json"
-    path.write_text(_json.dumps({"id": "x", "tasks": [], "edges": []}), encoding="utf-8")
+    path.write_text(
+        _json.dumps({"id": "x", "tasks": [], "edges": []}), encoding="utf-8"
+    )
     calls = {"create": 0, "put": 0}
 
     monkeypatch.setattr(taskflow, "_session", lambda *_a, **_k: object())
@@ -209,8 +283,14 @@ def test_deploy_updates_taskflow_when_workspace_has_one(monkeypatch, tmp_path) -
         "get_taskflow",
         lambda *_a: {"resourceId": "r", "etag": "e", "taskFlow": {"id": "i"}},
     )
-    monkeypatch.setattr(taskflow, "create_taskflow", lambda *a, **k: calls.update(create=calls["create"] + 1))
-    monkeypatch.setattr(taskflow, "put_taskflow", lambda *a, **k: calls.update(put=calls["put"] + 1))
+    monkeypatch.setattr(
+        taskflow,
+        "create_taskflow",
+        lambda *a, **k: calls.update(create=calls["create"] + 1),
+    )
+    monkeypatch.setattr(
+        taskflow, "put_taskflow", lambda *a, **k: calls.update(put=calls["put"] + 1)
+    )
 
     taskflow.deploy_taskflow("retail-demo-dev", path)
 

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -452,6 +452,18 @@ def _lakehouse_name(repo_root: Path, env: str) -> str:
     return str(name)
 
 
+def _auth_mode(repo_root: Path, env: str) -> str:
+    """Resolve auth.mode from deploy config; the environment overlay wins."""
+
+    base = yaml.safe_load((repo_root / "deploy" / "config" / "deploy.yml").read_text()) or {}
+    env_path = repo_root / "deploy" / "config" / "environments" / f"{env}.yml"
+    overlay = yaml.safe_load(env_path.read_text()) or {} if env_path.is_file() else {}
+    mode = _get_by_path(overlay, "auth.mode")
+    if mode is None:
+        mode = _get_by_path(base, "auth.mode")
+    return str(mode or "azure_cli")
+
+
 def _workspace_name(repo_root: Path, env: str) -> str:
     """Resolve the target workspace.name from deploy config (overlay wins)."""
     base = yaml.safe_load((repo_root / "deploy" / "config" / "deploy.yml").read_text()) or {}
@@ -871,14 +883,14 @@ def deploy(
         # dry runs must not require live config; fall back to the default name
         try:
             lakehouse = _lakehouse_name(repo_root, env)
-            auth_mode = _load_deploy_environment(repo_root, env).auth_mode
+            auth_mode = _auth_mode(repo_root, env)
         except (ImportError, typer.Exit, OSError, KeyError, yaml.YAMLError):
             lakehouse = "retail_lakehouse"
             auth_mode = "azure_cli"
             typer.echo("note: deploy config unavailable; plan shows default lakehouse name")
     else:
         lakehouse = _lakehouse_name(repo_root, env)
-        auth_mode = _load_deploy_environment(repo_root, env).auth_mode
+        auth_mode = _auth_mode(repo_root, env)
         _validate_azure_cli_tenant(repo_root, env)
         # Auto-detect a prior deployment so the user doesn't need to remember
         # --recreate. If the workspace exists, offer a clean-slate reset.

--- a/utility/src/retail_setup/cli/main.py
+++ b/utility/src/retail_setup/cli/main.py
@@ -34,6 +34,7 @@ app = typer.Typer(no_args_is_help=True)
 def _main() -> None:
     """retail-setup: configure, render, and deploy the Fabric setup utility."""
 
+
 # generation keys the user supplies via `configure`; derived defaults
 # (dc_count, customer_count, ...) are intentionally not persisted.
 _GENERATION_KEYS = ("store_type", "months", "store_count", "seed")
@@ -217,7 +218,9 @@ def _validate_azure_cli_tenant(repo_root: Path, env: str) -> None:
                 "Azure CLI is required for auth.mode=azure_cli but `az` was not found on PATH.",
                 err=True,
             )
-            typer.echo("Install Azure CLI or set deploy config auth.mode to azure_powershell.", err=True)
+            typer.echo(
+                "Install Azure CLI or set deploy config auth.mode to azure_powershell.", err=True
+            )
         else:
             typer.echo("Azure CLI is not logged in.", err=True)
             typer.echo(f"Run: az login --tenant {config.tenant_id}", err=True)
@@ -247,9 +250,7 @@ def configure(
     capacity_name: Optional[str] = typer.Option(
         None, "--capacity-name", help="Fabric capacity name."
     ),
-    lakehouse_name: Optional[str] = typer.Option(
-        None, "--lakehouse-name", help="Lakehouse name."
-    ),
+    lakehouse_name: Optional[str] = typer.Option(None, "--lakehouse-name", help="Lakehouse name."),
     eventhouse_name: Optional[str] = typer.Option(
         None, "--eventhouse-name", help="Eventhouse name."
     ),
@@ -294,14 +295,21 @@ def configure(
 
     store_types = _available_store_types()
     store_type_prompt = (
-        f"Store type (available: {', '.join(store_types)})"
-        if store_types
-        else "Store type"
+        f"Store type (available: {', '.join(store_types)})" if store_types else "Store type"
     )
 
     _prompted_values = (
-        tenant_id, workspace_name, capacity_name, lakehouse_name, eventhouse_name,
-        kql_database_name, use_custom_spark_pool, store_type, months, store_count, seed,
+        tenant_id,
+        workspace_name,
+        capacity_name,
+        lakehouse_name,
+        eventhouse_name,
+        kql_database_name,
+        use_custom_spark_pool,
+        store_type,
+        months,
+        store_count,
+        seed,
     )
     if any(value is None for value in _prompted_values) and sys.stdin.isatty():
         typer.echo("")
@@ -342,9 +350,7 @@ def configure(
     use_custom_spark_pool = _prompt_bool(
         "Run setup on a custom Spark pool (optimized for F64) instead of the default starter pool",
         use_custom_spark_pool,
-        default=bool(
-            _config_default(base_config, env_config, "spark.use_custom_pool") or False
-        ),
+        default=bool(_config_default(base_config, env_config, "spark.use_custom_pool") or False),
     )
     # Generation settings: prompt, show a record-count estimate, and (when
     # interactive) offer to change them before committing. Validation happens
@@ -356,9 +362,7 @@ def configure(
     )
     months_default = int(existing_generation.get("months", _DEFAULT_MONTHS))
     store_count_default = int(
-        existing_generation.get(
-            "store_count", GenerationConfig.model_fields["store_count"].default
-        )
+        existing_generation.get("store_count", GenerationConfig.model_fields["store_count"].default)
     )
     seed_default = int(
         existing_generation.get("seed", GenerationConfig.model_fields["seed"].default)
@@ -471,10 +475,14 @@ def _workspace_exists(repo_root: Path, workspace_name: str) -> bool:
     try:
         result = subprocess.run(
             [
-                az, "rest",
-                "--resource", "https://api.fabric.microsoft.com",
-                "--url", "https://api.fabric.microsoft.com/v1/workspaces",
-                "-o", "json",
+                az,
+                "rest",
+                "--resource",
+                "https://api.fabric.microsoft.com",
+                "--url",
+                "https://api.fabric.microsoft.com/v1/workspaces",
+                "-o",
+                "json",
             ],
             cwd=repo_root,
             capture_output=True,
@@ -490,10 +498,7 @@ def _workspace_exists(repo_root: Path, workspace_name: str) -> bool:
         data = json.loads(result.stdout)
     except json.JSONDecodeError:
         return False
-    return any(
-        str(item.get("displayName", "")) == workspace_name
-        for item in data.get("value", [])
-    )
+    return any(str(item.get("displayName", "")) == workspace_name for item in data.get("value", []))
 
 
 def _resolve_dictionary_ref(repo_root: Path, ref: str | None) -> str:
@@ -590,6 +595,7 @@ def _deploy_plan(
     skip_terraform: bool,
     lakehouse_name: str = "retail_lakehouse",
     recreate: bool = False,
+    auth_mode: str = "azure_cli",
 ) -> list[DeployStep]:
     """Build the ordered deploy command plan (data only; nothing is executed)."""
     py = sys.executable
@@ -624,8 +630,7 @@ def _deploy_plan(
                 DeployStep(
                     cmd=[py, "-c", f"import time; time.sleep({_RECREATE_WAIT_SECONDS})"],
                     description=(
-                        f"Wait {_RECREATE_WAIT_SECONDS}s for Fabric to finalize "
-                        "workspace deletion"
+                        f"Wait {_RECREATE_WAIT_SECONDS}s for Fabric to finalize workspace deletion"
                     ),
                 ),
             ]
@@ -678,7 +683,15 @@ def _deploy_plan(
             description="Build deployment artifacts",
         ),
         DeployStep(
-            cmd=[py, "-m", "deploy.scripts.deploy_items", "--environment", env],
+            cmd=[
+                py,
+                "-m",
+                "deploy.scripts.deploy_items",
+                "--environment",
+                env,
+                "--auth-mode",
+                auth_mode,
+            ],
             description="Deploy Fabric items",
         ),
         DeployStep(
@@ -689,6 +702,8 @@ def _deploy_plan(
                 "--execute",
                 "--environment",
                 env,
+                "--auth-mode",
+                auth_mode,
                 "--output",
                 f"deploy/.generated/{env}/database.kql",
             ],
@@ -749,7 +764,6 @@ def _missing_executable_message(executable: str) -> str:
     return f"Required executable not found: {executable}\nInstall it and ensure it is on PATH."
 
 
-
 def _is_terraform_apply(step: DeployStep) -> bool:
     return bool(step.cmd) and step.cmd[0] == "terraform" and "apply" in step.cmd
 
@@ -785,9 +799,7 @@ def _run_plan_plain(
             if step.output_file:
                 out_path = repo_root / step.output_file
                 out_path.parent.mkdir(parents=True, exist_ok=True)
-                result = subprocess.run(
-                    step.cmd, cwd=repo_root, capture_output=True, text=True
-                )
+                result = subprocess.run(step.cmd, cwd=repo_root, capture_output=True, text=True)
                 if result.returncode == 0:
                     out_path.write_text(result.stdout)
                     typer.echo(f"Wrote output to {step.output_file}")
@@ -824,9 +836,7 @@ def deploy(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print the command plan without executing anything."
     ),
-    yes: bool = typer.Option(
-        False, "--yes", help="Pre-confirm gated steps (Terraform apply)."
-    ),
+    yes: bool = typer.Option(False, "--yes", help="Pre-confirm gated steps (Terraform apply)."),
     recreate: bool = typer.Option(
         False,
         "--recreate",
@@ -861,11 +871,14 @@ def deploy(
         # dry runs must not require live config; fall back to the default name
         try:
             lakehouse = _lakehouse_name(repo_root, env)
-        except (typer.Exit, OSError, KeyError, yaml.YAMLError):
+            auth_mode = _load_deploy_environment(repo_root, env).auth_mode
+        except (ImportError, typer.Exit, OSError, KeyError, yaml.YAMLError):
             lakehouse = "retail_lakehouse"
+            auth_mode = "azure_cli"
             typer.echo("note: deploy config unavailable; plan shows default lakehouse name")
     else:
         lakehouse = _lakehouse_name(repo_root, env)
+        auth_mode = _load_deploy_environment(repo_root, env).auth_mode
         _validate_azure_cli_tenant(repo_root, env)
         # Auto-detect a prior deployment so the user doesn't need to remember
         # --recreate. If the workspace exists, offer a clean-slate reset.
@@ -882,7 +895,13 @@ def deploy(
                     recreate = True
                 else:
                     typer.echo("Keeping it — updating the existing workspace in place.")
-    plan = _deploy_plan(env, skip_terraform, lakehouse_name=lakehouse, recreate=recreate)
+    plan = _deploy_plan(
+        env,
+        skip_terraform,
+        lakehouse_name=lakehouse,
+        recreate=recreate,
+        auth_mode=auth_mode,
+    )
     total = len(plan)
 
     _deploy_banner(env, total, recreate, dry_run)
@@ -904,7 +923,7 @@ def deploy(
     taskflow_path = repo_root / "fabric" / "taskflow" / "taskflow.json"
     if taskflow_path.is_file():
         typer.echo("Wiring up the workspace task flow (the visual item graph)...")
-        _deploy_taskflow(repo_root, env)
+        _deploy_taskflow(repo_root, env, auth_mode=auth_mode)
 
     if not yes:
         if typer.confirm(
@@ -912,8 +931,8 @@ def deploy(
             "then train the ML models and build the ontology)?",
             default=False,
         ):
-            _run_setup_pipeline(repo_root, env)
-            _print_ontology_relink_hint(repo_root, env)
+            _run_setup_pipeline(repo_root, env, auth_mode=auth_mode)
+            _print_ontology_relink_hint(repo_root, env, auth_mode=auth_mode)
         else:
             typer.echo(
                 "Skipping. Run later with: "
@@ -921,7 +940,12 @@ def deploy(
             )
 
 
-def _deploy_taskflow(repo_root: Path, env: str) -> None:
+def _deploy_taskflow(
+    repo_root: Path,
+    env: str,
+    *,
+    auth_mode: str = "azure_cli",
+) -> None:
     """Deploy the workspace task flow to the target workspace."""
 
     workspace = _workspace_name(repo_root, env)
@@ -932,18 +956,26 @@ def _deploy_taskflow(repo_root: Path, env: str) -> None:
         "deploy",
         "--workspace",
         workspace,
+        "--auth-mode",
+        auth_mode,
     ]
     typer.echo("    " + " ".join(cmd))
     result = subprocess.run(cmd, cwd=repo_root)
     if result.returncode != 0:
         typer.echo(
             "Could not deploy the task flow automatically. Run later with: "
-            f"python -m deploy.scripts.taskflow deploy --workspace {workspace!r}.",
+            "python -m deploy.scripts.taskflow deploy "
+            f"--workspace {workspace!r} --auth-mode {auth_mode}.",
             err=True,
         )
 
 
-def _print_ontology_relink_hint(repo_root: Path, env: str) -> None:
+def _print_ontology_relink_hint(
+    repo_root: Path,
+    env: str,
+    *,
+    auth_mode: str = "azure_cli",
+) -> None:
     """Explain why the ontology task-flow node is unbound and how it links.
 
     The ontology is created at the end of the setup pipeline (``30-create-ontology``),
@@ -961,11 +993,17 @@ def _print_ontology_relink_hint(repo_root: Path, env: str) -> None:
         "It links automatically the next time you run 'retail-setup deploy' (once the\n"
         "ontology exists). To link it sooner, re-run the task flow deploy after the\n"
         "pipeline finishes:\n"
-        f"    python -m deploy.scripts.taskflow deploy --workspace {workspace}"
+        "    python -m deploy.scripts.taskflow deploy "
+        f"--workspace {workspace} --auth-mode {auth_mode}"
     )
 
 
-def _run_setup_pipeline(repo_root: Path, env: str) -> None:
+def _run_setup_pipeline(
+    repo_root: Path,
+    env: str,
+    *,
+    auth_mode: str = "azure_cli",
+) -> None:
     """Start an on-demand run of the deployed setup pipeline.
 
     Prints a heads-up that generation can take a while (it runs asynchronously in
@@ -990,6 +1028,8 @@ def _run_setup_pipeline(repo_root: Path, env: str) -> None:
         env,
         "--pipeline",
         "setup-pipeline",
+        "--auth-mode",
+        auth_mode,
     ]
     typer.echo("    " + " ".join(cmd))
     for attempt in range(1, _PIPELINE_TRIGGER_ATTEMPTS + 1):

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -33,10 +33,11 @@ def test_dry_run_prints_full_plan_and_executes_nothing(monkeypatch):
 
 
 def test_dry_run_uses_configured_auth_mode(monkeypatch):
+    assert hasattr(cli, "_auth_mode")
     monkeypatch.setattr(
         cli,
-        "_load_deploy_environment",
-        lambda *_args: SimpleNamespace(auth_mode="azure_powershell"),
+        "_auth_mode",
+        lambda *_args: "azure_powershell",
     )
 
     result = runner.invoke(app, ["deploy", "--env", "dev", "--dry-run"])
@@ -45,11 +46,13 @@ def test_dry_run_uses_configured_auth_mode(monkeypatch):
     assert "--auth-mode azure_powershell" in result.output
 
 
-def test_dry_run_falls_back_when_deploy_config_loader_is_unavailable(monkeypatch):
-    def unavailable(*_args):
-        raise ImportError("deploy helpers unavailable")
+def test_dry_run_falls_back_when_auth_config_is_unavailable(monkeypatch):
+    assert hasattr(cli, "_auth_mode")
 
-    monkeypatch.setattr(cli, "_load_deploy_environment", unavailable)
+    def unavailable(*_args):
+        raise OSError("deploy config unavailable")
+
+    monkeypatch.setattr(cli, "_auth_mode", unavailable)
 
     result = runner.invoke(app, ["deploy", "--env", "dev", "--dry-run"])
 

--- a/utility/tests/test_cli_deploy.py
+++ b/utility/tests/test_cli_deploy.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 import retail_setup.cli.main as cli
 from retail_setup.cli.main import (
     app,
+    _deploy_taskflow,
     _deploy_plan,
     _validate_azure_cli_tenant,
     _RECREATE_WAIT_SECONDS,
@@ -25,8 +26,35 @@ def test_dry_run_prints_full_plan_and_executes_nothing(monkeypatch):
     assert calls == []
     out = result.output
     assert "generate_configs" in out and "terraform" in out
-    assert "build_artifacts" in out and "core setup ml ontology reset stream" in out.replace("'", "")
+    assert "build_artifacts" in out and "core setup ml ontology reset stream" in out.replace(
+        "'", ""
+    )
     assert "deploy_items" in out and "apply_kql" in out and "validate_deployment" in out
+
+
+def test_dry_run_uses_configured_auth_mode(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_load_deploy_environment",
+        lambda *_args: SimpleNamespace(auth_mode="azure_powershell"),
+    )
+
+    result = runner.invoke(app, ["deploy", "--env", "dev", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "--auth-mode azure_powershell" in result.output
+
+
+def test_dry_run_falls_back_when_deploy_config_loader_is_unavailable(monkeypatch):
+    def unavailable(*_args):
+        raise ImportError("deploy helpers unavailable")
+
+    monkeypatch.setattr(cli, "_load_deploy_environment", unavailable)
+
+    result = runner.invoke(app, ["deploy", "--env", "dev", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "--auth-mode azure_cli" in result.output
 
 
 def test_skip_terraform_drops_terraform_steps():
@@ -34,6 +62,29 @@ def test_skip_terraform_drops_terraform_steps():
     flat = " ".join(" ".join(map(str, step.cmd)) for step in plan)
     assert "terraform" not in flat
     assert "generate_configs" in flat and "deploy_items" in flat
+
+
+def test_plan_propagates_selected_auth_mode():
+    import inspect
+
+    assert "auth_mode" in inspect.signature(_deploy_plan).parameters
+    plan = _deploy_plan(
+        "dev",
+        skip_terraform=True,
+        auth_mode="azure_powershell",
+    )
+    authenticated = [
+        step.cmd
+        for step in plan
+        if any(
+            name in step.cmd for name in ("deploy.scripts.deploy_items", "deploy.scripts.apply_kql")
+        )
+    ]
+
+    assert len(authenticated) == 2
+    assert all(
+        command[command.index("--auth-mode") + 1] == "azure_powershell" for command in authenticated
+    )
 
 
 def test_plan_builds_ontology_and_reset_notebook_groups():
@@ -66,9 +117,7 @@ def test_recreate_inserts_destroy_and_sleep_before_apply():
     cmds = [" ".join(map(str, s.cmd)) for s in plan]
     init_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and "init" in c)
     destroy_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and "destroy" in c)
-    sleep_idx = next(
-        i for i, c in enumerate(cmds) if f"time.sleep({_RECREATE_WAIT_SECONDS})" in c
-    )
+    sleep_idx = next(i for i, c in enumerate(cmds) if f"time.sleep({_RECREATE_WAIT_SECONDS})" in c)
     apply_idx = next(i for i, c in enumerate(cmds) if "terraform" in c and "apply" in c)
     assert init_idx < destroy_idx < sleep_idx < apply_idx
     assert plan[destroy_idx].needs_confirmation
@@ -209,18 +258,36 @@ def test_workspace_name_prefers_environment_overlay(tmp_path):
 def test_run_setup_pipeline_warns_takes_a_while_and_retries(monkeypatch, capsys):
     monkeypatch.setattr(cli.time, "sleep", lambda *_a: None)
     attempts = {"n": 0}
+    commands = []
 
-    def fake_run(_cmd, cwd=None):
+    def fake_run(cmd, cwd=None):
+        commands.append(cmd)
         attempts["n"] += 1
         # Fail the first trigger, succeed on the retry.
         return SimpleNamespace(returncode=1 if attempts["n"] == 1 else 0)
 
     monkeypatch.setattr("subprocess.run", fake_run)
-    _run_setup_pipeline(Path("."), "dev")
+    _run_setup_pipeline(Path("."), "dev", auth_mode="azure_powershell")
 
     out = capsys.readouterr().out
     assert "can take a while" in out
     assert attempts["n"] == 2  # retried once after the initial failure
+    assert all(
+        command[command.index("--auth-mode") + 1] == "azure_powershell" for command in commands
+    )
+
+
+def test_deploy_taskflow_passes_selected_auth_mode(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(cli, "_workspace_name", lambda *_args: "retail-demo-dev")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda cmd, cwd=None: calls.append(cmd) or SimpleNamespace(returncode=0),
+    )
+
+    _deploy_taskflow(tmp_path, "dev", auth_mode="azure_powershell")
+
+    assert calls[0][calls[0].index("--auth-mode") + 1] == "azure_powershell"
 
 
 def test_run_setup_pipeline_gives_up_after_max_attempts(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- centralize Azure CLI and Azure PowerShell credential construction for deployment clients
- propagate the environment-selected auth mode through item publication, KQL application, exports, task-flow deployment, and pipeline triggering
- add request and command contract coverage while preserving bearer headers and non-default KQL database targeting

## Test Plan
- `python -m pytest tests/deploy utility/tests/test_cli_deploy.py -q`
- `python -m ruff check <changed Python files>`
- `python -m ruff format --check <changed Python files>`

## Deployment considerations
- `azure_cli` remains the default for standalone commands
- no live Fabric mutation was performed; a live smoke deployment remains part of the broader IMP-001 backlog acceptance

Closes #318