### PR TITLE
fix(power-bi): hide remaining orphan raw event_date columns (IMP-009 slice)

### DIFF
--- a/docs/design/requirements/modules/power-bi/backlog.md
+++ b/docs/design/requirements/modules/power-bi/backlog.md
@@ -9,14 +9,17 @@
   weighting, labels, and technical-field visibility agree across KQL and DAX.
 - **Acceptance:** Automated query/model tests prove labels, slicers, state, and
   source grain.
-- **Progress:** Status normalization and one technical-field-visibility defect
-  are resolved and guarded: the payment-anomaly KQL function filtered on
-  lowercase `"declined"` (never matched the uppercase source enum), now fixed to
-  `"DECLINED"`; the orphan raw `event_date` column on `fact_payments` (no
-  `dim_date` relationship, duplicates `Event Timestamp`) is now hidden.
+- **Progress:** Status normalization and technical-field-visibility defects are
+  resolved and guarded: the payment-anomaly KQL function filtered on lowercase
+  `"declined"` (never matched the uppercase source enum), now fixed to
+  `"DECLINED"`; every orphan raw `event_date` column (`fact_payments`,
+  `fact_promotions`, `fact_receipt_lines` — none of which have a `dim_date`
+  relationship) is now hidden to remove duplicate/ambiguous date slicers.
   `tests/scripts/test_kpi_status_semantics.py` pins canonical UPPERCASE status
-  literals across KQL and DAX and the visibility fix. State folding, date
-  relationships, grain, and weighting reconciliation remain open.
+  literals across KQL and DAX and generically asserts that any `event_date`
+  column that is not a `dim_date` relationship key stays hidden. State folding,
+  date-relationship/grain reconciliation for the visible key columns, and
+  weighting remain open.
 
 ### ENH-002 - Make dynamic pricing the flagship closed-loop action story {#enh-002}
 

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_promotions.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_promotions.tmdl
@@ -117,9 +117,11 @@ table fact_promotions
 
 		annotation SummarizationSetBy = Automatic
 
+	/// Raw event date carried for lineage only. Promotions inherit date context via the active Promotions-to-Receipts relationship, so this technical column is hidden to avoid duplicate/ambiguous date slicers.
 	column event_date
 		dataType: dateTime
 		formatString: General Date
+		isHidden
 		lineageTag: e5bdf9a5-d264-46a2-ad65-0f11dea87b29
 		sourceLineageTag: event_date
 		summarizeBy: none

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_receipt_lines.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_receipt_lines.tmdl
@@ -164,9 +164,11 @@ table fact_receipt_lines
 
 		annotation SummarizationSetBy = Automatic
 
+	/// Raw event date carried for lineage only. Receipt lines inherit date context via the active Receipt-Lines-to-Receipts relationship, so this technical column is hidden to avoid duplicate/ambiguous date slicers.
 	column event_date
 		dataType: dateTime
 		formatString: General Date
+		isHidden
 		lineageTag: 2545fc5f-7a82-428a-be86-63f077dd2334
 		sourceLineageTag: event_date
 		summarizeBy: none

--- a/tests/scripts/test_kpi_status_semantics.py
+++ b/tests/scripts/test_kpi_status_semantics.py
@@ -6,9 +6,9 @@ Status enumerations (payment ``status``, ``attribution_status``, pricing
 ``utility/src/retail_setup/generation/receipts.py`` and ``online_orders.py``).
 Any KQL function/materialized view or DAX measure that compares against a
 lowercase literal silently matches nothing, so these tests pin the casing
-contract on both layers. They also assert that the orphan ``event_date``
-technical column on ``fact_payments`` stays hidden to avoid ambiguous date
-slicers.
+contract on both layers. They also assert that orphan ``event_date``
+technical columns (raw date columns that are not dim_date relationship keys)
+stay hidden to avoid ambiguous date slicers.
 """
 
 from __future__ import annotations
@@ -98,3 +98,53 @@ def test_orphan_payment_event_date_is_hidden() -> None:
     assert "isHidden" in block.group("body"), (
         "fact_payments.event_date must be hidden (isHidden)."
     )
+
+
+def _dim_date_relationship_keys() -> set[tuple[str, str]]:
+    """(table, column display name) pairs that are legitimate dim_date keys."""
+    text = (SEMANTIC_DEFINITION / "relationships.tmdl").read_text(encoding="utf-8")
+    keys: set[tuple[str, str]] = set()
+    for block in re.split(r"(?=^relationship )", text, flags=re.MULTILINE):
+        to_match = re.search(r"^\ttoColumn: (.+)$", block, re.MULTILINE)
+        from_match = re.search(r"^\tfromColumn: (.+)$", block, re.MULTILINE)
+        if not to_match or not from_match:
+            continue
+        if not to_match.group(1).strip().startswith("dim_date."):
+            continue
+        table, _, column = from_match.group(1).strip().partition(".")
+        keys.add((table.strip("'"), column.strip("'")))
+    return keys
+
+
+def _event_date_columns() -> list[tuple[str, str, str]]:
+    """(table, column display name, column body) for every event_date column."""
+    found: list[tuple[str, str, str]] = []
+    for path in sorted(TABLES_DIR.glob("*.tmdl")):
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(
+            r"\tcolumn '?(?P<name>[^'\n]+?)'?\n(?P<body>(?:\t\t.+\n)+)", text
+        ):
+            body = match.group("body")
+            if re.search(r"^\t\tsourceColumn: event_date$", body, re.MULTILINE):
+                found.append((path.stem, match.group("name"), body))
+    return found
+
+
+def test_orphan_event_date_columns_are_hidden() -> None:
+    # Any fact-table column sourced from raw ``event_date`` that is NOT used as
+    # a dim_date relationship key duplicates the event timestamp and produces an
+    # ambiguous date slicer, so it must be hidden. Relationship-key date columns
+    # (e.g. fact_receipts.'Event Date') stay visible.
+    relationship_keys = _dim_date_relationship_keys()
+    columns = _event_date_columns()
+    assert columns, "Expected at least one event_date column to guard."
+    offenders = [
+        f"{table}.{name}"
+        for table, name, body in columns
+        if (table, name) not in relationship_keys and "isHidden" not in body
+    ]
+    assert not offenders, (
+        "Orphan raw event_date columns (not dim_date relationship keys) must be "
+        f"hidden to avoid ambiguous date slicers; offenders: {offenders}"
+    )
+


### PR DESCRIPTION
## Summary
Continues **IMP-009** (KPI grain / date-slicer semantics). Extends the merged `fact_payments` visibility fix (#347) to the two remaining fact tables with the identical defect.

### Fixes
- Hid the orphan raw `event_date` column on **`fact_promotions`** and **`fact_receipt_lines`**. Neither table has a `dim_date` relationship — both inherit date context via their active parent *…-to-Receipts* relationship — so the raw lowercase `event_date` column only duplicated the event timestamp and produced an ambiguous date slicer.

### Guard (generalized)
- `tests/scripts/test_kpi_status_semantics.py` now scans **all** semantic-model tables and asserts that any `event_date`-sourced column that is **not** a `dim_date` relationship key (e.g. the legitimate `fact_receipts.'Event Date'` bridge stays visible) is hidden. This covers all three fixed tables and catches future orphans automatically.

### Safety
- Verified no report visual references these columns (the only forecast visuals bind `demand_forecast.'Forecast Date'`, untouched).

### Docs
- Updated the power-bi `backlog.md` progress note. **IMP-009 remains open** for state folding, visible-key date-relationship/grain reconciliation, and weighting.

## Testing
- `pytest tests/scripts tests/test_marketing_attribution_contract.py` → **78 passed**.