### PR TITLE
fix(power-bi): volume-weight roll-up average KPIs (IMP-009 slice)

### DIFF
--- a/docs/design/requirements/modules/power-bi/backlog.md
+++ b/docs/design/requirements/modules/power-bi/backlog.md
@@ -17,9 +17,14 @@
   relationship) is now hidden to remove duplicate/ambiguous date slicers.
   `tests/scripts/test_kpi_status_semantics.py` pins canonical UPPERCASE status
   literals across KQL and DAX and generically asserts that any `event_date`
-  column that is not a `dim_date` relationship key stays hidden. State folding,
-  date-relationship/grain reconciliation for the visible key columns, and
-  weighting remain open.
+  column that is not a `dim_date` relationship key stays hidden. Roll-up
+  "average" KPIs are now volume-weighted: `Avg Store Basket`,
+  `Avg Zone Dwell`, and `Avg Truck Dwell Minutes` recompute from base totals
+  (weighted by receipts/customers/trucks) instead of naively averaging stored
+  per-row averages, and the stored `avg_*` columns no longer auto-sum
+  (`tests/scripts/test_kpi_aggregation_weighting.py`). State folding and
+  date-relationship/grain reconciliation for the visible key columns remain
+  open.
 
 ### ENH-002 - Make dynamic pricing the flagship closed-loop action story {#enh-002}
 

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/online_sales_daily.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/online_sales_daily.tmdl
@@ -85,12 +85,12 @@ table online_sales_daily
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 793db82f-f43e-4840-88d5-e9395c64a96a
 		sourceLineageTag: avg_order_value
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: avg_order_value
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/sales_minute_store.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/sales_minute_store.tmdl
@@ -10,7 +10,7 @@ table sales_minute_store
 		formatString: #,0
 		lineageTag: 01a1a1c1-0001-0001-0001-000000000002
 
-	measure 'Avg Store Basket' = AVERAGE('sales_minute_store'[Average Basket])
+	measure 'Avg Store Basket' = DIVIDE([Total Store Sales], [Total Store Receipts], 0)
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: 01a1a1c1-0001-0001-0001-000000000003
 
@@ -69,12 +69,12 @@ table sales_minute_store
 		formatString: \$#,0.00;(\$#,0.00);\$#,0.00
 		lineageTag: c508e7f5-582e-463b-980f-2f0f662cc9b0
 		sourceLineageTag: avg_basket
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: avg_basket
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/truck_dwell_daily.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/truck_dwell_daily.tmdl
@@ -9,7 +9,8 @@ table truck_dwell_daily
 		lineageTag: 01a1a1c7-0001-0001-0001-000000000001
 
 	/// Average truck dwell minutes.
-	measure 'Avg Truck Dwell Minutes' = AVERAGE('truck_dwell_daily'[Average Dwell Minutes])
+	/// Truck-weighted average dwell minutes (weights each site-day row by its truck count so high-volume sites dominate, rather than averaging per-row averages).
+	measure 'Avg Truck Dwell Minutes' = DIVIDE(SUMX('truck_dwell_daily', 'truck_dwell_daily'[Average Dwell Minutes] * 'truck_dwell_daily'[Trucks]), [Total Trucks], 0)
 		formatString: #,0.0
 		displayFolder: Logistics\Dwell
 		lineageTag: 01a1a1c7-0001-0001-0001-000000000002
@@ -53,12 +54,12 @@ table truck_dwell_daily
 		dataType: double
 		lineageTag: d8e13419-3a71-47f4-baea-c166a92a46db
 		sourceLineageTag: avg_dwell_min
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: avg_dwell_min
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/zone_dwell_minute.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/zone_dwell_minute.tmdl
@@ -6,7 +6,8 @@ table zone_dwell_minute
 		formatString: #,0
 		lineageTag: 01a1a1c8-0001-0001-0001-000000000001
 
-	measure 'Avg Zone Dwell' = AVERAGE('zone_dwell_minute'[Average Dwell])
+	/// Customer-weighted average zone dwell minutes (weights each site-minute row by its customer count so busy zones dominate, rather than averaging per-row averages).
+	measure 'Avg Zone Dwell' = DIVIDE(SUMX('zone_dwell_minute', 'zone_dwell_minute'[Average Dwell] * 'zone_dwell_minute'[Customers]), [Zone Customers], 0)
 		formatString: #,0.0
 		lineageTag: 01a1a1c8-0001-0001-0001-000000000002
 
@@ -49,12 +50,12 @@ table zone_dwell_minute
 		dataType: double
 		lineageTag: 3e664904-d5dc-47c4-9316-6313e996935b
 		sourceLineageTag: avg_dwell
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: avg_dwell
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 

--- a/tests/scripts/test_kpi_aggregation_weighting.py
+++ b/tests/scripts/test_kpi_aggregation_weighting.py
@@ -1,0 +1,90 @@
+"""Aggregation-weighting guards for IMP-009.
+
+Pre-computed per-row averages (source columns like ``avg_basket`` /
+``avg_dwell``) must never auto-sum, and roll-up "average" measures must be
+volume-weighted recomputations rather than a naive ``AVERAGE`` of per-row
+averages (which weights every grain row equally regardless of volume). These
+tests pin both properties on the Direct Lake aggregate tables.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TABLES_DIR = (
+    REPO_ROOT
+    / "fabric"
+    / "powerbi"
+    / "retail_model.SemanticModel"
+    / "definition"
+    / "tables"
+)
+
+PRECOMPUTED_AVG_NAME_RE = re.compile(r"^(Average|Avg)\b")
+
+
+def _columns() -> list[tuple[str, str, str, str]]:
+    """(table, column display name, sourceColumn, column body)."""
+    found: list[tuple[str, str, str, str]] = []
+    for path in sorted(TABLES_DIR.glob("*.tmdl")):
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(
+            r"\tcolumn '?(?P<name>[^'\n]+?)'?\n(?P<body>(?:\t\t.+\n)+)", text
+        ):
+            body = match.group("body")
+            src = re.search(r"^\t\tsourceColumn: (.+)$", body, re.MULTILINE)
+            found.append(
+                (path.stem, match.group("name"), src.group(1) if src else "", body)
+            )
+    return found
+
+
+def _measure_expression(table: str, measure: str) -> str:
+    text = (TABLES_DIR / f"{table}.tmdl").read_text(encoding="utf-8")
+    match = re.search(
+        rf"^\tmeasure '{re.escape(measure)}' = (.+)$", text, re.MULTILINE
+    )
+    assert match, f"Missing measure {measure!r} on {table}."
+    return match.group(1)
+
+
+def test_precomputed_average_columns_do_not_sum() -> None:
+    # A stored per-row average summed across rows is meaningless; such columns
+    # must use summarizeBy: none so a bare drag-and-drop cannot roll them up.
+    offenders = []
+    for table, name, src, body in _columns():
+        is_avg = src.startswith("avg_") or bool(PRECOMPUTED_AVG_NAME_RE.match(name))
+        if is_avg and re.search(r"^\t\tsummarizeBy: sum$", body, re.MULTILINE):
+            offenders.append(f"{table}.{name}")
+    assert not offenders, (
+        "Pre-computed average columns must not summarizeBy sum; offenders: "
+        f"{offenders}"
+    )
+
+
+def test_rollup_average_measures_are_volume_weighted() -> None:
+    # Each measure must recompute from base totals (DIVIDE) and must not be a
+    # naive AVERAGE of the stored per-row average column.
+    expectations = {
+        ("sales_minute_store", "Avg Store Basket"): {
+            "required": ["DIVIDE(", "[Total Store Sales]", "[Total Store Receipts]"],
+            "forbidden": "AVERAGE('sales_minute_store'[Average Basket])",
+        },
+        ("zone_dwell_minute", "Avg Zone Dwell"): {
+            "required": ["DIVIDE(", "SUMX(", "[Customers]", "[Zone Customers]"],
+            "forbidden": "AVERAGE('zone_dwell_minute'[Average Dwell])",
+        },
+        ("truck_dwell_daily", "Avg Truck Dwell Minutes"): {
+            "required": ["DIVIDE(", "SUMX(", "[Trucks]", "[Total Trucks]"],
+            "forbidden": "AVERAGE('truck_dwell_daily'[Average Dwell Minutes])",
+        },
+    }
+    for (table, measure), spec in expectations.items():
+        expr = _measure_expression(table, measure)
+        for token in spec["required"]:
+            assert token in expr, f"{table}.{measure} must contain {token!r}: {expr}"
+        assert spec["forbidden"] not in expr, (
+            f"{table}.{measure} must not naively average the stored column."
+        )


### PR DESCRIPTION
## Summary
Continues **IMP-009** (KPI weighting semantics). Fixes roll-up `average` measures that mis-weighted, and stored per-row average columns that could silently sum.

### Weighting fixes
Three measures averaged **stored per-row averages**, giving every grain row equal weight regardless of volume:
- `Avg Store Basket` -> `DIVIDE([Total Store Sales], [Total Store Receipts])`
- `Avg Zone Dwell` -> customer-weighted `SUMX(... [Average Dwell] * [Customers]) / [Zone Customers]`
- `Avg Truck Dwell Minutes` -> truck-weighted `SUMX(... [Average Dwell Minutes] * [Trucks]) / [Total Trucks]`

### Aggregation-safety fixes
- Set `summarizeBy: none` on the stored `avg_*` columns (`avg_order_value`, `avg_basket`, `avg_dwell`, `avg_dwell_min`) so a bare drag-and-drop cannot sum a pre-computed average. (`online_sales_daily` already had a correct `DIVIDE` measure -- only its stored column needed the fix.)

### Guard
- `tests/scripts/test_kpi_aggregation_weighting.py`: asserts no precomputed-average column uses `summarizeBy: sum`, and that each roll-up measure recomputes from base totals (`DIVIDE`/`SUMX`) rather than naively averaging the stored column.

### Docs
- Updated the power-bi `backlog.md` progress note. **IMP-009 remains open** for state folding and visible-key date-relationship/grain reconciliation.

## Testing
- `pytest tests/scripts` -> **73 passed**.