### PR TITLE
fix(power-bi): hide pandas __index_level_0__ artifact columns (IMP-009 slice)

### DIFF
--- a/docs/design/requirements/modules/power-bi/backlog.md
+++ b/docs/design/requirements/modules/power-bi/backlog.md
@@ -22,7 +22,10 @@
   `Avg Zone Dwell`, and `Avg Truck Dwell Minutes` recompute from base totals
   (weighted by receipts/customers/trucks) instead of naively averaging stored
   per-row averages, and the stored `avg_*` columns no longer auto-sum
-  (`tests/scripts/test_kpi_aggregation_weighting.py`). State folding and
+  (`tests/scripts/test_kpi_aggregation_weighting.py`). The pandas
+  `__index_level_0__` write artifact exposed and summable on 11 fact tables is
+  now hidden and non-summable
+  (`tests/scripts/test_semantic_model_technical_fields.py`). State folding and
   date-relationship/grain reconciliation for the visible key columns remain
   open.
 

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_ble_pings.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_ble_pings.tmdl
@@ -76,11 +76,12 @@ table fact_ble_pings
 		dataType: int64
 		formatString: 0
 		lineageTag: 1618bcbd-d798-4e0b-8373-9f0c35f8b84c
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_ble_pings = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_customer_zone_changes.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_customer_zone_changes.tmdl
@@ -51,11 +51,12 @@ table fact_customer_zone_changes
 		dataType: int64
 		formatString: 0
 		lineageTag: fec0f7bc-2420-4ca6-9e66-6b1e2482f51e
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_customer_zone_changes = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_dc_inventory_txn.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_dc_inventory_txn.tmdl
@@ -74,11 +74,12 @@ table fact_dc_inventory_txn
 		dataType: int64
 		formatString: 0
 		lineageTag: 61a0bb77-d928-4266-8fca-1d1ef9ef4c50
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_dc_inventory_txn = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_marketing.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_marketing.tmdl
@@ -108,11 +108,12 @@ table fact_marketing
 		dataType: int64
 		formatString: 0
 		lineageTag: e8f39bc7-f231-4825-a5b9-1ee4050cf223
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_marketing = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_online_order_lines.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_online_order_lines.tmdl
@@ -191,11 +191,12 @@ table fact_online_order_lines
 		dataType: int64
 		formatString: 0
 		lineageTag: cf8ce641-935d-42f3-abb6-40101e6c746e
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_online_order_lines = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_promo_lines.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_promo_lines.tmdl
@@ -99,11 +99,12 @@ table fact_promo_lines
 		dataType: int64
 		formatString: 0
 		lineageTag: 046e12d9-a984-4b67-81bd-5c6afeca49f4
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_promo_lines = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_reorders.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_reorders.tmdl
@@ -119,11 +119,12 @@ table fact_reorders
 		dataType: int64
 		formatString: 0
 		lineageTag: 2b449ce3-7b50-4e3e-9974-b39bb336b0b3
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_reorders = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_stockouts.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_stockouts.tmdl
@@ -68,11 +68,12 @@ table fact_stockouts
 		dataType: int64
 		formatString: 0
 		lineageTag: 1cfbef48-7ab8-4c5d-8969-183c8eb05a7d
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_stockouts = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_store_inventory_txn.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_store_inventory_txn.tmdl
@@ -84,11 +84,12 @@ table fact_store_inventory_txn
 		dataType: int64
 		formatString: 0
 		lineageTag: 8ec48b5d-e930-43ca-900a-3ffce43b7a6f
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_store_inventory_txn = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_truck_inventory.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_truck_inventory.tmdl
@@ -87,11 +87,12 @@ table fact_truck_inventory
 		dataType: int64
 		formatString: 0
 		lineageTag: ef937be0-d5d2-4b63-83b1-6a38f25c4bc9
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_truck_inventory = entity
 		mode: directLake

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_truck_moves.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_truck_moves.tmdl
@@ -87,11 +87,12 @@ table fact_truck_moves
 		dataType: int64
 		formatString: 0
 		lineageTag: 442f04c0-247c-4c09-abe5-459a292e17ad
+		isHidden
 		sourceLineageTag: __index_level_0__
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: __index_level_0__
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	partition fact_truck_moves = entity
 		mode: directLake

--- a/tests/scripts/test_semantic_model_technical_fields.py
+++ b/tests/scripts/test_semantic_model_technical_fields.py
@@ -1,0 +1,71 @@
+"""Technical-column visibility guards for the semantic model (IMP-009).
+
+Direct Lake source parquet carries a pandas write artifact ``__index_level_0__``
+that has no analytical meaning. Such technical columns must be hidden and must
+never auto-sum so they cannot leak into report field lists or totals.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TABLES_DIR = (
+    REPO_ROOT
+    / "fabric"
+    / "powerbi"
+    / "retail_model.SemanticModel"
+    / "definition"
+    / "tables"
+)
+
+# Source columns that are pure technical artifacts and must stay hidden.
+TECHNICAL_SOURCE_COLUMNS = ("__index_level_0__",)
+
+
+def _artifact_column_blocks() -> list[tuple[str, str, str]]:
+    """(table, column display name, column body) for technical-artifact columns."""
+    found: list[tuple[str, str, str]] = []
+    for path in sorted(TABLES_DIR.glob("*.tmdl")):
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(
+            r"\tcolumn '?(?P<name>[^'\n]+?)'?\n(?P<body>(?:\t\t.+\n)+)", text
+        ):
+            body = match.group("body")
+            src = re.search(r"^\t\tsourceColumn: (.+)$", body, re.MULTILINE)
+            if src and src.group(1) in TECHNICAL_SOURCE_COLUMNS:
+                found.append((path.stem, match.group("name"), body))
+    return found
+
+
+def test_technical_artifact_columns_exist() -> None:
+    # Guard sanity: the artifact columns are still present in the model so the
+    # visibility assertions below stay meaningful.
+    assert _artifact_column_blocks(), (
+        "Expected at least one technical-artifact column to guard."
+    )
+
+
+def test_technical_artifact_columns_are_hidden() -> None:
+    offenders = [
+        f"{table}.{name}"
+        for table, name, body in _artifact_column_blocks()
+        if "isHidden" not in body
+    ]
+    assert not offenders, (
+        "Technical-artifact columns (e.g. __index_level_0__) must be hidden; "
+        f"offenders: {offenders}"
+    )
+
+
+def test_technical_artifact_columns_do_not_sum() -> None:
+    offenders = [
+        f"{table}.{name}"
+        for table, name, body in _artifact_column_blocks()
+        if re.search(r"^\t\tsummarizeBy: sum$", body, re.MULTILINE)
+    ]
+    assert not offenders, (
+        "Technical-artifact columns must not summarizeBy sum; offenders: "
+        f"{offenders}"
+    )


### PR DESCRIPTION
## Summary
Continues **IMP-009** (technical-field visibility). Removes a pandas write artifact leaking into the semantic model.

### Fix
- 11 fact tables (`fact_ble_pings`, `fact_customer_zone_changes`, `fact_dc_inventory_txn`, `fact_marketing`, `fact_online_order_lines`, `fact_promo_lines`, `fact_reorders`, `fact_stockouts`, `fact_store_inventory_txn`, `fact_truck_inventory`, `fact_truck_moves`) exposed a `__index_level_0__` column — a pandas `to_parquet` index artifact with no analytical meaning — as **visible** and `summarizeBy: sum`, letting it leak into report field lists and totals. Each is now hidden with `summarizeBy: none`.

### Guard
- `tests/scripts/test_semantic_model_technical_fields.py` asserts technical-artifact columns are hidden and non-summable, catching regressions and future artifact leakage.

### Docs
- Updated the power-bi `backlog.md` progress note. **IMP-009 remains open** for state folding and visible-key date-relationship/grain reconciliation.

## Testing
- `pytest tests/scripts` -> **76 passed**.