### PR TITLE
fix(power-bi): stop surrogate key columns from summing (IMP-009 slice)

### DIFF
--- a/docs/design/requirements/modules/power-bi/backlog.md
+++ b/docs/design/requirements/modules/power-bi/backlog.md
@@ -25,9 +25,14 @@
   (`tests/scripts/test_kpi_aggregation_weighting.py`). The pandas
   `__index_level_0__` write artifact exposed and summable on 11 fact tables is
   now hidden and non-summable
-  (`tests/scripts/test_semantic_model_technical_fields.py`). State folding and
-  date-relationship/grain reconciliation for the visible key columns remain
-  open.
+  (`tests/scripts/test_semantic_model_technical_fields.py`). Surrogate key
+  columns (`*_id`) across 19 tables now default to `summarizeBy: none` so a
+  bare drag-and-drop cannot produce a meaningless key total
+  (`tests/scripts/test_semantic_model_grain.py`). State folding was verified as
+  a non-issue: every current-state/ML table is written `mode("overwrite")` as a
+  single snapshot (no accumulating generations to fold). Date-relationship/grain
+  reconciliation for the visible `Event Date` key columns and label alignment
+  remain open.
 
 ### ENH-002 - Make dynamic pricing the flagship closed-loop action story {#enh-002}
 

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/dc_inventory_position_current.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/dc_inventory_position_current.tmdl
@@ -25,24 +25,24 @@ table dc_inventory_position_current
 		formatString: 0
 		lineageTag: 847804d1-5b60-4232-a3c8-4daa440a4ceb
 		sourceLineageTag: dc_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: dc_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 637a2bb9-88bd-4b52-a68d-f453131dd46e
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'On Hand'
 		dataType: int64

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_ble_pings.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_ble_pings.tmdl
@@ -52,12 +52,12 @@ table fact_ble_pings
 		formatString: 0
 		lineageTag: b00319bf-5301-4ba3-951d-d5092ca7d125
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Customer ID'
 		dataType: double

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_dc_inventory_txn.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_dc_inventory_txn.tmdl
@@ -30,12 +30,12 @@ table fact_dc_inventory_txn
 		formatString: 0
 		lineageTag: 7dde12d4-b2ad-4285-8593-6084695d1c99
 		sourceLineageTag: dc_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: dc_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column Balance
 		dataType: int64
@@ -54,12 +54,12 @@ table fact_dc_inventory_txn
 		formatString: 0
 		lineageTag: a7168582-c6e8-4b62-89e2-de93b91dc4c9
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column Source
 		dataType: string

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_foot_traffic.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_foot_traffic.tmdl
@@ -60,12 +60,12 @@ table fact_foot_traffic
 		formatString: 0
 		lineageTag: 569af1b5-d33d-496c-b590-76158423c9ce
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Sensor ID'
 		dataType: string

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_marketing_attribution.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_marketing_attribution.tmdl
@@ -172,12 +172,12 @@ table fact_marketing_attribution
 		formatString: 0
 		lineageTag: a35cd889-b393-4e80-9a27-c5886ef06007
 		sourceLineageTag: customer_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: customer_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Touch Timestamp'
 		dataType: dateTime
@@ -253,12 +253,12 @@ table fact_marketing_attribution
 		formatString: 0
 		lineageTag: 954032f6-1f8f-44d1-86c2-fe59dce6e0de
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Gross Subtotal Cents'
 		dataType: int64

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_online_order_headers.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_online_order_headers.tmdl
@@ -55,12 +55,12 @@ table fact_online_order_headers
 		formatString: 0
 		lineageTag: c6cd591e-21eb-4a48-82fe-be8ca75c1e34
 		sourceLineageTag: customer_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: customer_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Subtotal Cents'
 		dataType: int64

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_online_order_lines.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_online_order_lines.tmdl
@@ -99,12 +99,12 @@ table fact_online_order_lines
 		formatString: 0
 		lineageTag: 7a040420-92ea-4167-a7e8-35029e01d4dd
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Extended Price'
 		dataType: string
@@ -180,12 +180,12 @@ table fact_online_order_lines
 		formatString: 0
 		lineageTag: 46f9dba7-f1fe-421f-b5d6-5753941c2834
 		sourceLineageTag: node_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: node_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column __index_level_0__
 		dataType: int64

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_payments.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_payments.tmdl
@@ -144,24 +144,24 @@ table fact_payments
 		formatString: 0
 		lineageTag: d21b659a-0979-44b0-ad34-53109ed5050d
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Customer ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: ae5fe31f-a97a-4799-93fb-98b992cf414d
 		sourceLineageTag: customer_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: customer_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Event Timestamp'
 		dataType: dateTime

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_receipt_lines.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_receipt_lines.tmdl
@@ -66,12 +66,12 @@ table fact_receipt_lines
 		formatString: 0
 		lineageTag: 160f5195-0ef4-431a-9e58-e0dda60336f2
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Line Number'
 		dataType: int64

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_receipts.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_receipts.tmdl
@@ -340,12 +340,12 @@ table fact_receipts
 		formatString: 0
 		lineageTag: aa658e70-f275-4c6d-91c8-63d908c09403
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Tax Cents'
 		dataType: int64

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_reorders.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_reorders.tmdl
@@ -37,36 +37,36 @@ table fact_reorders
 		formatString: 0
 		lineageTag: 9ba003b4-5818-4fdf-a7cb-e746a618a80f
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'DC ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: e8cc3010-af1a-40d5-b05e-2ae21f44ae39
 		sourceLineageTag: dc_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: dc_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: b38c131f-e4a2-4baa-b46c-144a36a860fa
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Current Quantity'
 		dataType: int64

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_store_inventory_txn.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_store_inventory_txn.tmdl
@@ -50,24 +50,24 @@ table fact_store_inventory_txn
 		formatString: 0
 		lineageTag: 85ecab4a-5ef0-4c6a-bcbd-2db04af2a261
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: f9411773-fe61-4cc9-bd55-1a200d71cdf8
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column Source
 		dataType: string

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_store_ops.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_store_ops.tmdl
@@ -30,12 +30,12 @@ table fact_store_ops
 		formatString: 0
 		lineageTag: 7e3719b4-06ee-4594-87db-11bf9f3ce04c
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Operation Type'
 		dataType: string

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_truck_inventory.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_truck_inventory.tmdl
@@ -7,12 +7,12 @@ table fact_truck_inventory
 		formatString: 0
 		lineageTag: abe4d6b6-e6c5-457a-8b6d-7dd3c383dcfb
 		sourceLineageTag: truck_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: truck_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Shipment ID'
 		dataType: string
@@ -30,12 +30,12 @@ table fact_truck_inventory
 		formatString: 0
 		lineageTag: 648fcce8-4a56-44b5-91b4-ffba8a16f659
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column Quantity
 		dataType: int64
@@ -65,12 +65,12 @@ table fact_truck_inventory
 		formatString: 0
 		lineageTag: 360d161e-5905-4982-bef4-21af95d6251f
 		sourceLineageTag: location_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: location_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Location Type'
 		dataType: string

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_truck_moves.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/fact_truck_moves.tmdl
@@ -41,36 +41,36 @@ table fact_truck_moves
 		formatString: 0
 		lineageTag: 8cc6a6be-bcbb-4e57-a42e-383babd8c30c
 		sourceLineageTag: dc_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: dc_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Truck ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: f91cf596-0f96-4834-b402-c55cbabbad71
 		sourceLineageTag: truck_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: truck_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Store ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: 54d28e85-f677-4d6c-a288-e1e48f68932e
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column actual_unload_duration
 		dataType: double

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/inventory_position_current.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/inventory_position_current.tmdl
@@ -61,24 +61,24 @@ table inventory_position_current
 		formatString: 0
 		lineageTag: 657f2501-30bd-49f7-b3b0-979a5491791c
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'Product ID'
 		dataType: int64
 		formatString: 0
 		lineageTag: cbc2790a-4977-4e9b-af30-d485dcdee191
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column 'On Hand'
 		dataType: int64

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/sales_minute_store.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/sales_minute_store.tmdl
@@ -19,12 +19,12 @@ table sales_minute_store
 		formatString: 0
 		lineageTag: 4523c24b-1eb5-4e76-a360-a309c8aa50aa
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column Timestamp
 		dataType: dateTime

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/top_products_15m.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/top_products_15m.tmdl
@@ -15,12 +15,12 @@ table top_products_15m
 		formatString: 0
 		lineageTag: f71dd371-de91-495f-ad76-db7f3c6fde8b
 		sourceLineageTag: product_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: product_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column Revenue
 		dataType: double

--- a/fabric/powerbi/retail_model.SemanticModel/definition/tables/zone_dwell_minute.tmdl
+++ b/fabric/powerbi/retail_model.SemanticModel/definition/tables/zone_dwell_minute.tmdl
@@ -16,12 +16,12 @@ table zone_dwell_minute
 		formatString: 0
 		lineageTag: cbd46151-4680-4fd3-9a7c-0e95183412ff
 		sourceLineageTag: store_id
-		summarizeBy: sum
+		summarizeBy: none
 		sourceColumn: store_id
 
 		changedProperty = Name
 
-		annotation SummarizationSetBy = Automatic
+		annotation SummarizationSetBy = User
 
 	column Zone
 		dataType: string

--- a/tests/scripts/test_semantic_model_grain.py
+++ b/tests/scripts/test_semantic_model_grain.py
@@ -1,0 +1,55 @@
+"""Grain guards for surrogate-key columns (IMP-009).
+
+Surrogate identifier columns (source columns ending in ``_id`` such as
+``store_id``/``product_id``/``customer_id``) are foreign keys, not additive
+facts. If they default to ``summarizeBy: sum`` a bare drag-and-drop produces a
+meaningless key total, so they must default to ``summarizeBy: none``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TABLES_DIR = (
+    REPO_ROOT
+    / "fabric"
+    / "powerbi"
+    / "retail_model.SemanticModel"
+    / "definition"
+    / "tables"
+)
+
+COLUMN_RE = re.compile(
+    r"\tcolumn '?(?P<name>[^'\n]+?)'?\n(?P<body>(?:\t\t.+\n)+)"
+)
+
+
+def _key_columns() -> list[tuple[str, str, str]]:
+    """(table, column display name, column body) for *_id-sourced columns."""
+    found: list[tuple[str, str, str]] = []
+    for path in sorted(TABLES_DIR.glob("*.tmdl")):
+        text = path.read_text(encoding="utf-8")
+        for match in COLUMN_RE.finditer(text):
+            body = match.group("body")
+            src = re.search(r"^\t\tsourceColumn: (.+)$", body, re.MULTILINE)
+            if src and src.group(1).endswith("_id"):
+                found.append((path.stem, match.group("name"), body))
+    return found
+
+
+def test_surrogate_key_columns_exist() -> None:
+    assert _key_columns(), "Expected at least one *_id key column to guard."
+
+
+def test_surrogate_key_columns_do_not_sum() -> None:
+    offenders = [
+        f"{table}.{name}"
+        for table, name, body in _key_columns()
+        if re.search(r"^\t\tsummarizeBy: sum$", body, re.MULTILINE)
+    ]
+    assert not offenders, (
+        "Surrogate key columns (*_id) must not summarizeBy sum; offenders: "
+        f"{offenders}"
+    )


### PR DESCRIPTION
## Summary
Continues **IMP-009** (KPI grain). Fixes surrogate-key columns that defaulted to summing, and records that state folding is a verified non-issue.

### Grain fix
- 32 surrogate identifier columns (source columns ending in `_id` — `store_id`, `product_id`, `customer_id`, `dc_id`, `truck_id`, `node_id`, `location_id`) across 19 tables defaulted to `summarizeBy: sum`. Dragging e.g. `Store ID` onto a card produced a meaningless key total. Set `summarizeBy: none`; the columns stay **visible** for drill/filter/grouping.

### State folding — verified non-issue
- Every current-state and ML gold table (`demand_forecast`, `churn_predictions`, `stockout_risk`, `*_position_current`) is written `mode(\"overwrite\")` as a single snapshot, so there are no accumulating generations to fold. No change required; documented in the backlog.

### Guard
- `tests/scripts/test_semantic_model_grain.py` asserts no `*_id` column uses `summarizeBy: sum`.

### Docs
- Updated the power-bi `backlog.md` progress note. **IMP-009 remaining:** visible `Event Date` key-column reconciliation and label alignment.

## Testing
- `pytest tests/scripts` -> **78 passed**.